### PR TITLE
feat: add type asm extensions

### DIFF
--- a/core/checks/ops/const.tir
+++ b/core/checks/ops/const.tir
@@ -2,7 +2,7 @@
 
 ; test
 module {
-  func @foo(%arg0: !void attrs = {}) -> !void attrs = {} {
+  func @foo(%arg0: !void) -> !void {
     ^entry:
     const attrs = {value = <i8: 0>} -> !int attrs = {bits = <u32: 8>}
   }

--- a/core/checks/ops/function.tir
+++ b/core/checks/ops/function.tir
@@ -2,11 +2,11 @@
 
 module {
   ; CHECK-LABEL: foo
-  func @foo(%arg0: !void attrs = {}) -> !void attrs = {} {
+  func @foo(%arg0: !void) -> !void {
     ; CHECK: ^entry:
     ^entry:
     ; CHECK-NEXT: const
     ; CHECK-SAME: value = <i8: 0>
-    const attrs = {value = <i8: 0>} -> !void attrs = {}
+    const attrs = {value = <i8: 0>} -> !void
   }
 }

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -182,6 +182,13 @@ where
     delimited(space0, inner, space0)
 }
 
+pub fn skip_attrs(
+    _input: &mut ParseStream<'_>,
+) -> AsmPResult<std::collections::HashMap<String, Attr>> {
+    let res: std::collections::HashMap<String, Attr> = HashMap::new();
+    Ok(res)
+}
+
 fn single_comment(input: &mut ParseStream<'_>) -> AsmPResult<()> {
     (';', take_till(1.., ['\n', '\r']), line_ending)
         .void()

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -53,10 +53,7 @@ mod test {
 
         let mut printer = StringPrinter::new();
         constant.borrow().print(&mut printer);
-        assert_eq!(
-            printer.get(),
-            "const attrs = {value = <i8: 16>} -> !void attrs = {}\n"
-        );
+        assert_eq!(printer.get(), "const attrs = {value = <i8: 16>} -> !void\n");
 
         builder.insert(&constant);
         assert_eq!(
@@ -83,7 +80,7 @@ mod test {
     fn parse_const() {
         let ir = "
         module {
-            const attrs = {value = <i8: 16>} -> !void attrs = {}
+            const attrs = {value = <i8: 16>} -> !void
         }
         ";
 

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -1,15 +1,30 @@
 use crate::Printable;
 use crate::{Attr, ContextRef, Ty, TyAssembly, Type};
 use std::collections::HashMap;
-use tir_macros::dialect_type;
+use tir_macros::{dialect_type, dialect_type_with_extensions};
 
 use crate as tir_core;
 
 use crate::builtin::DIALECT_NAME;
 
-dialect_type!(FuncType);
+dialect_type_with_extensions!(FuncType);
 dialect_type!(VoidType);
-dialect_type!(IntType);
+dialect_type_with_extensions!(IntType);
+
+impl TyAssembly for VoidType {
+    fn print_assembly(
+        _attrs: &HashMap<String, tir_core::Attr>,
+        fmt: &mut dyn tir_core::IRFormatter,
+    ) {
+        fmt.write_direct("void");
+    }
+
+    fn parse_assembly(
+        input: &mut tir_core::parser::ParseStream<'_>,
+    ) -> tir_core::parser::AsmPResult<std::collections::HashMap<String, tir_core::Attr>> {
+        tir_core::parser::skip_attrs(input)
+    }
+}
 
 impl FuncType {
     fn get_inputs_attr_name() -> &'static str {
@@ -123,7 +138,7 @@ mod tests {
         let ty = VoidType::build(context.clone());
         let mut printer = StringPrinter::new();
         ty.print(&mut printer);
-        assert_eq!("!void attrs = {}", &printer.get());
+        assert_eq!("!void", &printer.get());
         let ty: Type = ty.into();
         assert!(ty.isa::<VoidType>());
         assert!(VoidType::try_from(ty.clone()).is_ok());


### PR DESCRIPTION
We need a way to support two different cases:
- default type assembly format, with attribute list
- custom type assembly format, like "void" or "int<n>"