### PR TITLE
feat: add LIT-style tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,14 +20,22 @@ jobs:
       with:
         components: llvm-tools-preview
     - uses: Swatinem/rust-cache@v2
+    - name: Install cargo-make
+      run: cargo install cargo-make
     - name: Build
       run: cargo build --verbose
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-C instrument-coverage --deny warnings'
         RUSTDOCFLAGS: '-C instrument-coverage'
-    - name: Run tests
+    - name: Run cargo tests
       run: cargo test --verbose
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-C instrument-coverage --deny warnings'
+        RUSTDOCFLAGS: '-C instrument-coverage'
+    - name: Run check tests
+      run: cargo make check-only
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-C instrument-coverage --deny warnings'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,6 +43,15 @@ jobs:
     - name: Install grcov
       run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
     - name: Run grcov
-      run: grcov . --binary-path target/debug/ -s . -t lcov --branch --llvm --ignore '../*' --ignore "/*" --ignore 'macros/*' --ignore 'fuzz/*' --ignore '**/tests/**' -o lcov.info
+      run: |
+        grcov . --binary-path target/debug/ -s . -t lcov --branch --llvm \
+            --ignore '../*' \
+            --ignore "/*" \
+            --ignore 'macros/*' \
+            --ignore 'fuzz/*' \
+            --ignore 'utils/*' \
+            --ignore 'target/**/build/litcheck-filecheck-*/**' \
+            --ignore '**/tests/**' \
+            -o lcov.info
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,6 @@ members = [
     "backends/common",
     "backends/riscv",
     "fuzz",
+    "tools/opt",
+    "utils/check-runner", "utils/filecheck",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,25 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = false
+
+[tasks.build]
+workspace = false
+command = "cargo"
+args = ["build", "${@}"]
+
+[tasks.check-only]
+workspace = false
+command = "cargo"
+args = ["run", "--bin", "check-runner", "${@}"]
+
+[tasks.check]
+workspace = false
+dependencies = ["build", "check-only"]
+
+[tasks.test-only]
+workspace = false
+command = "cargo"
+args = ["test", "${@}"]
+
+[tasks.test]
+workspace = false
+dependencies = ["build", "test-only", "check-only"]

--- a/core/checks/module.tir
+++ b/core/checks/module.tir
@@ -1,0 +1,7 @@
+; RUN: tir-opt %s | filecheck %s
+
+; CHECK: module {
+; CHECK-NEXT: }
+module {
+
+}

--- a/core/checks/test_suite.toml
+++ b/core/checks/test_suite.toml
@@ -1,0 +1,3 @@
+[suite]
+name = "TIR Core LIT checks"
+glob = ["**/*.tir"]

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -68,6 +68,9 @@ fn comment<'s>(input: &mut ParseStream<'s>) -> PResult<()> {
 
 pub fn single_op(input: &mut ParseStream) -> PResult<OpRef> {
     let context = input.state.get_context();
+
+    // TODO: find a smarter way
+    multispace0.parse_next(input)?;
     let (dialect_name, op_name) = preceded(comment, op_tuple).parse_next(input)?;
 
     let dialect = context
@@ -92,7 +95,6 @@ pub fn parse_ir(
         state: ParserState { context },
     };
 
-    // preceded(comment, single_op).parse(input)
     single_op.parse(input)
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@ mod context;
 mod dialect;
 mod error;
 mod operation;
+pub mod opt;
 mod region;
 mod r#type;
 pub mod utils;

--- a/core/src/opt.rs
+++ b/core/src/opt.rs
@@ -1,0 +1,18 @@
+use std::env;
+
+use crate::{parse_ir, Context, StdoutPrinter};
+
+pub fn opt_main() {
+    let args: Vec<String> = env::args().collect();
+
+    let path = &args[1];
+
+    let context = Context::new();
+
+    let ir = std::fs::read_to_string(path).unwrap();
+
+    let module = parse_ir(context.clone(), &ir).unwrap();
+
+    let mut printer = StdoutPrinter::new();
+    module.borrow().print(&mut printer);
+}

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -30,6 +30,19 @@ cargo nextest r
 
 `nextest` is much faster than the default test runner.
 
+### Running check tests
+
+There are also check-tests, which are very similar to LLVM Integrated Tests.
+An easy and quick way to run those is to invoke `cargo run --bin check-runner`.
+However, a more convenient way for day-to-day use is `cargo-make`:
+
+```sh
+cargo install cargo-make
+cargo make check # run build and check tests
+cargo make check-only # only run check whithout re-building TIR
+cargo make test # run build, cargo tests and check
+```
+
 ### Running fuzz tests
 
 We also have fuzzing set up for each user input parser, like a disassembler

--- a/tools/opt/Cargo.toml
+++ b/tools/opt/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tir-opt"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tir-core = {path = "../../core"}

--- a/tools/opt/src/main.rs
+++ b/tools/opt/src/main.rs
@@ -1,0 +1,5 @@
+use tir_core::opt::opt_main;
+
+fn main() {
+    opt_main();
+}

--- a/utils/check-runner/Cargo.toml
+++ b/utils/check-runner/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "check-runner"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+glob = "0.3.1"
+toml = "0.8.12"
+serde = { version = "1.0.201", features = ["derive"] }
+map-ok = "1.0.0"
+regex = "1.10.4"
+shlex = "1.3.0"
+unescaper = "0.1.4"
+descape = "1.1.2"
+

--- a/utils/check-runner/src/main.rs
+++ b/utils/check-runner/src/main.rs
@@ -1,0 +1,138 @@
+use glob::glob;
+use map_ok::MapOk;
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use unescaper::unescape;
+
+#[derive(Debug, Deserialize)]
+struct GlobalConfig {
+    suite: Suite,
+}
+
+#[derive(Debug, Deserialize)]
+struct Suite {
+    name: String,
+    glob: Vec<String>,
+}
+
+fn resolve_path() -> String {
+    let path = env::var("PATH").unwrap().to_string();
+
+    let cur_exe = env::current_exe().unwrap();
+    let target_dir = cur_exe.parent().unwrap().to_str().unwrap();
+
+    format!("{}:{}", target_dir, path)
+}
+
+fn run_command(command: &str, test_path: &PathBuf) -> Result<Output, std::io::Error> {
+    let words = shlex::split(command)
+        .unwrap()
+        .iter()
+        .map(|term| match term.as_str() {
+            "%s" => test_path.to_str().unwrap().to_string(),
+            _ => term.to_string(),
+        })
+        .collect::<Vec<String>>();
+
+    let script = words.join(" ");
+
+    let mut filtered_env: HashMap<String, String> = env::vars()
+        .filter(|&(ref k, _)| k == "TERM" || k == "TZ" || k == "LANG" || k == "LD_LIBRARY_PATH")
+        .collect();
+    filtered_env.insert("PATH".to_string(), resolve_path());
+
+    Command::new("bash")
+        .args(["-c", &script])
+        .env_clear()
+        .envs(&filtered_env)
+        .output()
+}
+
+fn run_test(test: &PathBuf) -> bool {
+    let path_str = test.to_str().unwrap();
+
+    let test_contents = std::fs::read_to_string(&test).expect("Failed to read test file");
+    let lines = test_contents.lines();
+
+    let re = Regex::new(".*RUN:(.*)$").unwrap();
+
+    let run_lines = lines
+        .map(|line| re.captures_iter(line))
+        .flatten()
+        .map(|c| c.get(1).map(|c| c.as_str().trim()))
+        .flatten()
+        .collect::<Vec<&str>>();
+
+    let mut has_failures = false;
+
+    for command in run_lines {
+        print!("test {} ... ", path_str);
+        match run_command(command, test) {
+            Err(_) => {
+                has_failures = true;
+                print!("fail");
+            }
+            Ok(output) => {
+                if output.status.success() {
+                    print!("ok");
+                } else {
+                    has_failures = true;
+                    let stdout = unescape(&String::from_utf8(output.stdout).unwrap()).unwrap();
+                    eprintln!("STDOUT: \n{}", stdout);
+                    let stderr = unescape(&String::from_utf8(output.stderr).unwrap()).unwrap();
+                    eprintln!("STDERR: \n{}", stderr);
+                    print!("fail")
+                }
+            }
+        }
+
+        println!(" : test")
+    }
+
+    has_failures
+}
+
+pub fn main() -> Result<(), String> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+        .map_err(|_| "CARGO_MANIFEST_DIR env var not defined".to_string())?;
+
+    let configs = glob(&format!("{}/../../**/test_suite.toml", manifest_dir))
+        .map_err(|_| "Failed to glob test directories".to_string())?
+        .map_ok(|entry| {
+            let config = std::fs::read_to_string(&entry).expect("Failed to read file");
+            let config: GlobalConfig = toml::from_str(&config).expect("Failed to decode a file");
+
+            (entry.canonicalize().unwrap(), config.suite)
+        })
+        .filter_map(|suite| suite.ok())
+        .collect::<Vec<(PathBuf, Suite)>>();
+
+    let mut has_failures = false;
+    for (path, suite) in configs {
+        eprintln!("Running {}", &suite.name);
+
+        let path = path.parent().unwrap().to_str().unwrap();
+
+        let tests = suite
+            .glob
+            .iter()
+            .map(|pattern| glob(&format!("{}/{}", path, &pattern)).expect("Failed to glob tests"))
+            .flatten()
+            .filter_map(|test| test.ok())
+            .collect::<Vec<_>>();
+
+        for test in tests {
+            has_failures = has_failures | run_test(&test);
+        }
+    }
+
+    if has_failures {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/utils/filecheck/Cargo.toml
+++ b/utils/filecheck/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "filecheck"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+litcheck-filecheck = "0.2.2"
+litcheck-core = "0.2.2"
+clap = { version = "4.5.4", features = ["derive"]}

--- a/utils/filecheck/src/main.rs
+++ b/utils/filecheck/src/main.rs
@@ -1,0 +1,38 @@
+use clap::{CommandFactory, FromArgMatches, Parser};
+use litcheck_core::Input;
+use litcheck_filecheck::Config;
+use litcheck_filecheck::Test;
+
+#[derive(Debug, Parser)]
+#[command(name = "filecheck", arg_required_else_help(true))]
+struct Cli {
+    #[arg(value_name = "CHECK")]
+    pub match_file: Input,
+    #[arg(value_name = "VERIFY", default_value = "-")]
+    pub input_file: Input,
+    #[command(flatten)]
+    pub config: Config,
+}
+
+fn main() {
+    let cmd = Cli::command().mut_arg("allow_empty", |arg| arg.long("allow_empty"));
+    let matches = cmd.get_matches();
+    let args = Cli::from_arg_matches(&matches).unwrap();
+    let match_file = args.match_file.into_source(true).unwrap();
+
+    let mut config = args.config;
+    config.comment_prefixes.sort();
+    config.comment_prefixes.dedup();
+    config.check_prefixes.sort();
+    config.check_prefixes.dedup();
+
+    let input_file = args.input_file.into_source(true).unwrap();
+    let mut test = Test::new(match_file, &config);
+    match test.verify(input_file) {
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("filecheck failed:\n{:?}", err);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
The new "check" tests are a convenient way to test various parts of the compiler stack, similar to LLVM Integrated tests. There're two ways to run check tests:
```sh
cargo build
cargo run --bin check-runner
```

or a more convenient:

```
cargo install cargo-make
cargo make check
```

The syntax of check tests is very similar to what LIT can accept, however, the functionality is currently limited to RUN directive only.

This commit also provides a `filecheck` utility, that is a replica of LLVM's `FileCheck` in both syntax and CLI usage.