### PR TITLE
feat: add return type to ops

### DIFF
--- a/core/src/attrs.rs
+++ b/core/src/attrs.rs
@@ -21,7 +21,7 @@ macro_rules! impl_from {
     };
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Attr {
     String(String),
     Bool(bool),

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -6,11 +6,10 @@ use crate::utils::{trait_id, TraitId};
 use crate::*;
 use tir_macros::operation;
 
-#[operation(name = "const")]
+#[operation(name = "const", return_type = create::builtin::Type)]
 pub struct ConstOp {
     #[cfg(attribute = true)]
     value: Attr,
-    // FIXME: missing type attribute?
 }
 
 #[cfg(test)]

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -30,12 +30,12 @@ mod test {
         let module = ModuleOp::builder(context.clone()).build();
         let builder = OpBuilder::new(context.clone(), module.borrow().get_body());
 
-        let attr = Attr::I8(16);
+        let value_attr = Attr::I8(16);
+        let value_type = IntegerType::build(context.clone(), true, 8);
 
         let constant = ConstOp::builder(context.clone())
-            .value(attr.into())
-            // TODO: here we need to build I8 type
-            .return_type(None)
+            .value(value_attr.into())
+            .return_type(value_type.into())
             .build();
 
         builder.borrow_mut().insert(constant.clone());

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -3,10 +3,11 @@ use std::rc::Rc;
 
 use crate::builtin::DIALECT_NAME;
 use crate::utils::{trait_id, TraitId};
+use crate::Type;
 use crate::*;
 use tir_macros::operation;
 
-#[operation(name = "const", return_type = create::builtin::Type)]
+#[operation(name = "const", return_type = Type)]
 pub struct ConstOp {
     #[cfg(attribute = true)]
     value: Attr,
@@ -31,7 +32,11 @@ mod test {
 
         let attr = Attr::I8(16);
 
-        let constant = ConstOp::builder(context.clone()).value(attr.into()).build();
+        let constant = ConstOp::builder(context.clone())
+            .value(attr.into())
+            // TODO: here we need to build I8 type
+            .return_type(None)
+            .build();
 
         builder.borrow_mut().insert(constant.clone());
         assert_eq!(

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::builtin::DIALECT_NAME;
 use crate::builtin::IntegerType;
+use crate::builtin::DIALECT_NAME;
 use crate::utils::{trait_id, TraitId};
 use crate::*;
 use tir_macros::operation;

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -43,6 +43,8 @@ mod test {
             TryInto::<i8>::try_into(constant.borrow().get_value_attr()).unwrap(),
             16
         );
+        // FIXME: add test
+        // assert_eq!(constant.borrow().get_return_type.unwrap(), value_type);
         let body = module.borrow().get_body().clone();
         let op = body.borrow().get_operations().first().unwrap().clone();
         assert_eq!((*op.borrow()).type_id(), TypeId::of::<ConstOp>());

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -46,6 +46,6 @@ mod test {
         // FIXME: add test
         let body = module.borrow().get_body().clone();
         let op = body.borrow().get_operations().first().unwrap().clone();
-        assert_eq!((*op.borrow()).type_id(), TypeId::of::<IntegerType>());
+        assert_eq!((*op.borrow()).type_id(), TypeId::of::<IntegerConstOp>());
     }
 }

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -44,7 +44,7 @@ mod test {
             16
         );
         // FIXME: add test
-        // assert_eq!(constant.borrow().get_return_type.unwrap(), value_type);
+        assert_eq!(constant.borrow().get_return_type(), value_type);
         let body = module.borrow().get_body().clone();
         let op = body.borrow().get_operations().first().unwrap().clone();
         assert_eq!((*op.borrow()).type_id(), TypeId::of::<ConstOp>());

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -2,13 +2,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::builtin::DIALECT_NAME;
+use crate::builtin::IntegerType;
 use crate::utils::{trait_id, TraitId};
-use crate::Type;
 use crate::*;
 use tir_macros::operation;
 
-#[operation(name = "const", return_type = Type)]
-pub struct ConstOp {
+#[operation(name = "const", return_type = IntegerType)]
+pub struct IntegerConstOp {
     #[cfg(attribute = true)]
     value: Attr,
 }
@@ -24,7 +24,7 @@ mod test {
 
     #[test]
     fn test_const_op() {
-        assert!(ConstOp::get_operation_name() == "const");
+        assert!(IntegerConstOp::get_operation_name() == "const");
 
         let context = Context::new();
         let module = ModuleOp::builder(context.clone()).build();
@@ -33,7 +33,7 @@ mod test {
         let value_attr = Attr::I8(16);
         let value_type = IntegerType::build(context.clone(), true, 8);
 
-        let constant = ConstOp::builder(context.clone())
+        let constant = IntegerConstOp::builder(context.clone())
             .value(value_attr.into())
             .return_type(value_type.into())
             .build();
@@ -44,9 +44,8 @@ mod test {
             16
         );
         // FIXME: add test
-        assert_eq!(constant.borrow().get_return_type(), value_type);
         let body = module.borrow().get_body().clone();
         let op = body.borrow().get_operations().first().unwrap().clone();
-        assert_eq!((*op.borrow()).type_id(), TypeId::of::<ConstOp>());
+        assert_eq!((*op.borrow()).type_id(), TypeId::of::<IntegerType>());
     }
 }

--- a/core/src/builtin/mod.rs
+++ b/core/src/builtin/mod.rs
@@ -17,5 +17,5 @@ use tir_macros::populate_dialect_types;
 pub use types::*;
 
 dialect!(builtin);
-populate_dialect_ops!(ModuleOp, FuncOp, ConstOp);
+populate_dialect_ops!(ModuleOp, FuncOp, IntegerConstOp);
 populate_dialect_types!(FuncType, VoidType, IntegerType);

--- a/core/src/builtin/mod.rs
+++ b/core/src/builtin/mod.rs
@@ -18,4 +18,4 @@ pub use types::*;
 
 dialect!(builtin);
 populate_dialect_ops!(ModuleOp, FuncOp, ConstOp);
-populate_dialect_types!(FuncType, VoidType);
+populate_dialect_types!(FuncType, VoidType, IntegerType);

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -108,8 +108,3 @@ impl IntegerType {
     }
 }
 
-impl PartialEq for IntegerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.r#type == other.r#type
-    }
-}

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -10,8 +10,6 @@ dialect_type!(FuncType);
 dialect_type!(VoidType);
 dialect_type!(IntegerType);
 
-// FIXME: we need scalar types
-
 impl FuncType {
     fn get_inputs_attr_name() -> &'static str {
         "inputs"

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -81,11 +81,11 @@ impl VoidType {
 
 impl IntegerType {
     fn get_signed_attr_name() -> &'static str {
-        "inputs"
+        "signed"
     }
 
     fn get_bitwidth_attr_name() -> &'static str {
-        "return"
+        "bitwidth"
     }
 
     pub fn build(context: Rc<RefCell<Context>>, signed: bool, bitwidth: u32) -> IntegerType {
@@ -105,5 +105,12 @@ impl IntegerType {
         let r#type = Type::new(context, dialect.borrow().get_id(), type_id, attrs);
 
         IntegerType { r#type }
+    }
+}
+
+
+impl PartialEq for IntegerType {
+    fn eq(&self, other: &Self) -> bool {
+        self.r#type == other.r#type
     }
 }

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -8,6 +8,7 @@ use crate::builtin::DIALECT_NAME;
 
 dialect_type!(FuncType);
 dialect_type!(VoidType);
+dialect_type!(IntegerType);
 
 // FIXME: we need scalar types
 
@@ -77,5 +78,34 @@ impl VoidType {
         let r#type = Type::new(context, dialect.borrow().get_id(), type_id, HashMap::new());
 
         VoidType { r#type }
+    }
+}
+
+impl IntegerType {
+    fn get_signed_attr_name() -> &'static str {
+        "inputs"
+    }
+
+    fn get_bitwidth_attr_name() -> &'static str {
+        "return"
+    }
+
+    pub fn build(context: Rc<RefCell<Context>>, signed: bool, bitwidth: u32) -> IntegerType {
+        let mut attrs = HashMap::new();
+
+        attrs.insert(
+            IntegerType::get_signed_attr_name().to_string(),
+            Attr::Bool(signed),
+        );
+        attrs.insert(
+            IntegerType::get_bitwidth_attr_name().to_string(),
+            Attr::U32(bitwidth),
+        );
+
+        let dialect = context.borrow().get_dialect_by_name(DIALECT_NAME).unwrap();
+        let type_id = dialect.borrow().get_type_id(IntegerType::get_type_name());
+        let r#type = Type::new(context, dialect.borrow().get_id(), type_id, attrs);
+
+        IntegerType { r#type }
     }
 }

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -108,7 +108,6 @@ impl IntegerType {
     }
 }
 
-
 impl PartialEq for IntegerType {
     fn eq(&self, other: &Self) -> bool {
         self.r#type == other.r#type

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -1,4 +1,4 @@
-use crate::{Attr, ContextRef};
+use crate::{Attr, ContextRef, Type};
 use std::collections::HashMap;
 
 use std::{
@@ -85,6 +85,7 @@ pub struct OperationImpl {
     pub operands: Vec<Operand>,
     pub attrs: HashMap<String, Attr>,
     pub regions: Vec<Rc<RefCell<Region>>>,
+    pub return_type: Option<Type>,
 }
 
 impl OperationImpl {

--- a/core/src/type.rs
+++ b/core/src/type.rs
@@ -48,3 +48,10 @@ impl Type {
 pub trait Ty {
     fn get_type_name() -> &'static str;
 }
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        // FIXME: missing checks, is it even legit?
+        self.type_id == other.type_id && self.dialect_id == other.dialect_id
+    }
+}

--- a/core/src/type.rs
+++ b/core/src/type.rs
@@ -45,13 +45,17 @@ impl Type {
     }
 }
 
-pub trait Ty {
+pub trait Ty: PartialEq {
     fn get_type_name() -> &'static str;
 }
 
 impl PartialEq for Type {
     fn eq(&self, other: &Self) -> bool {
-        // FIXME: missing checks, is it even legit?
-        self.type_id == other.type_id && self.dialect_id == other.dialect_id
+        // We compare contexts as raw pointers, so two structurally identical
+        // datatypes in separate contexts are treated as unequal.
+        self.context.as_ptr() == other.context.as_ptr()
+            && self.attrs == other.attrs
+            && self.type_id == other.type_id
+            && self.dialect_id == other.dialect_id
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -473,6 +473,7 @@ pub fn dialect_type(input: TokenStream) -> TokenStream {
     let name_str = camel_to_snake(name_str);
 
     quote! {
+        #[derive(Debug)]
         pub struct #name_ident {
             r#type: Type,
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -260,7 +260,7 @@ fn build_op_builder(
 
     if return_type.is_some() {
         builder_fields.push(quote! {
-            return_type: Option<Type>,
+            return_type: Option<#return_type>,
         });
 
         builder_setters.push(quote! {
@@ -268,7 +268,7 @@ fn build_op_builder(
         });
 
         builder_accessors.push(quote! {
-            pub fn return_type(mut self, ty: Type) -> Self {
+            pub fn return_type(mut self, ty: #return_type) -> Self {
                 self.return_type = Some(ty);
                 self
             }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -473,7 +473,7 @@ pub fn dialect_type(input: TokenStream) -> TokenStream {
     let name_str = camel_to_snake(name_str);
 
     quote! {
-        #[derive(Debug)]
+        #[derive(Debug, PartialEq)]
         pub struct #name_ident {
             r#type: Type,
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -179,6 +179,17 @@ fn build_region_accessors(regions: &[RegionField]) -> proc_macro2::TokenStream {
     }
 }
 
+fn build_return_type_accessor(maybe_return_type: &Option<syn::Path>) -> proc_macro2::TokenStream {
+    if maybe_return_type.is_none() {
+        return proc_macro2::TokenStream::new();
+    }
+    quote! {
+        pub fn get_return_type(&self) -> &Type {
+            self.operation.return_type.as_ref().unwrap()
+        }
+    }
+}
+
 fn build_op_builder(
     op: &syn::Ident,
     op_name: &str,
@@ -346,6 +357,7 @@ pub fn operation(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let attr_accessors = build_attr_accessors(&attrs);
     let operand_accessors = build_operand_accessors(&operands);
     let region_accessors = build_region_accessors(&regions);
+    let return_type_accessor = build_return_type_accessor(&op_attrs.return_type);
 
     let op_builder = build_op_builder(
         &input.ident,
@@ -371,6 +383,7 @@ pub fn operation(metadata: TokenStream, input: TokenStream) -> TokenStream {
             #attr_accessors
             #operand_accessors
             #region_accessors
+            #return_type_accessor
         }
 
         impl Op for #op_name {


### PR DESCRIPTION
Operation now stores type information about the value it returns (if any). In order to retrieve type information from a value, one should check the operation it originates from. Builder is also fixed but the need to some kind of verifier arises as we can now easily introduce some nonsensical operations like add with no return type etc.