### PR TITLE
feat: proper custom assembly interface

### DIFF
--- a/backends/common/Cargo.toml
+++ b/backends/common/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 tir-core = { path = "../../core/" }
 tir-macros = { path = "../../macros" }
 thiserror = "1.0.59"
+winnow = "0.6.7"

--- a/backends/common/src/target/mod.rs
+++ b/backends/common/src/target/mod.rs
@@ -1,5 +1,5 @@
-use tir_core::Assembly;
 use tir_core::Dialect;
+use tir_core::OpAssembly;
 
 mod ops;
 

--- a/backends/common/src/target/ops.rs
+++ b/backends/common/src/target/ops.rs
@@ -1,5 +1,6 @@
 use tir_core::*;
 use tir_macros::{Op, OpAssembly};
+use winnow::Parser;
 
 use crate::target::DIALECT_NAME;
 

--- a/backends/common/src/target/ops.rs
+++ b/backends/common/src/target/ops.rs
@@ -1,9 +1,9 @@
 use tir_core::*;
-use tir_macros::{Assembly, Op};
+use tir_macros::{Op, OpAssembly};
 
 use crate::target::DIALECT_NAME;
 
-#[derive(Op, Assembly)]
+#[derive(Op, OpAssembly)]
 #[operation(name = "section", known_attrs(name: String))]
 pub struct SectionOp {
     #[region]

--- a/backends/riscv/Cargo.toml
+++ b/backends/riscv/Cargo.toml
@@ -10,3 +10,4 @@ tir-core = { path = "../../core" }
 tir-macros = { path = "../../macros" }
 tir-backend = { path = "../common" }
 seq-macro = "0.3.5"
+winnow = "0.6.7"

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -1,6 +1,6 @@
 use tir_backend::DisassemblerError;
 use tir_core::Dialect;
-use tir_core::{Assembly, ContextRef, OpBuilder};
+use tir_core::{ContextRef, OpAssembly, OpBuilder};
 
 mod ops;
 mod registers;

--- a/backends/riscv/src/ops/alu.rs
+++ b/backends/riscv/src/ops/alu.rs
@@ -2,8 +2,9 @@ use crate::utils::RTypeInstr;
 use crate::Register;
 use crate::{assemble_reg, disassemble_gpr};
 use tir_backend::BinaryEmittable;
+use tir_core::OpAssembly;
 use tir_core::*;
-use tir_macros::{Assembly, Op};
+use tir_macros::{Op, OpAssembly};
 
 use crate::DIALECT_NAME;
 
@@ -11,7 +12,7 @@ const ALU_OPCODE: u8 = 0b110011;
 
 macro_rules! alu_op_base {
     ($struct_name:ident, $op_name:literal) => {
-        #[derive(Op, Assembly)]
+        #[derive(Op, OpAssembly)]
         #[operation(name = $op_name)]
         pub struct $struct_name {
             #[operand]

--- a/backends/riscv/src/ops/alu.rs
+++ b/backends/riscv/src/ops/alu.rs
@@ -2,9 +2,11 @@ use crate::utils::RTypeInstr;
 use crate::Register;
 use crate::{assemble_reg, disassemble_gpr};
 use tir_backend::BinaryEmittable;
+use tir_core::parser::Parseable;
 use tir_core::OpAssembly;
 use tir_core::*;
 use tir_macros::{Op, OpAssembly};
+use winnow::Parser;
 
 use crate::DIALECT_NAME;
 

--- a/backends/riscv/src/registers.rs
+++ b/backends/riscv/src/registers.rs
@@ -1,5 +1,9 @@
 use seq_macro::seq;
-use tir_core::{IRFormatter, Printable};
+use tir_core::{
+    parser::{identifier, PResult, ParseStream, Parseable},
+    IRFormatter, Printable,
+};
+use winnow::Parser;
 
 macro_rules! register {
     ($($case_name:ident => { abi_name = $abi_name:literal, encoding = $encoding:literal, num = $num:literal },)*) => {
@@ -39,6 +43,20 @@ macro_rules! register {
                 $(
                     Register::$case_name => fmt.write_direct($abi_name),
                 )*
+                }
+            }
+        }
+
+        impl Parseable<Register> for Register {
+            fn parse(input: &mut ParseStream<'_>) -> PResult<Register> {
+                let ident = identifier.parse_next(input)?;
+
+                match ident {
+                $(
+                    $abi_name => Ok(Register::$case_name),
+                    stringify!($case_name) => Ok(Register::$case_name),
+                )*
+                    _ => panic!(),
                 }
             }
         }

--- a/backends/riscv/src/registers.rs
+++ b/backends/riscv/src/registers.rs
@@ -1,4 +1,5 @@
 use seq_macro::seq;
+use tir_core::{IRFormatter, Printable};
 
 macro_rules! register {
     ($($case_name:ident => { abi_name = $abi_name:literal, encoding = $encoding:literal, num = $num:literal },)*) => {
@@ -29,6 +30,16 @@ macro_rules! register {
             $(
                 Register::$case_name => Ok($encoding as u8),
             )*
+            }
+        }
+
+        impl Printable for Register {
+            fn print(&self, fmt: &mut dyn IRFormatter) {
+                match self {
+                $(
+                    Register::$case_name => fmt.write_direct($abi_name),
+                )*
+                }
             }
         }
     };

--- a/core/src/assembly/mod.rs
+++ b/core/src/assembly/mod.rs
@@ -2,7 +2,7 @@ mod formatter;
 pub mod parser;
 mod printer;
 
-use crate::{Attr, OpRef, Type};
+use crate::{Attr, OpRef};
 use std::collections::HashMap;
 
 pub use formatter::*;
@@ -20,7 +20,9 @@ pub trait TyAssembly {
     fn print_assembly(attrs: &HashMap<String, Attr>, fmt: &mut dyn IRFormatter)
     where
         Self: Sized;
-    fn parse_assembly(input: &mut parser::ParseStream<'_>) -> parser::PResult<Type>
+    fn parse_assembly(
+        input: &mut parser::ParseStream<'_>,
+    ) -> parser::PResult<HashMap<String, Attr>>
     where
         Self: Sized;
 }

--- a/core/src/assembly/mod.rs
+++ b/core/src/assembly/mod.rs
@@ -1,17 +1,17 @@
 mod formatter;
-mod parser;
+pub mod parser;
 mod printer;
 
 pub use formatter::*;
-pub use parser::*;
 pub use printer::*;
 
-use crate::ContextRef;
+pub use crate::parser::parse_ir;
 
+use crate::OpRef;
 
-pub trait Assembly<T> {
-    fn print_ir(&self, fmt: &mut dyn IRFormatter);
-    fn parse_ir(context: ContextRef, input: &mut &str) -> std::result::Result<T, ()>
+pub trait OpAssembly {
+    fn print_assembly(&self, fmt: &mut dyn IRFormatter);
+    fn parse_assembly(input: &mut parser::ParseStream<'_>) -> parser::PResult<OpRef>
     where
         Self: Sized;
 }

--- a/core/src/assembly/mod.rs
+++ b/core/src/assembly/mod.rs
@@ -2,16 +2,25 @@ mod formatter;
 pub mod parser;
 mod printer;
 
+use crate::{Attr, OpRef, Type};
+use std::collections::HashMap;
+
 pub use formatter::*;
+pub use parser::parse_ir;
 pub use printer::*;
-
-pub use crate::parser::parse_ir;
-
-use crate::OpRef;
 
 pub trait OpAssembly {
     fn print_assembly(&self, fmt: &mut dyn IRFormatter);
     fn parse_assembly(input: &mut parser::ParseStream<'_>) -> parser::PResult<OpRef>
+    where
+        Self: Sized;
+}
+
+pub trait TyAssembly {
+    fn print_assembly(attrs: &HashMap<String, Attr>, fmt: &mut dyn IRFormatter)
+    where
+        Self: Sized;
+    fn parse_assembly(input: &mut parser::ParseStream<'_>) -> parser::PResult<Type>
     where
         Self: Sized;
 }

--- a/core/src/assembly/mod.rs
+++ b/core/src/assembly/mod.rs
@@ -6,11 +6,12 @@ pub use formatter::*;
 pub use parser::*;
 pub use printer::*;
 
-use crate::{ContextRef, OpRef};
+use crate::ContextRef;
 
-pub trait Assembly {
-    fn print(&self, fmt: &mut dyn IRFormatter);
-    fn parse(context: ContextRef, input: &mut &str) -> std::result::Result<OpRef, ()>
+
+pub trait Assembly<T> {
+    fn print_ir(&self, fmt: &mut dyn IRFormatter);
+    fn parse_ir(context: ContextRef, input: &mut &str) -> std::result::Result<T, ()>
     where
         Self: Sized;
 }

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -11,7 +11,6 @@ use winnow::combinator::separated_pair;
 use winnow::combinator::terminated;
 use winnow::error::ContextError;
 use winnow::error::ErrMode;
-use winnow::stream::Accumulate;
 use winnow::stream::Stateful;
 use winnow::Parser;
 
@@ -52,7 +51,7 @@ fn builtin_op<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
         .map(|op| ("builtin", op))
 }
 
-fn op_tuple<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
+pub fn op_tuple<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
     alt((dialect_op, builtin_op)).parse_next(input)
 }
 
@@ -82,7 +81,7 @@ pub fn parse_ir(
         state: ParserState { context },
     };
 
-    single_op.parse(input)
+    preceded(multispace0, single_op).parse(input)
 }
 
 pub fn single_block_region(ir: &mut ParseStream<'_>) -> PResult<Vec<OpRef>> {
@@ -99,7 +98,7 @@ pub fn single_block_region(ir: &mut ParseStream<'_>) -> PResult<Vec<OpRef>> {
     Ok(operations)
 }
 
-fn attr_pair<'s>(input: &mut ParseStream<'s>) -> PResult<(String, Attr)> {
+fn attr_pair(input: &mut ParseStream<'_>) -> PResult<(String, Attr)> {
     separated_pair(
         identifier.map(|s| s.to_string()),
         (space0, "=", space0),

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -1,111 +1,151 @@
-use winnow::ascii::alpha1;
-use winnow::ascii::alphanumeric0;
-use winnow::ascii::multispace0;
-use winnow::combinator::alt;
-use winnow::combinator::separated_pair;
-use winnow::error::ContextError;
-use winnow::error::ErrMode;
-use winnow::PResult;
-use winnow::Parser;
+use winnow::error::ErrorKind;
+use winnow::stream::Stream;
 
-use crate::{ContextRef, OpRef};
+pub type PResult<I> = winnow::prelude::PResult<I, ParserError<I>>;
 
-fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
-    (alpha1, alphanumeric0).recognize().parse_next(input)
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParserError<I> {
+    Nom(I, ErrorKind),
 }
 
-fn dialect_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-    separated_pair(identifier, ".", identifier).parse_next(input)
-}
-
-fn builtin_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-    identifier
-        .recognize()
-        .parse_next(input)
-        .map(|op| ("builtin", op))
-}
-
-fn op_tuple<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-    alt((dialect_op, builtin_op)).parse_next(input)
-}
-
-pub fn parse_ir(context: ContextRef, ir: &str) -> Result<OpRef, ()> {
-    let mut input = ir;
-    let (dialect_name, op_name) = op_tuple.parse_next(&mut input).map_err(|_| ())?;
-
-    let dialect = context.get_dialect_by_name(dialect_name).ok_or(())?;
-
-    let operation_id = dialect.get_operation_id(op_name).ok_or(())?;
-    let parser = dialect.get_operation_parser(operation_id).ok_or(())?;
-    parser(context, &mut input)
-}
-
-pub fn parse_single_operation(context: &ContextRef, ir: &mut &str) -> PResult<OpRef> {
-    let ir = ir;
-    let (dialect_name, op_name) = op_tuple
-        .parse_next(ir)
-        .map_err(|_| ErrMode::Backtrack(ContextError::new()))?;
-
-    let dialect = context
-        .get_dialect_by_name(dialect_name)
-        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
-
-    let operation_id = dialect
-        .get_operation_id(op_name)
-        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
-    let parser = dialect
-        .get_operation_parser(operation_id)
-        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
-    parser(context.clone(), ir).map_err(|_| ErrMode::Backtrack(ContextError::new()))
-}
-
-pub fn parse_single_block_region(context: ContextRef, ir: &mut &str) -> Result<Vec<OpRef>, ()> {
-    let _ = (multispace0, "{", multispace0)
-        .parse_next(ir)
-        .map_err(|_: ErrMode<ContextError>| ())?;
-
-    let mut operations = vec![];
-
-    loop {
-        if let Ok(operation) = parse_single_operation(&context, ir) {
-            operations.push(operation);
-        } else {
-            break;
-        }
+impl<I: Stream + Clone> winnow::error::ParserError<I> for ParserError<I> {
+    fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
+        ParserError::Nom(input.clone(), kind)
     }
 
-    let _ = (multispace0, "}")
-        .parse_next(ir)
-        .map_err(|_: ErrMode<ContextError>| ())?;
-
-    Ok(operations)
-}
-
-#[cfg(test)]
-mod tests {
-    use winnow::Parser;
-
-    use super::{identifier, op_tuple};
-
-    #[test]
-    fn parse_ident() {
-        assert!(identifier.parse("abc").is_ok());
-        assert!(identifier.parse("abc123").is_ok());
-        assert!(identifier.parse("123").is_err());
-        assert!(identifier.parse("123abc").is_err());
-        let mut input = "abc123 abc 123";
-        let ident = identifier.parse_next(&mut input).unwrap();
-        assert_eq!(ident, "abc123");
-    }
-
-    #[test]
-    fn parse_op_name() {
-        let mut ir = "module";
-        let result = op_tuple.parse_next(&mut ir).unwrap();
-        assert_eq!(result, ("builtin", "module"));
-
-        let mut ir = "test.module";
-        let result = op_tuple.parse_next(&mut ir).unwrap();
-        assert_eq!(result, ("test", "module"));
+    fn append(self, _: &I, _: &<I as Stream>::Checkpoint, _: ErrorKind) -> Self {
+        self
     }
 }
+
+// use winnow::ascii::alpha1;
+// use winnow::ascii::alphanumeric0;
+// use winnow::ascii::multispace0;
+// use winnow::combinator::alt;
+// use winnow::combinator::separated_pair;
+// use winnow::error::ContextError;
+// use winnow::error::ErrMode;
+// use winnow::error::StrContext;
+// // use winnow::PResult;
+// use winnow::Parser;
+// use winnow::error::ErrorKind;
+// use winnow::stream::Stream;
+
+// use crate::{ContextRef, OpRef};
+
+// #[derive(Debug, PartialEq, Eq)]
+// pub enum ParserError<I> {
+//     Nom(I, ErrorKind),
+// }
+
+// impl<I: Stream + Clone> winnow::error::ParserError<I> for ParserError<I> {
+//     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
+//         ParserError::Nom(input.clone(), kind)
+//     }
+
+//     fn append(self, _: &I, _: &<I as Stream>::Checkpoint, _: ErrorKind) -> Self {
+//         self
+//     }
+// }
+
+// type PResult<T, I = ContextError> = Result<T, ErrMode<ParserError<I>>>;
+
+// fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//     (alpha1, alphanumeric0).recognize().parse_next(input)
+// }
+
+// fn dialect_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//     separated_pair(identifier, ".", identifier).parse_next(input)
+// }
+
+// fn builtin_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//     identifier
+//         .recognize()
+//         .parse_next(input)
+//         .map(|op| ("builtin", op))
+// }
+
+// fn op_tuple<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//     alt((dialect_op, builtin_op)).parse_next(input)
+// }
+
+// pub fn parse_ir(context: ContextRef, ir: &str) -> Result<OpRef, ()> {
+//     let mut input = ir;
+//     let (dialect_name, op_name) = op_tuple.parse_next(&mut input).map_err(|_| ())?;
+
+//     let dialect = context.get_dialect_by_name(dialect_name).ok_or(())?;
+
+//     let operation_id = dialect.get_operation_id(op_name).ok_or(())?;
+//     let parser = dialect.get_operation_parser(operation_id).ok_or(())?;
+//     parser(context, &mut input)
+// }
+
+// pub fn parse_single_operation(context: &ContextRef, ir: &mut &str) -> PResult<OpRef> {
+//     let ir = ir;
+//     let (dialect_name, op_name) = op_tuple
+//         .parse_next(ir)
+//         .map_err(|_| ErrMode::Backtrack(ContextError::new()))?;
+
+//     let dialect = context
+//         .get_dialect_by_name(dialect_name)
+//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+
+//     let operation_id = dialect
+//         .get_operation_id(op_name)
+//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+//     let parser = dialect
+//         .get_operation_parser(operation_id)
+//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+//     parser(context.clone(), ir).map_err(|_| ErrMode::Backtrack(ContextError::new()))
+// }
+
+// pub fn parse_single_block_region(context: ContextRef, ir: &mut &str) -> Result<Vec<OpRef>, ()> {
+//     let _ = (multispace0, "{", multispace0)
+//         .parse_next(ir)
+//         .map_err(|_: ErrMode<ContextError>| ())?;
+
+//     let mut operations = vec![];
+
+//     loop {
+//         if let Ok(operation) = parse_single_operation(&context, ir) {
+//             operations.push(operation);
+//         } else {
+//             break;
+//         }
+//     }
+
+//     let _ = (multispace0, "}")
+//         .parse_next(ir)
+//         .map_err(|_: ErrMode<ContextError>| ())?;
+
+//     Ok(operations)
+// }
+
+// #[cfg(test)]
+// mod tests {
+//     use winnow::Parser;
+
+//     use super::{identifier, op_tuple};
+
+//     #[test]
+//     fn parse_ident() {
+//         assert!(identifier.parse("abc").is_ok());
+//         assert!(identifier.parse("abc123").is_ok());
+//         assert!(identifier.parse("123").is_err());
+//         assert!(identifier.parse("123abc").is_err());
+//         let mut input = "abc123 abc 123";
+//         let ident = identifier.parse_next(&mut input).unwrap();
+//         assert_eq!(ident, "abc123");
+//     }
+
+//     #[test]
+//     fn parse_op_name() {
+//         let mut ir = "module";
+//         let result = op_tuple.parse_next(&mut ir).unwrap();
+//         assert_eq!(result, ("builtin", "module"));
+
+//         let mut ir = "test.module";
+//         let result = op_tuple.parse_next(&mut ir).unwrap();
+//         assert_eq!(result, ("test", "module"));
+//     }
+// }

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -1,151 +1,129 @@
-use winnow::error::ErrorKind;
-use winnow::stream::Stream;
+use winnow::ascii::alpha1;
+use winnow::ascii::alphanumeric0;
+use winnow::ascii::multispace0;
+use winnow::combinator::alt;
+use winnow::combinator::separated_pair;
+use winnow::error::ContextError;
+use winnow::error::ErrMode;
+use winnow::stream::Stateful;
+use winnow::Parser;
 
-pub type PResult<I> = winnow::prelude::PResult<I, ParserError<I>>;
+use crate::{ContextRef, OpRef};
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum ParserError<I> {
-    Nom(I, ErrorKind),
+#[derive(Debug, Clone)]
+pub struct ParserState {
+    context: ContextRef,
 }
 
-impl<I: Stream + Clone> winnow::error::ParserError<I> for ParserError<I> {
-    fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
-        ParserError::Nom(input.clone(), kind)
-    }
-
-    fn append(self, _: &I, _: &<I as Stream>::Checkpoint, _: ErrorKind) -> Self {
-        self
+impl ParserState {
+    pub fn get_context(&self) -> ContextRef {
+        self.context.clone()
     }
 }
 
-// use winnow::ascii::alpha1;
-// use winnow::ascii::alphanumeric0;
-// use winnow::ascii::multispace0;
-// use winnow::combinator::alt;
-// use winnow::combinator::separated_pair;
-// use winnow::error::ContextError;
-// use winnow::error::ErrMode;
-// use winnow::error::StrContext;
-// // use winnow::PResult;
-// use winnow::Parser;
-// use winnow::error::ErrorKind;
-// use winnow::stream::Stream;
+pub type ParseStream<'a> = Stateful<&'a str, ParserState>;
 
-// use crate::{ContextRef, OpRef};
+pub type PResult<I> = winnow::PResult<I>;
 
-// #[derive(Debug, PartialEq, Eq)]
-// pub enum ParserError<I> {
-//     Nom(I, ErrorKind),
-// }
+fn identifier<'s>(input: &mut ParseStream<'s>) -> PResult<&'s str> {
+    (alpha1, alphanumeric0).recognize().parse_next(input)
+}
 
-// impl<I: Stream + Clone> winnow::error::ParserError<I> for ParserError<I> {
-//     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
-//         ParserError::Nom(input.clone(), kind)
-//     }
+fn dialect_op<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
+    separated_pair(identifier, ".", identifier).parse_next(input)
+}
 
-//     fn append(self, _: &I, _: &<I as Stream>::Checkpoint, _: ErrorKind) -> Self {
-//         self
-//     }
-// }
+fn builtin_op<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
+    identifier
+        .recognize()
+        .parse_next(input)
+        .map(|op| ("builtin", op))
+}
 
-// type PResult<T, I = ContextError> = Result<T, ErrMode<ParserError<I>>>;
+fn op_tuple<'s>(input: &mut ParseStream<'s>) -> PResult<(&'s str, &'s str)> {
+    alt((dialect_op, builtin_op)).parse_next(input)
+}
 
-// fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
-//     (alpha1, alphanumeric0).recognize().parse_next(input)
-// }
+pub fn single_op(input: &mut ParseStream) -> PResult<OpRef> {
+    let context = input.state.get_context();
+    let (dialect_name, op_name) = op_tuple.parse_next(input)?;
 
-// fn dialect_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-//     separated_pair(identifier, ".", identifier).parse_next(input)
-// }
+    let dialect = context
+        .get_dialect_by_name(dialect_name)
+        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
 
-// fn builtin_op<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-//     identifier
-//         .recognize()
-//         .parse_next(input)
-//         .map(|op| ("builtin", op))
-// }
+    let operation_id = dialect
+        .get_operation_id(op_name)
+        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+    let mut parser = dialect
+        .get_operation_parser(operation_id)
+        .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+    parser.parse_next(input)
+}
 
-// fn op_tuple<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
-//     alt((dialect_op, builtin_op)).parse_next(input)
-// }
+pub fn parse_ir(
+    context: ContextRef,
+    input: &str,
+) -> Result<OpRef, winnow::error::ParseError<ParseStream<'_>, winnow::error::ContextError>> {
+    let input = ParseStream {
+        input,
+        state: ParserState { context },
+    };
 
-// pub fn parse_ir(context: ContextRef, ir: &str) -> Result<OpRef, ()> {
-//     let mut input = ir;
-//     let (dialect_name, op_name) = op_tuple.parse_next(&mut input).map_err(|_| ())?;
+    single_op.parse(input)
+}
 
-//     let dialect = context.get_dialect_by_name(dialect_name).ok_or(())?;
+pub fn single_block_region(ir: &mut ParseStream<'_>) -> PResult<Vec<OpRef>> {
+    let _ = (multispace0, "{", multispace0).parse_next(ir)?;
 
-//     let operation_id = dialect.get_operation_id(op_name).ok_or(())?;
-//     let parser = dialect.get_operation_parser(operation_id).ok_or(())?;
-//     parser(context, &mut input)
-// }
+    let mut operations = vec![];
 
-// pub fn parse_single_operation(context: &ContextRef, ir: &mut &str) -> PResult<OpRef> {
-//     let ir = ir;
-//     let (dialect_name, op_name) = op_tuple
-//         .parse_next(ir)
-//         .map_err(|_| ErrMode::Backtrack(ContextError::new()))?;
+    while let Ok(operation) = single_op.parse_next(ir) {
+        operations.push(operation);
+    }
 
-//     let dialect = context
-//         .get_dialect_by_name(dialect_name)
-//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
+    let _ = (multispace0, "}", multispace0).parse_next(ir)?;
 
-//     let operation_id = dialect
-//         .get_operation_id(op_name)
-//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
-//     let parser = dialect
-//         .get_operation_parser(operation_id)
-//         .ok_or(ErrMode::Backtrack(ContextError::new()))?;
-//     parser(context.clone(), ir).map_err(|_| ErrMode::Backtrack(ContextError::new()))
-// }
+    Ok(operations)
+}
 
-// pub fn parse_single_block_region(context: ContextRef, ir: &mut &str) -> Result<Vec<OpRef>, ()> {
-//     let _ = (multispace0, "{", multispace0)
-//         .parse_next(ir)
-//         .map_err(|_: ErrMode<ContextError>| ())?;
+#[cfg(test)]
+mod tests {
+    use winnow::Parser;
 
-//     let mut operations = vec![];
+    use super::{identifier, op_tuple, ParseStream, ParserState};
+    use crate::Context;
 
-//     loop {
-//         if let Ok(operation) = parse_single_operation(&context, ir) {
-//             operations.push(operation);
-//         } else {
-//             break;
-//         }
-//     }
+    macro_rules! input {
+        ($inp:literal, $context:expr) => {
+            ParseStream {
+                input: $inp.into(),
+                state: ParserState { context: $context },
+            }
+        };
+    }
 
-//     let _ = (multispace0, "}")
-//         .parse_next(ir)
-//         .map_err(|_: ErrMode<ContextError>| ())?;
+    #[test]
+    fn parse_ident() {
+        let context = Context::new();
+        assert!(identifier.parse(input!("abc", context.clone())).is_ok());
+        assert!(identifier.parse(input!("abc123", context.clone())).is_ok());
+        assert!(identifier.parse(input!("123", context.clone())).is_err());
+        assert!(identifier.parse(input!("123abs", context.clone())).is_err());
+        let mut inp = input!("abc123 abc 123", context.clone());
+        let ident = identifier.parse_next(&mut inp).unwrap();
+        assert_eq!(ident, "abc123");
+    }
 
-//     Ok(operations)
-// }
+    #[test]
+    fn parse_op_name() {
+        let context = Context::new();
+        let mut ir = input!("module", context.clone());
+        let result = op_tuple.parse_next(&mut ir).unwrap();
+        assert_eq!(result, ("builtin", "module"));
 
-// #[cfg(test)]
-// mod tests {
-//     use winnow::Parser;
-
-//     use super::{identifier, op_tuple};
-
-//     #[test]
-//     fn parse_ident() {
-//         assert!(identifier.parse("abc").is_ok());
-//         assert!(identifier.parse("abc123").is_ok());
-//         assert!(identifier.parse("123").is_err());
-//         assert!(identifier.parse("123abc").is_err());
-//         let mut input = "abc123 abc 123";
-//         let ident = identifier.parse_next(&mut input).unwrap();
-//         assert_eq!(ident, "abc123");
-//     }
-
-//     #[test]
-//     fn parse_op_name() {
-//         let mut ir = "module";
-//         let result = op_tuple.parse_next(&mut ir).unwrap();
-//         assert_eq!(result, ("builtin", "module"));
-
-//         let mut ir = "test.module";
-//         let result = op_tuple.parse_next(&mut ir).unwrap();
-//         assert_eq!(result, ("test", "module"));
-//     }
-// }
+        let mut ir = input!("test.module", context.clone());
+        let result = op_tuple.parse_next(&mut ir).unwrap();
+        assert_eq!(result, ("test", "module"));
+    }
+}

--- a/core/src/assembly/printer.rs
+++ b/core/src/assembly/printer.rs
@@ -1,5 +1,9 @@
 use crate::{builtin, IRFormatter, OpRef};
 
+pub trait Print<T> {
+    fn print(&self, fmt: &mut dyn IRFormatter);
+}
+
 /// Prints given operation to stdout
 pub fn print_op(op: OpRef, fmt: &mut dyn IRFormatter) {
     let context = op.borrow().get_context();

--- a/core/src/assembly/printer.rs
+++ b/core/src/assembly/printer.rs
@@ -1,30 +1,14 @@
-use crate::{builtin, IRFormatter, OpRef};
+use crate::IRFormatter;
 
-pub trait Print<T> {
+pub trait Printable {
     fn print(&self, fmt: &mut dyn IRFormatter);
-}
-
-/// Prints given operation to stdout
-pub fn print_op(op: OpRef, fmt: &mut dyn IRFormatter) {
-    let context = op.borrow().get_context();
-    let dialect = op.borrow().get_dialect_id();
-    let dialect = context.get_dialect(dialect).unwrap();
-
-    if dialect.get_name() != builtin::DIALECT_NAME {
-        fmt.write_direct(dialect.get_name());
-        fmt.write_direct(".");
-    }
-
-    fmt.write_direct(op.borrow().get_operation_name());
-    fmt.write_direct(" ");
-    op.borrow().print(fmt);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::print_op;
     use crate::builtin::ModuleOp;
     use crate::Context;
+    use crate::Printable;
     use crate::StringPrinter;
 
     #[test]
@@ -34,7 +18,7 @@ mod tests {
 
         let mut printer = StringPrinter::new();
 
-        print_op(module, &mut printer);
+        module.borrow().print(&mut printer);
 
         let result = printer.get();
 

--- a/core/src/attrs.rs
+++ b/core/src/attrs.rs
@@ -1,4 +1,13 @@
-use crate::{Printable, Type};
+use winnow::{
+    ascii::{alphanumeric0, alphanumeric1, space0},
+    combinator::{delimited, separated_pair},
+    Parser,
+};
+
+use crate::{
+    parser::{identifier, PResult, ParseStream, Parseable},
+    Printable, Type,
+};
 
 macro_rules! impl_from {
     ($case:ident, $from:ty) => {
@@ -48,7 +57,7 @@ pub enum Attr {
 impl Printable for Attr {
     fn print(&self, fmt: &mut dyn crate::IRFormatter) {
         match self {
-            Attr::String(value) => fmt.write_direct(&format!("<str: {}>", &value)),
+            Attr::String(value) => fmt.write_direct(&format!("<str: \"{}\">", &value)),
             Attr::Bool(value) => fmt.write_direct(&format!("<bool: {}>", &value)),
             Attr::I8(value) => fmt.write_direct(&format!("<i8: {}>", &value)),
             Attr::U8(value) => fmt.write_direct(&format!("<u8: {}>", &value)),
@@ -58,6 +67,27 @@ impl Printable for Attr {
             Attr::U32(value) => fmt.write_direct(&format!("<u32: {}>", &value)),
             Attr::I64(value) => fmt.write_direct(&format!("<i64: {}>", &value)),
             Attr::U64(value) => fmt.write_direct(&format!("<u64: {}>", &value)),
+            _ => todo!(),
+        }
+    }
+}
+
+impl Parseable<Attr> for Attr {
+    fn parse(input: &mut ParseStream<'_>) -> PResult<Attr> {
+        let atom = separated_pair(identifier, (space0, ":", space0), alphanumeric1);
+        let (ty, value) =
+            delimited((space0, "<", space0), atom, (space0, ">", space0)).parse_next(input)?;
+
+        match ty {
+            "str" => Ok(Attr::String(value.to_string())),
+            "i8" => Ok(Attr::I8(value.parse::<i8>().unwrap())),
+            "u8" => Ok(Attr::U8(value.parse::<u8>().unwrap())),
+            "i16" => Ok(Attr::I16(value.parse::<i16>().unwrap())),
+            "u16" => Ok(Attr::U16(value.parse::<u16>().unwrap())),
+            "i32" => Ok(Attr::I32(value.parse::<i32>().unwrap())),
+            "u32" => Ok(Attr::U32(value.parse::<u32>().unwrap())),
+            "i64" => Ok(Attr::I64(value.parse::<i64>().unwrap())),
+            "u64" => Ok(Attr::U64(value.parse::<u64>().unwrap())),
             _ => todo!(),
         }
     }

--- a/core/src/attrs.rs
+++ b/core/src/attrs.rs
@@ -1,4 +1,4 @@
-use crate::Type;
+use crate::{Printable, Type};
 
 macro_rules! impl_from {
     ($case:ident, $from:ty) => {
@@ -43,6 +43,24 @@ pub enum Attr {
     U64Array(Vec<u64>),
     Type(Type),
     TypeArray(Vec<Type>),
+}
+
+impl Printable for Attr {
+    fn print(&self, fmt: &mut dyn crate::IRFormatter) {
+        match self {
+            Attr::String(value) => fmt.write_direct(&format!("<str: {}>", &value)),
+            Attr::Bool(value) => fmt.write_direct(&format!("<bool: {}>", &value)),
+            Attr::I8(value) => fmt.write_direct(&format!("<i8: {}>", &value)),
+            Attr::U8(value) => fmt.write_direct(&format!("<u8: {}>", &value)),
+            Attr::I16(value) => fmt.write_direct(&format!("<i16: {}>", &value)),
+            Attr::U16(value) => fmt.write_direct(&format!("<u16: {}>", &value)),
+            Attr::I32(value) => fmt.write_direct(&format!("<i32: {}>", &value)),
+            Attr::U32(value) => fmt.write_direct(&format!("<u32: {}>", &value)),
+            Attr::I64(value) => fmt.write_direct(&format!("<i64: {}>", &value)),
+            Attr::U64(value) => fmt.write_direct(&format!("<u64: {}>", &value)),
+            _ => todo!(),
+        }
+    }
 }
 
 impl_from!(String, String);

--- a/core/src/attrs.rs
+++ b/core/src/attrs.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    ascii::{alphanumeric0, alphanumeric1, space0},
+    ascii::{alphanumeric1, space0},
     combinator::{delimited, separated_pair},
     Parser,
 };

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -1,5 +1,6 @@
 use crate::builtin::DIALECT_NAME;
 use crate::OpAssembly;
+use crate::Printable;
 use crate::{Op, OpImpl, OpRef, Type};
 use tir_macros::{Op, OpAssembly};
 

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -1,10 +1,11 @@
 use crate::builtin::DIALECT_NAME;
-use crate::{Op, OpImpl, Type};
-use tir_macros::{Assembly, Op};
+use crate::OpAssembly;
+use crate::{Op, OpImpl, OpRef, Type};
+use tir_macros::{Op, OpAssembly};
 
 use crate as tir_core;
 
-#[derive(Op, Assembly)]
+#[derive(Op, OpAssembly)]
 #[operation(name = "const", known_attrs(value: IntegerAttr))]
 pub struct ConstOp {
     #[ret_type]

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -3,6 +3,7 @@ use crate::OpAssembly;
 use crate::Printable;
 use crate::{Op, OpImpl, OpRef, Type};
 use tir_macros::{Op, OpAssembly};
+use winnow::Parser;
 
 use crate as tir_core;
 
@@ -22,6 +23,8 @@ mod test {
     use crate::Attr;
     use crate::Context;
     use crate::OpBuilder;
+    use crate::Printable;
+    use crate::StringPrinter;
 
     use super::*;
 
@@ -43,6 +46,10 @@ mod test {
 
         constant.borrow().get_context();
         module.borrow().get_context();
+
+        let mut printer = StringPrinter::new();
+        constant.borrow().print(&mut printer);
+        panic!("~~ {}", printer.get());
 
         builder.insert(&constant);
         assert_eq!(

--- a/core/src/builtin/func.rs
+++ b/core/src/builtin/func.rs
@@ -1,11 +1,11 @@
 use crate::builtin::DIALECT_NAME;
 use crate::*;
-use tir_macros::Assembly;
 use tir_macros::Op;
+use tir_macros::OpAssembly;
 
 use crate as tir_core;
 
-#[derive(Op, Assembly)]
+#[derive(Op, OpAssembly)]
 #[operation(name = "func", known_attrs(sym_name: String, func_type: Type))]
 pub struct FuncOp {
     #[region]

--- a/core/src/builtin/func.rs
+++ b/core/src/builtin/func.rs
@@ -2,6 +2,7 @@ use crate::builtin::DIALECT_NAME;
 use crate::*;
 use tir_macros::Op;
 use tir_macros::OpAssembly;
+use winnow::Parser;
 
 use crate as tir_core;
 

--- a/core/src/builtin/mod.rs
+++ b/core/src/builtin/mod.rs
@@ -15,6 +15,7 @@ use tir_macros::populate_dialect_types;
 pub use types::*;
 
 use crate::assembly::OpAssembly;
+use crate::assembly::TyAssembly;
 
 dialect!(builtin);
 populate_dialect_ops!(ModuleOp, FuncOp, ConstOp);

--- a/core/src/builtin/mod.rs
+++ b/core/src/builtin/mod.rs
@@ -14,7 +14,7 @@ use tir_macros::populate_dialect_ops;
 use tir_macros::populate_dialect_types;
 pub use types::*;
 
-use crate::assembly::Assembly;
+use crate::assembly::OpAssembly;
 
 dialect!(builtin);
 populate_dialect_ops!(ModuleOp, FuncOp, ConstOp);

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -1,13 +1,12 @@
-use crate::{Attr, ContextRef, Ty, Type};
-
+use crate::{Attr, ContextRef, Ty, TyAssembly, Type};
 use std::collections::HashMap;
-
 use tir_macros::dialect_type;
-
-use crate::builtin::DIALECT_NAME;
 
 use crate as tir_core;
 
+use crate::builtin::DIALECT_NAME;
+
+// FIXME: figure out way to properly print and parse FuncType
 dialect_type!(FuncType);
 dialect_type!(VoidType);
 
@@ -80,7 +79,7 @@ impl VoidType {
 
 #[cfg(test)]
 mod tests {
-    use crate::{builtin::FuncType, Context, Type};
+    use crate::{builtin::FuncType, Context, Printable, StringPrinter, Type};
 
     use super::VoidType;
 
@@ -89,6 +88,9 @@ mod tests {
         let context = Context::new();
 
         let ty = VoidType::build(context.clone());
+        let mut printer = StringPrinter::new();
+        ty.print(&mut printer);
+        assert_eq!("!void", &printer.get());
         let ty: Type = ty.into();
         assert!(ty.isa::<VoidType>());
         assert!(VoidType::try_from(ty.clone()).is_ok());

--- a/core/src/dialect.rs
+++ b/core/src/dialect.rs
@@ -1,10 +1,10 @@
 use crate::parser::{PResult, ParseStream};
-use crate::{Attr, IRFormatter, OpRef, Type};
+use crate::{Attr, IRFormatter, OpRef};
 use std::collections::HashMap;
 
 type ParseFn<T> = fn(&mut ParseStream) -> PResult<T>;
 pub type OpParseFn = ParseFn<OpRef>;
-pub type TyParseFn = ParseFn<Type>;
+pub type TyParseFn = ParseFn<HashMap<String, Attr>>;
 pub type TyPrintFn = fn(&HashMap<String, Attr>, &mut dyn IRFormatter);
 
 pub struct Dialect {
@@ -71,11 +71,15 @@ impl Dialect {
         self.ty_parse_fn.insert(id, parse_fn);
     }
 
-    pub fn get_type_id(&self, name: &'static str) -> u32 {
+    pub fn get_type_id(&self, name: &str) -> u32 {
         *self.type_ids.get(name).unwrap()
     }
 
     pub fn get_type_printer(&self, id: u32) -> Option<TyPrintFn> {
         self.ty_print_fn.get(&id).cloned()
+    }
+
+    pub fn get_type_parser(&self, id: u32) -> Option<TyParseFn> {
+        self.ty_parse_fn.get(&id).cloned()
     }
 }

--- a/core/src/dialect.rs
+++ b/core/src/dialect.rs
@@ -1,7 +1,8 @@
-use crate::{ContextRef, OpRef};
+use crate::parser::{PResult, ParseStream};
+use crate::OpRef;
 use std::collections::HashMap;
 
-pub type ParseFn = fn(ContextRef, &mut &str) -> Result<OpRef, ()>;
+pub type ParseFn = fn(&mut ParseStream) -> PResult<OpRef>;
 
 pub struct Dialect {
     name: &'static str,

--- a/core/src/dialect.rs
+++ b/core/src/dialect.rs
@@ -1,15 +1,20 @@
 use crate::parser::{PResult, ParseStream};
-use crate::OpRef;
+use crate::{Attr, IRFormatter, OpRef, Type};
 use std::collections::HashMap;
 
-pub type ParseFn = fn(&mut ParseStream) -> PResult<OpRef>;
+type ParseFn<T> = fn(&mut ParseStream) -> PResult<T>;
+pub type OpParseFn = ParseFn<OpRef>;
+pub type TyParseFn = ParseFn<Type>;
+pub type TyPrintFn = fn(&HashMap<String, Attr>, &mut dyn IRFormatter);
 
 pub struct Dialect {
     name: &'static str,
     id: u32,
     operation_ids: HashMap<&'static str, u32>,
     type_ids: HashMap<&'static str, u32>,
-    parse_fn: HashMap<u32, ParseFn>,
+    op_parse_fn: HashMap<u32, OpParseFn>,
+    ty_parse_fn: HashMap<u32, TyParseFn>,
+    ty_print_fn: HashMap<u32, TyPrintFn>,
 }
 
 impl Dialect {
@@ -19,7 +24,9 @@ impl Dialect {
             id: 0,
             operation_ids: HashMap::new(),
             type_ids: HashMap::new(),
-            parse_fn: HashMap::new(),
+            op_parse_fn: HashMap::new(),
+            ty_parse_fn: HashMap::new(),
+            ty_print_fn: HashMap::new(),
         }
     }
 
@@ -38,13 +45,13 @@ impl Dialect {
         self.name
     }
 
-    pub fn add_operation(&mut self, name: &'static str, parser: ParseFn) {
+    pub fn add_operation(&mut self, name: &'static str, parser: OpParseFn) {
         if self
             .operation_ids
             .insert(name, self.operation_ids.len().try_into().unwrap())
             .is_none()
         {
-            self.parse_fn
+            self.op_parse_fn
                 .insert((self.operation_ids.len() - 1).try_into().unwrap(), parser);
         }
     }
@@ -53,16 +60,22 @@ impl Dialect {
         self.operation_ids.get(name).cloned()
     }
 
-    pub fn get_operation_parser(&self, id: u32) -> Option<ParseFn> {
-        self.parse_fn.get(&id).cloned()
+    pub fn get_operation_parser(&self, id: u32) -> Option<OpParseFn> {
+        self.op_parse_fn.get(&id).cloned()
     }
 
-    pub fn add_type(&mut self, name: &'static str) {
-        self.type_ids
-            .insert(name, self.type_ids.len().try_into().unwrap());
+    pub fn add_type(&mut self, name: &'static str, print_fn: TyPrintFn, parse_fn: TyParseFn) {
+        let id: u32 = self.type_ids.len().try_into().unwrap();
+        self.type_ids.insert(name, id);
+        self.ty_print_fn.insert(id, print_fn);
+        self.ty_parse_fn.insert(id, parse_fn);
     }
 
     pub fn get_type_id(&self, name: &'static str) -> u32 {
         *self.type_ids.get(name).unwrap()
+    }
+
+    pub fn get_type_printer(&self, id: u32) -> Option<TyPrintFn> {
+        self.ty_print_fn.get(&id).cloned()
     }
 }

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -1,10 +1,12 @@
-use crate::{AllocId, Assembly, Attr, ContextRef, ContextWRef, RegionRef, RegionWRef, Type};
+use crate::{
+    AllocId, Attr, ContextRef, ContextWRef, OpAssembly, Printable, RegionRef, RegionWRef, Type,
+};
 use std::any::Any;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 pub type OpRef = Rc<RefCell<dyn Op>>;
 
-pub trait Op: Any + Assembly {
+pub trait Op: Any + OpAssembly + Printable {
     fn get_operation_name(&self) -> &'static str;
     fn get_attrs(&self) -> &HashMap<String, Attr>;
     fn get_context(&self) -> ContextRef;

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -9,6 +9,7 @@ pub type OpRef = Rc<RefCell<dyn Op>>;
 pub trait Op: Any + OpAssembly + Printable {
     fn get_operation_name(&self) -> &'static str;
     fn get_attrs(&self) -> &HashMap<String, Attr>;
+    fn set_attrs(&mut self, attrs: HashMap<String, Attr>);
     fn get_context(&self) -> ContextRef;
     fn get_parent_region(&self) -> Option<RegionRef>;
     fn get_return_type(&self) -> Option<Type>;

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -9,7 +9,7 @@ pub type OpRef = Rc<RefCell<dyn Op>>;
 pub trait Op: Any + OpAssembly + Printable {
     fn get_operation_name(&self) -> &'static str;
     fn get_attrs(&self) -> &HashMap<String, Attr>;
-    fn set_attrs(&mut self, attrs: HashMap<String, Attr>);
+    fn add_attrs(&mut self, attrs: &HashMap<String, Attr>);
     fn get_context(&self) -> ContextRef;
     fn get_parent_region(&self) -> Option<RegionRef>;
     fn get_return_type(&self) -> Option<Type>;

--- a/core/src/type.rs
+++ b/core/src/type.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use crate::Attr;
 use crate::ContextRef;
 use crate::ContextWRef;
+use crate::Printable;
+use crate::TyAssembly;
 
 #[derive(Debug, Clone)]
 pub struct Type {
@@ -31,7 +33,6 @@ impl Type {
     pub fn get_context(&self) -> Option<ContextRef> {
         self.context.upgrade()
     }
-
     pub fn get_dialect_id(&self) -> u32 {
         self.dialect_id
     }
@@ -55,7 +56,22 @@ impl Type {
     }
 }
 
-pub trait Ty {
+impl Printable for Type {
+    fn print(&self, fmt: &mut dyn crate::IRFormatter) {
+        let context = self.get_context().unwrap();
+        let dialect = context.get_dialect(self.dialect_id).unwrap();
+
+        fmt.write_direct("!");
+        if dialect.get_name() != crate::builtin::DIALECT_NAME {
+            fmt.write_direct(&format!("{}.", dialect.get_name()));
+        }
+
+        let printer = dialect.get_type_printer(self.type_id).unwrap();
+        printer(&self.attrs, fmt);
+    }
+}
+
+pub trait Ty: TyAssembly {
     fn get_type_name() -> &'static str;
     fn get_dialect_name() -> &'static str;
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,10 +1,20 @@
-use std::any::TypeId;
+use std::{any::TypeId, cell::RefCell, rc::Rc};
+
+use crate::{Op, OpRef};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct TraitId(TypeId);
 
 pub fn trait_id<T: ?Sized + 'static>() -> TraitId {
     TraitId(TypeId::of::<T>())
+}
+
+pub fn op_cast<T: Op>(op: OpRef) -> Option<Rc<RefCell<T>>> {
+    if op.borrow().type_id() != TypeId::of::<T>() {
+        return None;
+    }
+
+    Some(unsafe { Rc::from_raw(Rc::into_raw(op) as *const RefCell<T>) })
 }
 
 #[cfg(test)]

--- a/macros/src/assembly.rs
+++ b/macros/src/assembly.rs
@@ -4,13 +4,13 @@ use syn::Ident;
 
 pub fn make_generic_ir_printer_parser(op_name: Ident) -> TokenStream {
     quote! {
-      impl tir_core::Assembly for #op_name {
-          fn print(&self, fmt: &mut dyn tir_core::IRFormatter) {
+      impl tir_core::OpAssembly for #op_name {
+          fn print_assembly(&self, fmt: &mut dyn tir_core::IRFormatter) {
             todo!();
           }
 
-          fn parse<'s>(context: tir_core::ContextRef, input: &mut &'s str) -> std::result::Result<tir_core::OpRef, ()> {
-            Err(())
+          fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::PResult<OpRef> {
+            todo!();
           }
       }
     }

--- a/macros/src/assembly.rs
+++ b/macros/src/assembly.rs
@@ -1,12 +1,54 @@
+use crate::{OpFieldAttrs, OpFieldReceiver, OpReceiver};
+use darling::FromDeriveInput;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Ident;
+use syn::DeriveInput;
 
-pub fn make_generic_ir_printer_parser(op_name: Ident) -> TokenStream {
+fn make_operand_printer(fields: &[OpFieldReceiver]) -> proc_macro2::TokenStream {
+    let mut printers = vec![];
+
+    for f in fields {
+        if let OpFieldAttrs::Operand = f.attrs {
+            let operand_str = format!("{}", f.ident.as_ref().unwrap());
+            let operand = f.ident.as_ref().unwrap();
+            printers.push(quote! {
+                fmt.write_direct(#operand_str);
+                fmt.write_direct(" = ");
+                self.#operand.print(fmt);
+                fmt.write_direct(", ");
+            });
+        }
+    }
+    quote! {
+        #(#printers)*
+    }
+}
+
+pub fn make_generic_ir_printer_parser(op: DeriveInput) -> TokenStream {
+    let op = OpReceiver::from_derive_input(&op).unwrap();
+    let op_name = op.ident;
+
+    let fields = op
+        .data
+        .take_struct()
+        .unwrap()
+        .into_iter()
+        .collect::<Vec<OpFieldReceiver>>();
+
+    let operand_printer = make_operand_printer(&fields);
+
     quote! {
       impl tir_core::OpAssembly for #op_name {
           fn print_assembly(&self, fmt: &mut dyn tir_core::IRFormatter) {
-            todo!();
+            #operand_printer
+
+            fmt.write_direct("attrs = {");
+            for (name, attr) in &self.r#impl.attrs {
+                fmt.write_direct(name);
+                fmt.write_direct(" = ");
+                attr.print(fmt);
+            }
+            fmt.write_direct("}");
           }
 
           fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::PResult<OpRef> {

--- a/macros/src/assembly.rs
+++ b/macros/src/assembly.rs
@@ -24,6 +24,44 @@ fn make_operand_printer(fields: &[OpFieldReceiver]) -> proc_macro2::TokenStream 
     }
 }
 
+fn make_return_type_printer(fields: &[OpFieldReceiver]) -> proc_macro2::TokenStream {
+    for f in fields {
+        if let OpFieldAttrs::Return = f.attrs {
+            let ident = f.ident.as_ref().unwrap();
+            return quote! {
+                fmt.write_direct(" -> ");
+                self.#ident.print(fmt);
+            };
+        }
+    }
+
+    quote! {}
+}
+
+fn make_operand_parser(fields: &[OpFieldReceiver]) -> proc_macro2::TokenStream {
+    let mut parsers = vec![];
+
+    for f in fields {
+        if let OpFieldAttrs::Operand = f.attrs {
+            let operand_str = format!("{}", f.ident.as_ref().unwrap());
+            let operand = f.ident.as_ref().unwrap();
+            let ty = &f.ty;
+            parsers.push(quote! {
+                let (_, value) = winnow::combinator::separated_pair(
+                    #operand_str,
+                    (winnow::ascii::space0, "=", winnow::ascii::space0).recognize(),
+                    #ty::parse
+                ).parse_next(input)?;
+                builder = builder.#operand(value);
+            });
+        }
+    }
+
+    quote! {
+        #(#parsers)*
+    }
+}
+
 pub fn make_generic_ir_printer_parser(op: DeriveInput) -> TokenStream {
     let op = OpReceiver::from_derive_input(&op).unwrap();
     let op_name = op.ident;
@@ -36,6 +74,8 @@ pub fn make_generic_ir_printer_parser(op: DeriveInput) -> TokenStream {
         .collect::<Vec<OpFieldReceiver>>();
 
     let operand_printer = make_operand_printer(&fields);
+    let return_printer = make_return_type_printer(&fields);
+    let operand_parsers = make_operand_parser(&fields);
 
     quote! {
       impl tir_core::OpAssembly for #op_name {
@@ -49,10 +89,20 @@ pub fn make_generic_ir_printer_parser(op: DeriveInput) -> TokenStream {
                 attr.print(fmt);
             }
             fmt.write_direct("}");
+
+            #return_printer
           }
 
           fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::PResult<OpRef> {
-            todo!();
+            let mut builder = Self::builder(&input.state.get_context());
+            #operand_parsers
+
+            let attr_list = tir_core::parser::attr_list.parse_next(input)?;
+
+            let op = builder.build();
+            op.borrow_mut().set_attrs(attr_list);
+
+            Ok(op)
           }
       }
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -72,8 +72,8 @@ pub fn dialect_type(input: TokenStream) -> TokenStream {
                 fmt.write_direct(#name_str);
             }
 
-            fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::PResult<tir_core::Type> {
-                todo!();
+            fn parse_assembly(_input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::PResult<std::collections::HashMap<String, tir_core::Attr>> {
+                Ok(HashMap::new())
             }
         }
 
@@ -450,8 +450,10 @@ pub fn derive_op(input: TokenStream) -> TokenStream {
                 todo!();
             }
 
-            fn set_attrs(&mut self, attrs: std::collections::HashMap<String, tir_core::Attr>) {
-                self.r#impl.attrs = attrs;
+            fn add_attrs(&mut self, attrs: &std::collections::HashMap<String, tir_core::Attr>) {
+                for (k, v) in attrs {
+                    self.r#impl.attrs.insert(k.clone(), v.clone());
+                }
             }
 
             fn get_context(&self) -> tir_core::ContextRef {

--- a/macros/src/op_impl.rs
+++ b/macros/src/op_impl.rs
@@ -1,0 +1,104 @@
+use darling::{FromDeriveInput, FromField, FromMeta};
+use syn::parse::{Parse, ParseStream, Parser};
+use syn::punctuated::Punctuated;
+use syn::Token;
+
+#[derive(Debug)]
+pub struct OpAttrs {
+    pub attrs: Vec<Attr>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct Attr(pub syn::Ident, pub syn::Type);
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attr_name = input.parse::<syn::Ident>()?;
+        input.parse::<Token![:]>()?;
+        let attr_ty = input.parse::<syn::Type>()?;
+
+        Ok(Self(attr_name, attr_ty))
+    }
+}
+
+impl FromMeta for OpAttrs {
+    fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
+        if let syn::Meta::List(list) = item {
+            let parser = Punctuated::<Attr, Token![,]>::parse_separated_nonempty;
+            let tokens = list.tokens.clone();
+            let attrs = parser
+                .parse(tokens.into())?
+                .iter()
+                .cloned()
+                .collect::<Vec<Attr>>();
+
+            return Ok(OpAttrs { attrs });
+        }
+        // I genuinely have no idea what kind of error to put here
+        panic!("expected syn::MetaList");
+    }
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(operation), supports(struct_named))]
+pub struct OpReceiver {
+    pub ident: syn::Ident,
+    pub data: darling::ast::Data<(), OpFieldReceiver>,
+    pub name: String,
+    #[darling(default)]
+    pub known_attrs: Option<OpAttrs>,
+}
+
+#[derive(Default, Debug, FromMeta)]
+pub struct RegionAttrs {
+    #[darling(default)]
+    pub single_block: bool,
+    #[darling(default)]
+    pub no_args: bool,
+}
+
+fn parse_region_attrs(attr: &syn::Attribute) -> Option<RegionAttrs> {
+    if !attr.path().is_ident("region") {
+        return None;
+    }
+
+    if let syn::Meta::Path(_) = &attr.meta {
+        Some(RegionAttrs::default())
+    } else {
+        RegionAttrs::from_meta(&attr.meta).ok()
+    }
+}
+
+#[derive(Debug)]
+pub enum OpFieldAttrs {
+    Region(RegionAttrs),
+    Operand,
+    Return,
+    None,
+}
+
+fn transform_field_attrs(attrs: Vec<syn::Attribute>) -> darling::Result<OpFieldAttrs> {
+    for attr in attrs {
+        if let Some(region) = parse_region_attrs(&attr) {
+            return Ok(OpFieldAttrs::Region(region));
+        }
+        if attr.path().is_ident("ret_type") {
+            return Ok(OpFieldAttrs::Return);
+        }
+        if attr.path().is_ident("operand") {
+            return Ok(OpFieldAttrs::Operand);
+        }
+    }
+
+    Ok(OpFieldAttrs::None)
+}
+
+#[derive(Debug, FromField)]
+#[darling(forward_attrs(region, ret_type, operand))]
+pub struct OpFieldReceiver {
+    pub ident: Option<syn::Ident>,
+    pub ty: syn::Type,
+    #[darling(with = transform_field_attrs)]
+    pub attrs: OpFieldAttrs,
+}


### PR DESCRIPTION
Refactor the printer and parser interfaces. Allow custom assembly for operations and types. Unify errors and inputs across all parsers. Embrace winnow as a parser combinator library. Add a more thorough test for end-to-end parsing.