### PR TITLE
feat: proper int type asm format

### DIFF
--- a/core/checks/ops/const.tir
+++ b/core/checks/ops/const.tir
@@ -1,9 +1,10 @@
-; RUN: tir-opt %s
+; RUN: tir-opt %s | filecheck %s
 
 ; test
 module {
   func @foo(%arg0: !void) -> !void {
     ^entry:
-    const attrs = {value = <i8: 0>} -> !int attrs = {bits = <u32: 8>}
+    ; CHECK: !int<8>
+    const attrs = {value = <i8: 0>} -> !int<8>
   }
 }

--- a/core/src/builtin/types.rs
+++ b/core/src/builtin/types.rs
@@ -9,7 +9,7 @@ use crate::builtin::DIALECT_NAME;
 
 dialect_type_with_extensions!(FuncType);
 dialect_type!(VoidType);
-dialect_type_with_extensions!(IntType);
+dialect_type!(IntType);
 
 impl TyAssembly for VoidType {
     fn print_assembly(
@@ -122,6 +122,29 @@ impl IntType {
             Attr::U32(bits) => *bits,
             _ => panic!("Expected 'bits' to be u32"),
         }
+    }
+}
+
+impl TyAssembly for IntType {
+    fn print_assembly(
+        attrs: &HashMap<String, tir_core::Attr>,
+        fmt: &mut dyn tir_core::IRFormatter,
+    ) {
+        fmt.write_direct("int<");
+        if let Some(bits) = attrs.get("bits") {
+            let bits_int: u32 = (bits.clone()).try_into().unwrap();
+            fmt.write_direct(&bits_int.to_string());
+        }
+        fmt.write_direct(">");
+    }
+
+    fn parse_assembly(
+        input: &mut tir_core::parser::ParseStream<'_>,
+    ) -> tir_core::parser::AsmPResult<HashMap<String, Attr>>
+    where
+        Self: Sized,
+    {
+        tir_core::parser::parse_int_bits(input)
     }
 }
 


### PR DESCRIPTION
Replace attributes with custom format like this: "int<8>" instead of "int attrs = {bits: 8}".