### PR TITLE
refactor: rethink how operations are formed (again)

### DIFF
--- a/backends/common/src/target/ops.rs
+++ b/backends/common/src/target/ops.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
+use tir_core::utils::{trait_id, TraitId};
+use tir_core::*;
+use tir_macros::operation;
 
 use crate::target::DIALECT_NAME;
-use tir_core::utils::{trait_id, TraitId};
-use tir_core::{Attr, Op, Operation, OperationImpl, Region};
-use tir_macros::operation;
 
 #[operation(name = "section")]
 pub struct SectionOp {

--- a/backends/common/tests/traits_test.rs
+++ b/backends/common/tests/traits_test.rs
@@ -1,10 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use tir_backend::{AsmPrintable, BinaryEmittable};
-use tir_core::{
-    utils::{trait_id, TraitId},
-    Dialect, Op, Operation, OperationImpl,
-};
+use tir_core::utils::{trait_id, TraitId};
+use tir_core::*;
 use tir_macros::{dialect, operation, populate_dialect_ops, populate_dialect_types};
 
 dialect!(test_backend);

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -45,9 +45,11 @@ pub fn disassemble(
 
 #[cfg(test)]
 mod tests {
+    use std::any::TypeId;
+
+    use super::*;
     use tir_core::builtin::ModuleOp;
     use tir_core::{Context, OpBuilder};
-    use super::*;
 
     #[test]
     fn test_disassembler() {
@@ -61,7 +63,7 @@ mod tests {
         // or x28, x6, x7
         // and x28, x6, x7
         let instructions = vec![
-            0x00730e33 as u32,
+            0x00730e33_u32,
             0x40730e33,
             0x00731e33,
             0x00732e33,
@@ -81,31 +83,29 @@ mod tests {
         let context = Context::new();
         context.borrow_mut().add_dialect(crate::create_dialect());
 
-        let module = ModuleOp::new(context.clone());
+        let module = ModuleOp::builder(context.clone()).build();
 
-        let builder = OpBuilder::new(context.clone(), module.get_body());
+        let builder = OpBuilder::new(context.clone(), module.borrow_mut().get_body());
 
         assert!(disassemble(&context, builder, &data).is_ok());
 
-        let ops = module.get_body().borrow().operations.to_vec();
+        let ops = module.borrow_mut().get_body().borrow().operations.to_vec();
 
         assert_eq!(ops.len(), 9);
-        assert!(AddOp::try_from(ops[0].clone()).is_ok());
-        assert!(SubOp::try_from(ops[1].clone()).is_ok());
-        assert!(SllOp::try_from(ops[2].clone()).is_ok());
-        assert!(SltOp::try_from(ops[3].clone()).is_ok());
-        assert!(SltuOp::try_from(ops[4].clone()).is_ok());
-        assert!(SrlOp::try_from(ops[5].clone()).is_ok());
-        assert!(SraOp::try_from(ops[6].clone()).is_ok());
-        assert!(OrOp::try_from(ops[7].clone()).is_ok());
-        assert!(AndOp::try_from(ops[8].clone()).is_ok());
+        assert_eq!(ops[0].borrow().type_id(), TypeId::of::<AddOp>());
+        assert_eq!(ops[1].borrow().type_id(), TypeId::of::<SubOp>());
+        assert_eq!(ops[2].borrow().type_id(), TypeId::of::<SllOp>());
+        assert_eq!(ops[3].borrow().type_id(), TypeId::of::<SltOp>());
+        assert_eq!(ops[4].borrow().type_id(), TypeId::of::<SltuOp>());
+        assert_eq!(ops[5].borrow().type_id(), TypeId::of::<SrlOp>());
+        assert_eq!(ops[6].borrow().type_id(), TypeId::of::<SraOp>());
+        assert_eq!(ops[7].borrow().type_id(), TypeId::of::<OrOp>());
+        assert_eq!(ops[8].borrow().type_id(), TypeId::of::<AndOp>());
     }
 
     #[test]
     fn test_disassembler_negative() {
-        let instructions = vec![
-            0x7fffff3 as u32,
-        ];
+        let instructions = vec![0x7fffff3_u32];
 
         let mut data = vec![];
 
@@ -116,9 +116,9 @@ mod tests {
         let context = Context::new();
         context.borrow_mut().add_dialect(crate::create_dialect());
 
-        let module = ModuleOp::new(context.clone());
+        let module = ModuleOp::builder(context.clone()).build();
 
-        let builder = OpBuilder::new(context.clone(), module.get_body());
+        let builder = OpBuilder::new(context.clone(), module.borrow().get_body());
 
         assert!(disassemble(&context, builder, &data).is_err());
     }

--- a/core/src/attrs.rs
+++ b/core/src/attrs.rs
@@ -7,6 +7,17 @@ macro_rules! impl_from {
                 Attr::$case(value)
             }
         }
+
+        impl TryInto<$from> for Attr {
+            type Error = ();
+            fn try_into(self) -> Result<$from, Self::Error> {
+                if let Attr::$case(value) = self {
+                    return Ok(value);
+                }
+
+                Err(())
+            }
+        }
     };
 }
 

--- a/core/src/builder.rs
+++ b/core/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::{BlockRef, Context, Operation};
-use std::rc::Rc;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 pub type OpBuilderRef = Rc<RefCell<OpBuilder>>;
 
@@ -16,19 +16,20 @@ pub struct OpBuilder {
 
 impl OpBuilder {
     pub fn new(context: Rc<RefCell<Context>>, block: BlockRef) -> Rc<RefCell<Self>> {
-        let insertion_point = InsertionPoint{
-            block,
-            index: 0
-        };
+        let insertion_point = InsertionPoint { block, index: 0 };
 
         Rc::new(RefCell::new(OpBuilder {
             context,
-            insertion_point
+            insertion_point,
         }))
     }
 
     pub fn insert(&mut self, operation: Operation) {
-        self.insertion_point.block.borrow_mut().operations.insert(self.insertion_point.index, operation);
+        self.insertion_point
+            .block
+            .borrow_mut()
+            .operations
+            .insert(self.insertion_point.index, operation);
         self.insertion_point.index += 1;
     }
 

--- a/core/src/builtin/module.rs
+++ b/core/src/builtin/module.rs
@@ -2,29 +2,13 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::builtin::DIALECT_NAME;
 use crate::utils::{trait_id, TraitId};
-use crate::{Block, Context, Op, Operation, OperationImpl, Region};
+use crate::*;
 use tir_macros::operation;
 
 #[operation(name = "module")]
 pub struct ModuleOp {
     #[cfg(region = true, single_block = true)]
     body: Region,
-}
-
-impl ModuleOp {
-    pub fn new(context: Rc<RefCell<Context>>) -> Self {
-        let dialect = context.borrow().get_dialect_by_name(DIALECT_NAME).unwrap();
-        let mut operation =
-            Operation::new(context.clone(), dialect, ModuleOp::get_operation_name());
-
-        let region = operation.emplace_region();
-
-        region.borrow_mut().emplace_block(Rc::downgrade(&region));
-
-        Self {
-            operation: operation.get_impl().clone(),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -36,9 +20,9 @@ mod test {
         assert!(ModuleOp::get_operation_name() == "module");
 
         let context = Context::new();
-        let module = ModuleOp::new(context);
-        module.get_body_region();
-        module.get_body();
-        module.get_region();
+        let module = ModuleOp::builder(context).build();
+        module.borrow().get_body_region();
+        module.borrow().get_body();
+        module.borrow().get_region();
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -2,6 +2,8 @@ use std::{cell::RefCell, fmt::Debug, rc::Rc};
 
 use crate::Dialect;
 
+pub type ContextRef = Rc<RefCell<Context>>;
+
 /// Context holds all the resources required for building an IR
 ///
 /// Examples:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,17 +1,17 @@
 mod attrs;
+mod builder;
 pub mod builtin;
 mod context;
 mod dialect;
 mod error;
 mod operation;
 mod r#type;
-mod builder;
 pub mod utils;
 
 pub use attrs::*;
+pub use builder::*;
 pub use context::*;
 pub use dialect::*;
 pub use error::*;
 pub use operation::*;
 pub use r#type::*;
-pub use builder::*;

--- a/fuzz/fuzz_targets/riscv/disassembler.rs
+++ b/fuzz/fuzz_targets/riscv/disassembler.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use tir_core::{Context, OpBuilder, builtin::ModuleOp};
+use tir_core::{builtin::ModuleOp, Context, OpBuilder};
 use tir_riscv::disassemble;
 
 fuzz_target!(|data: &[u8]| {
@@ -10,9 +10,9 @@ fuzz_target!(|data: &[u8]| {
         .borrow_mut()
         .add_dialect(tir_riscv::create_dialect());
 
-    let module = ModuleOp::new(context.clone());
+    let module = ModuleOp::builder(context.clone()).build();
 
-    let builder = OpBuilder::new(context.clone(), module.get_body());
+    let builder = OpBuilder::new(context.clone(), module.borrow().get_body());
 
     let _ = disassemble(&context, builder, data);
 });

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 syn = { version = "2.0.60", features=["full","fold"] }
 quote = "1.0.36"
 darling = "0.20.8"
+proc-macro2 = "1.0.81"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -31,6 +31,273 @@ struct OperationField {
     pub single_block: bool,
 }
 
+struct AttrField {
+    ident: syn::Ident,
+    ty: syn::Type,
+}
+
+struct OperandField {
+    ident: syn::Ident,
+    _ty: syn::Type,
+}
+
+struct RegionField {
+    ident: syn::Ident,
+    single_block: bool,
+}
+
+fn parse_fields(
+    fields: &syn::Fields,
+) -> Result<(Vec<AttrField>, Vec<OperandField>, Vec<RegionField>), darling::Error> {
+    let mut attrs = vec![];
+    let mut operands = vec![];
+    let mut regions = vec![];
+
+    for field in fields {
+        if field.attrs.len() != 1 {
+            panic!("Expected all fields to have one attribute");
+        }
+        let op_field = OperationField::from_field(field)?;
+
+        if op_field.attribute {
+            attrs.push(AttrField {
+                ident: op_field.ident.unwrap(),
+                ty: op_field.ty,
+            });
+        } else if op_field.operand {
+            operands.push(OperandField {
+                ident: op_field.ident.unwrap(),
+                _ty: op_field.ty,
+            });
+        } else if op_field.region {
+            regions.push(RegionField {
+                ident: op_field.ident.unwrap(),
+                single_block: op_field.single_block,
+            });
+        }
+    }
+
+    Ok((attrs, operands, regions))
+}
+
+fn build_attr_accessors(attrs: &[AttrField]) -> proc_macro2::TokenStream {
+    let mut impls = vec![];
+
+    for attr in attrs {
+        let attr_name = attr.ident.to_string();
+        let ty = &attr.ty;
+        let get_name = format_ident!("get_{}_attr", attr.ident);
+        let set_name = format_ident!("set_{}_attr", attr.ident);
+
+        let funcs = quote! {
+            pub fn #get_name(&self) -> Attr {
+                self.operation.attrs.get(#attr_name).unwrap().clone()
+            }
+            pub fn #set_name<T>(&mut self, value: T) where T: Into<#ty> {
+                let tmp: #ty = value.into();
+                self.operation.attrs.insert(#attr_name.to_string(), Attr::from(tmp));
+            }
+        };
+
+        impls.push(funcs);
+    }
+
+    quote! {
+        #(#impls)*
+    }
+}
+
+fn build_operand_accessors(operands: &[OperandField]) -> proc_macro2::TokenStream {
+    let mut impls = vec![];
+
+    for (id, operand) in operands.iter().enumerate() {
+        let get_func = format_ident!("get_{}", operand.ident);
+        // TODO implement setters!
+        let set_func = format_ident!("set_{}", operand.ident);
+        let funcs = quote! {
+            pub fn #get_func(&self) -> &Operand {
+                &self.operation.operands[#id]
+            }
+            pub fn #set_func(&mut self) {
+                todo!()
+            }
+        };
+
+        impls.push(funcs);
+    }
+
+    quote! {
+        #(#impls)*
+    }
+}
+
+fn build_region_accessors(regions: &[RegionField]) -> proc_macro2::TokenStream {
+    let mut impls = vec![];
+
+    for (id, region) in regions.iter().enumerate() {
+        let get_func = format_ident!("get_{}_region", region.ident);
+        let func = quote! {
+            pub fn #get_func(&self) -> RegionRef {
+                self.operation
+                    .regions[#id]
+                    .clone()
+            }
+        };
+        impls.push(func);
+
+        if region.single_block {
+            let get_func = format_ident!("get_{}", region.ident);
+            let func = quote! {
+                pub fn #get_func(&self) -> BlockRef {
+                    self.operation
+                        .regions[#id]
+                        .borrow()
+                        .get_blocks()
+                        .first()
+                        .unwrap()
+                        .clone()
+                }
+            };
+            impls.push(func);
+        }
+    }
+
+    if regions.len() == 1 {
+        let func = quote! {
+            pub fn get_region(&self) -> RegionRef {
+               self.operation.regions.first().unwrap().clone()
+            }
+        };
+        impls.push(func);
+    }
+
+    quote! {
+        #(#impls)*
+    }
+}
+
+fn build_op_builder(
+    op: &syn::Ident,
+    op_name: &str,
+    attrs: &[AttrField],
+    operands: &[OperandField],
+    regions: &[RegionField],
+) -> proc_macro2::TokenStream {
+    let builder_name = format_ident!("{}Builder", op);
+
+    let mut builder_fields = vec![];
+    let mut builder_accessors = vec![];
+    let mut builder_setters = vec![];
+    let mut builder_fillers = vec![];
+
+    for attr in attrs {
+        let name = &attr.ident;
+
+        builder_fields.push(quote! {
+            #name: Option<Attr>,
+        });
+
+        builder_accessors.push(quote! {
+            pub fn #name(mut self, attr: Attr) -> Self {
+                self.#name = Some(attr);
+                self
+            }
+        });
+
+        builder_setters.push(quote! {
+            #name: None,
+        });
+
+        let name_str = name.to_string();
+        builder_fillers.push(quote! {
+            if let Some(val) = self.#name {
+                attrs.insert(#name_str.to_string(), val);
+            }
+        });
+    }
+
+    for operand in operands {
+        let name = &operand.ident;
+
+        builder_fields.push(quote! {
+            #name: Option<Operand>,
+        });
+
+        builder_accessors.push(quote! {
+            pub fn #name(mut self, operand: Operand) -> Self {
+                self.#name = Some(operand);
+                self
+            }
+        });
+
+        builder_setters.push(quote! {
+            #name: None,
+        });
+
+        builder_fillers.push(quote! {
+            if let Some(val) = self.#name {
+               operands.push(val);
+            }
+        });
+    }
+
+    for region in regions {
+        builder_fillers.push(quote! {
+            let region = Region::new(context.clone());
+            regions.push(region.clone());
+        });
+
+        if region.single_block {
+            builder_fillers.push(quote! {
+                region.borrow_mut().emplace_block(Rc::downgrade(&region));
+            });
+        }
+    }
+
+    quote! {
+        pub struct #builder_name {
+            context: ContextRef,
+            #(#builder_fields)*
+        }
+
+        impl #op {
+            pub fn builder(context: ContextRef) -> #builder_name {
+                #builder_name {
+                    context,
+                    #(#builder_setters)*
+                }
+            }
+        }
+
+        impl #builder_name {
+            #(#builder_accessors)*
+
+            pub fn build(self) -> std::rc::Rc<std::cell::RefCell<#op>> {
+                let context = self.context.clone();
+                let dialect = context.borrow().get_dialect_by_name(DIALECT_NAME).unwrap();
+                let dialect_id = dialect.borrow().get_id();
+                let operation_id = dialect.borrow().get_operation_id(#op_name);
+                let mut attrs = std::collections::HashMap::new();
+                let mut operands = vec![];
+                let mut regions = vec![];
+
+                #(#builder_fillers)*
+
+                let operation = Rc::new(RefCell::new(#op{operation: OperationImpl{
+                    context: self.context.clone(),
+                    dialect_id,
+                    operation_id,
+                    operands,
+                    attrs,
+                    regions,
+                }}));
+
+                operation
+            }
+        }
+    }
+}
+
 #[proc_macro_attribute]
 pub fn operation(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let args = match NestedMeta::parse_meta_list(metadata.into()) {
@@ -48,115 +315,32 @@ pub fn operation(metadata: TokenStream, input: TokenStream) -> TokenStream {
 
     let input = parse_macro_input!(input as syn::ItemStruct);
 
-    let mut attrs = vec![];
-    let mut operands = vec![];
-    let mut regions = vec![];
+    let (attrs, operands, regions) = match parse_fields(&input.fields) {
+        Ok((attrs, operands, regions)) => (attrs, operands, regions),
+        Err(e) => return TokenStream::from(e.write_errors()),
+    };
 
-    for field in &input.fields {
-        if field.attrs.len() != 1 {
-            panic!("Expected all fields to have one attribute");
-        }
-        let op_field = match OperationField::from_field(field) {
-            Ok(v) => v,
-            Err(e) => {
-                return TokenStream::from(e.write_errors());
-            }
-        };
+    let attr_accessors = build_attr_accessors(&attrs);
+    let operand_accessors = build_operand_accessors(&operands);
+    let region_accessors = build_region_accessors(&regions);
 
-        if op_field.attribute {
-            attrs.push((op_field.ident.unwrap(), op_field.ty));
-        } else if op_field.operand {
-            operands.push(op_field.ident.unwrap());
-        } else if op_field.region {
-            regions.push((op_field.ident.unwrap(), op_field.single_block));
-        }
-    }
-
-    let mut impls = vec![];
-
-    for (attr, ty) in attrs {
-        let attr_name = attr.to_string();
-        let get_name = format_ident!("get_{}_attr", attr);
-        let set_name = format_ident!("set_{}_attr", attr);
-
-        let funcs = quote! {
-            pub fn #get_name(&self) -> Attr {
-                self.operation.borrow().attrs.get(#attr_name).unwrap().clone()
-            }
-            pub fn #set_name<T>(&mut self, value: T) where T: Into<#ty> {
-                let tmp: #ty = value.into();
-                self.operation.borrow_mut().attrs.insert(#attr_name.to_string(), Attr::from(tmp));
-            }
-        };
-        impls.push(funcs);
-    }
-
-    for (id, (region, single_block)) in regions.iter().enumerate() {
-        let get_func = format_ident!("get_{}_region", region);
-        let func = quote! {
-            pub fn #get_func(&self) -> Rc<RefCell<Region>> {
-                self.operation
-                    .borrow()
-                    .regions[#id]
-                    .clone()
-            }
-        };
-        impls.push(func);
-
-        if *single_block {
-            let get_func = format_ident!("get_{}", region);
-            let func = quote! {
-                pub fn #get_func(&self) -> Rc<RefCell<Block>> {
-                    self.operation
-                        .borrow()
-                        .regions[#id]
-                        .borrow()
-                        .get_blocks()
-                        .first()
-                        .unwrap()
-                        .clone()
-                }
-            };
-            impls.push(func);
-        }
-    }
-
-    for (id, operand) in operands.iter().enumerate() {
-        let get_func = format_ident!("get_{}", operand);
-        // TODO implement setters!
-        let set_func = format_ident!("set_{}", operand);
-        let funcs = quote! {
-            pub fn #get_func(&self) -> Ref<'_, Operand> {
-                Ref::map(self.operation.borrow(), |ops| &ops.operands[#id])
-            }
-            pub fn #set_func(&mut self) {
-                todo!()
-            }
-        };
-        impls.push(funcs);
-    }
-
-    if regions.len() == 1 {
-        let func = quote! {
-            pub fn get_region(&self) -> Rc<RefCell<Region>> {
-               self.operation.borrow().regions.first().unwrap().clone()
-            }
-        };
-        impls.push(func);
-    }
+    let op_builder = build_op_builder(&input.ident, &op_attrs.name, &attrs, &operands, &regions);
 
     let op_name_str = op_attrs.name;
     let op_name = input.ident;
     let traits = op_attrs.traits;
 
     TokenStream::from(quote! {
-        #[derive(Debug)]
         pub struct #op_name {
-            operation: Rc<RefCell<OperationImpl>>,
+            operation: OperationImpl,
         }
 
+        #op_builder
+
         impl #op_name {
-            #(#impls)*
+            #attr_accessors
+            #operand_accessors
+            #region_accessors
         }
 
         impl Op for #op_name {
@@ -170,32 +354,35 @@ pub fn operation(metadata: TokenStream, input: TokenStream) -> TokenStream {
                 ];
                 ids.iter().find(|&x| x == &trait_id::<T>()).is_some()
             }
-        }
 
-        impl Into<Operation> for #op_name {
-            fn into(self) -> Operation {
-                Operation::from(self.operation.clone())
+            fn get_context(&self) -> ContextRef {
+                self.operation.context.clone()
             }
-        }
 
-        impl TryFrom<Operation> for #op_name {
-            type Error = ();
+            fn get_dialect_id(&self) -> u32 {
+                self.operation.dialect_id
+            }
 
-            fn try_from(operation: Operation) -> Result<Self, Self::Error> {
-                if operation.get_operation_name() != Self::get_operation_name()
-                    || operation.get_dialect_id()
-                        != operation
-                            .get_context()
-                            .borrow()
-                            .get_dialect_by_name(DIALECT_NAME)
-                            .unwrap()
-                            .borrow()
-                            .get_id()
-                {
-                    return Err(());
-                }
+            fn emplace_region(&mut self) -> RegionRef {
+                let region = Region::new(self.get_context());
+                self.operation.regions.push(region.clone());
+                region
+            }
 
-                Ok(Self { operation: operation.get_impl() })
+            fn get_regions(&self) -> &[RegionRef] {
+                &self.operation.regions
+            }
+
+            fn add_attr(&mut self, name: String, attr: Attr) {
+                self.operation.attrs.insert(name, attr);
+            }
+
+            fn get_attrs(&self) -> &std::collections::HashMap<String, Attr> {
+                &self.operation.attrs
+            }
+
+            fn add_operand(&mut self, operand: Operand) {
+                self.operation.operands.push(operand);
             }
         }
     })


### PR DESCRIPTION
- Add Builder interface to easily construct new operations
- Get rid of Operation class, just use `Rc<RefCell<dyn Op>>`
- Allow full usage of `std::any::Any` to easily cast to traits and ops
- Add shortcuts like BlockRef to be used instead of `Rc<RefCell<...>>`

Downsides:
- Now we have to use .borrow() everywhere. Plan is to replace `Rc<RefCell<...>>` with a custom container, similar to `Box` in terms of API.
- Operations are still scattered across the memory, leading to worse performance. Need to define some arena allocation APIs and tie operation lifetime to its parent Block.