### PR TITLE
fix: potential crash during unknown type parsing

### DIFF
--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -102,6 +102,8 @@ pub enum PError {
     UnknownOperation(String, String),
     #[error("expected '{0}'")]
     ExpectedNotFound(String),
+    #[error("unknown type '{0}'")]
+    UnknownType(String),
     #[error("syntax error")]
     Unknown,
 }

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -33,7 +33,8 @@ impl FuncType {
         );
 
         let dialect = context.get_dialect_by_name(DIALECT_NAME).unwrap();
-        let type_id = dialect.get_type_id(FuncType::get_type_name());
+        // we are sure the type exists, because we are the type!
+        let type_id = dialect.get_type_id(FuncType::get_type_name()).unwrap();
         let r#type = Type::new(context.clone(), dialect.get_id(), type_id, attrs);
 
         FuncType { r#type }
@@ -69,7 +70,8 @@ impl FuncType {
 impl VoidType {
     pub fn build(context: ContextRef) -> VoidType {
         let dialect = context.get_dialect_by_name(DIALECT_NAME).unwrap();
-        let type_id = dialect.get_type_id(VoidType::get_type_name());
+        // we are sure the type exists, because we are the type!
+        let type_id = dialect.get_type_id(VoidType::get_type_name()).unwrap();
         let r#type = Type::new(context, dialect.get_id(), type_id, HashMap::new());
 
         VoidType { r#type }
@@ -87,7 +89,8 @@ impl IntType {
         attrs.insert(IntType::get_bits_attr_name().to_string(), Attr::U32(bits));
 
         let dialect = context.get_dialect_by_name(DIALECT_NAME).unwrap();
-        let type_id = dialect.get_type_id(IntType::get_type_name());
+        // we are sure the type exists, because we are the type!
+        let type_id = dialect.get_type_id(IntType::get_type_name()).unwrap();
         let r#type = Type::new(context.clone(), dialect.get_id(), type_id, attrs);
 
         IntType { r#type }

--- a/core/src/dialect.rs
+++ b/core/src/dialect.rs
@@ -57,7 +57,7 @@ impl Dialect {
     }
 
     pub fn get_operation_id(&self, name: &str) -> Option<u32> {
-        self.operation_ids.get(name).cloned()
+        self.operation_ids.get(name).copied()
     }
 
     pub fn get_operation_parser(&self, id: u32) -> Option<OpParseFn> {
@@ -71,8 +71,8 @@ impl Dialect {
         self.ty_parse_fn.insert(id, parse_fn);
     }
 
-    pub fn get_type_id(&self, name: &str) -> u32 {
-        *self.type_ids.get(name).unwrap()
+    pub fn get_type_id(&self, name: &str) -> Option<u32> {
+        self.type_ids.get(name).copied()
     }
 
     pub fn get_type_printer(&self, id: u32) -> Option<TyPrintFn> {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -118,7 +118,8 @@ pub fn dialect_type(input: TokenStream) -> TokenStream {
                 if let Attr::Type(ty) = attr {
                     let context = ty.get_context().ok_or(())?;
                     let dialect = context.get_dialect_by_name(DIALECT_NAME).unwrap();
-                    let type_id = dialect.get_type_id(#name_ident::get_type_name());
+                    // we are sure the type exists, because we are the type!
+                    let type_id = dialect.get_type_id(#name_ident::get_type_name()).unwrap();
                     if type_id != ty.get_type_id() {
                         return Err(());
                     }


### PR DESCRIPTION
Prior to this patch dialect tries to unwrap type id no matter what. If the type in the IR assembly is not registered with the dialect, the entire thing just panics. Wrap the type id into Option and check in the parser if the type really exists.

fixes #49