### PR TITLE
feat: basic arith const implementation

### DIFF
--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -1,0 +1,46 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::builtin::DIALECT_NAME;
+use crate::utils::{trait_id, TraitId};
+use crate::*;
+use tir_macros::operation;
+
+#[operation(name = "const")]
+pub struct ConstOp {
+    #[cfg(attribute = true)]
+    value: Attr,
+    // FIXME: missing type attribute?
+}
+
+#[cfg(test)]
+mod test {
+    use std::any::TypeId;
+
+    use crate::{builtin::*, OpBuilder};
+    use crate::{Context, Op};
+
+    use super::*;
+
+    #[test]
+    fn test_const_op() {
+        assert!(ConstOp::get_operation_name() == "const");
+
+        let context = Context::new();
+        let module = ModuleOp::builder(context.clone()).build();
+        let builder = OpBuilder::new(context.clone(), module.borrow().get_body());
+
+        let attr = Attr::I8(16);
+
+        let constant = ConstOp::builder(context.clone()).value(attr.into()).build();
+
+        builder.borrow_mut().insert(constant.clone());
+        assert_eq!(
+            TryInto::<i8>::try_into(constant.borrow().get_value_attr()).unwrap(),
+            16
+        );
+        let body = module.borrow().get_body().clone();
+        let op = body.borrow().get_operations().first().unwrap().clone();
+        assert_eq!((*op.borrow()).type_id(), TypeId::of::<ConstOp>());
+    }
+}

--- a/core/src/builtin/mod.rs
+++ b/core/src/builtin/mod.rs
@@ -3,10 +3,12 @@ use crate::Op;
 use crate::Operation;
 use crate::Ty;
 
+mod arith;
 mod func;
 mod module;
 mod types;
 
+pub use arith::*;
 pub use func::*;
 pub use module::*;
 use tir_macros::dialect;
@@ -15,5 +17,5 @@ use tir_macros::populate_dialect_types;
 pub use types::*;
 
 dialect!(builtin);
-populate_dialect_ops!(ModuleOp, FuncOp);
+populate_dialect_ops!(ModuleOp, FuncOp, ConstOp);
 populate_dialect_types!(FuncType, VoidType);

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -9,6 +9,8 @@ use crate::builtin::DIALECT_NAME;
 dialect_type!(FuncType);
 dialect_type!(VoidType);
 
+// FIXME: we need scalar types
+
 impl FuncType {
     fn get_inputs_attr_name() -> &'static str {
         "inputs"


### PR DESCRIPTION
Basic version of arithmentic constant. It is not ready yet, because dialect-level type infromation is missing.