### PR TITLE
feat: allow for custom type asm

### DIFF
--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -11,6 +11,27 @@ dialect_type!((FuncType, true));
 dialect_type!((VoidType, true));
 dialect_type!((IntType, false));
 
+impl tir_core::TyAssembly for IntType {
+    fn print_assembly(
+        attrs: &HashMap<String, tir_core::Attr>,
+        fmt: &mut dyn tir_core::IRFormatter,
+    ) {
+        fmt.write_direct("int attrs = {");
+        for (name, attr) in attrs {
+            fmt.write_direct(name);
+            fmt.write_direct(" = ");
+            attr.print(fmt);
+        }
+        fmt.write_direct("}");
+    }
+
+    fn parse_assembly(
+        input: &mut tir_core::parser::ParseStream<'_>,
+    ) -> tir_core::parser::AsmPResult<std::collections::HashMap<String, tir_core::Attr>> {
+        tir_core::parser::attr_list(input)
+    }
+}
+
 impl FuncType {
     fn get_inputs_attr_name() -> &'static str {
         "inputs"

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -7,9 +7,9 @@ use crate as tir_core;
 
 use crate::builtin::DIALECT_NAME;
 
-dialect_type!(FuncType);
-dialect_type!(VoidType);
-dialect_type!(IntType);
+dialect_type!((FuncType, true));
+dialect_type!((VoidType, true));
+dialect_type!((IntType, false));
 
 impl FuncType {
     fn get_inputs_attr_name() -> &'static str {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -132,26 +132,23 @@ pub fn dialect_type(input: TokenStream) -> TokenStream {
 
     let extension = if extension_flag {
         quote! {
-        impl tir_core::TyAssembly for #name_ident {
-            fn print_assembly(attrs: &HashMap<String, tir_core::Attr>, fmt: &mut dyn tir_core::IRFormatter) {
-                // FIXME: make attrs optional
-                fmt.write_direct(#name_str);
-                fmt.write_direct(" ");
-                fmt.write_direct("attrs = {");
-                for (name, attr) in attrs {
-                    fmt.write_direct(name);
-                    fmt.write_direct(" = ");
-                    attr.print(fmt);
+            impl tir_core::TyAssembly for #name_ident {
+                fn print_assembly(attrs: &HashMap<String, tir_core::Attr>, fmt: &mut dyn tir_core::IRFormatter) {
+                    fmt.write_direct(#name_str);
+                    fmt.write_direct(" ");
+                    fmt.write_direct("attrs = {");
+                    for (name, attr) in attrs {
+                        fmt.write_direct(name);
+                        fmt.write_direct(" = ");
+                        attr.print(fmt);
+                    }
+                    fmt.write_direct("}");
                 }
-                fmt.write_direct("}");
-            }
 
-            fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::AsmPResult<std::collections::HashMap<String, tir_core::Attr>> {
-                // FIXME: make attrs optional
-                tir_core::parser::attr_list(input)
+                fn parse_assembly(input: &mut tir_core::parser::ParseStream<'_>) -> tir_core::parser::AsmPResult<std::collections::HashMap<String, tir_core::Attr>> {
+                    tir_core::parser::attr_list(input)
+                }
             }
-        }
-
         }
     } else {
         quote!()


### PR DESCRIPTION
Some types, like integer need cusom assembly formats while others do not. To make life easier we allow for two cases - default implementation and user-provided one.