### PR TITLE
feat: instruction semantics dialect

### DIFF
--- a/backends/common/checks/isema_ops.tir
+++ b/backends/common/checks/isema_ops.tir
@@ -1,16 +1,16 @@
-; RUN: tir-opt %s | tir-opt -
+; RUN: tir opt %s | tir opt -
 module {
-  isema.add attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.sub attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.and attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.or attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.xor attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.sll attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.srl attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-  isema.sra attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.add attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.sub attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.and attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.or attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.xor attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.sll attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.srl attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+  isema.sra attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
 
   isema.comp_instr {
-    isema.add attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
-    isema.comp_instr_end
+    isema.add attrs = {rs1 = <str: "x0">, rs2 = <str: "x1">, rd = <str: "x2">}
+    isema.comp_instr_end attrs = {}
   }
 }

--- a/backends/common/checks/isema_ops.tir
+++ b/backends/common/checks/isema_ops.tir
@@ -1,0 +1,16 @@
+; RUN: tir-opt %s | tir-opt -
+module {
+  isema.add attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.sub attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.and attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.or attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.xor attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.sll attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.srl attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+  isema.sra attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+
+  isema.comp_instr {
+    isema.add attrs = { rs1 = "x0", rs2 = "x1", rd = "x2" }
+    isema.comp_instr_end
+  }
+}

--- a/backends/common/checks/test_suite.toml
+++ b/backends/common/checks/test_suite.toml
@@ -1,0 +1,4 @@
+[suite]
+name = "TIR common Backend dialects checks"
+glob = ["**/*.tir"]
+

--- a/backends/common/src/isema/mod.rs
+++ b/backends/common/src/isema/mod.rs
@@ -29,5 +29,5 @@ pub use ops::*;
 use tir_macros::{dialect, populate_dialect_ops, populate_dialect_types};
 
 dialect!(isema);
-populate_dialect_ops!(AddOp, SubOp, AndOp, OrOp, SllOp, SrlOp, SraOp);
+populate_dialect_ops!(AddOp, SubOp, AndOp, OrOp, XorOp, SllOp, SrlOp, SraOp, CompInstrOp, CompInstrEndOp);
 populate_dialect_types!();

--- a/backends/common/src/isema/mod.rs
+++ b/backends/common/src/isema/mod.rs
@@ -1,0 +1,33 @@
+//! Instruction semantics modeling dialect
+//!
+//! The `isema` dialect provides a set of low-level utilities to model the behavior of particular
+//! machine instructions. This can be used for a number of applications:
+//! 1. Verify low-level optimizations
+//! 2. Emulate the execution of a piece of assembly code
+//! 3. Search for new optimization patterns
+//!
+//! Note, however, that at the moment the dialect only captures the *semantics* of an instruction, and does not
+//! advertise any architecture-level details, such as register file. Neither it is targeted at
+//! modeling microarchitecture details of a particular platform.
+//!
+//! The general idea of a dialect is that we can model any program as a set of simple operations
+//! that do one of the following things:
+//! 1. Update registers with immediate values
+//! 2. Perform simple arithmetic operations on registers or immediates
+//! 3. Load from and store to memory
+//!
+//! That means, that the semantics of `addi x6, x7, 42` and `vfadd.s v0, v1, v2` are the same and
+//! will be represented by `isema.add` operation, even though nothing is similar about these two
+//! instructions from architecture point of view: data type, vector width, use of an immediate.
+
+use tir_core::Dialect;
+use tir_core::OpAssembly;
+
+mod ops;
+pub use ops::*;
+
+use tir_macros::{dialect, populate_dialect_ops, populate_dialect_types};
+
+dialect!(isema);
+populate_dialect_ops!(AddOp, SubOp, AndOp, OrOp, SllOp, SrlOp, SraOp);
+populate_dialect_types!();

--- a/backends/common/src/isema/ops.rs
+++ b/backends/common/src/isema/ops.rs
@@ -1,0 +1,78 @@
+use tir_core::{
+    parser::{single_block_region, AsmPResult, ParseStream},
+    IRFormatter, Op, OpAssembly, OpImpl, OpRef, Printable, RegionRef,
+};
+use tir_macros::{Op, OpAssembly};
+use winnow::Parser;
+
+use crate::isema::DIALECT_NAME;
+
+/// A compound instruction
+///
+/// Sometimes operations can do multiple things at once. To allow one model complex instructions
+/// and still preserve operation atomicity, introduce a container operation, that can represent
+/// instructions as a combination of simpler operations.
+#[derive(Op, Debug, Clone)]
+#[operation(name = "comp_instr", known_attrs(asm: String))]
+pub struct CompInstrOp {
+    #[region(single_block, no_args)]
+    body: RegionRef,
+    r#impl: OpImpl,
+}
+
+/// Terminator for compound instructions
+#[derive(Op, Debug, Clone, OpAssembly)]
+#[operation(name = "comp_instr_end")]
+pub struct CompInstrEndOp {
+    r#impl: OpImpl,
+}
+
+impl OpAssembly for CompInstrOp {
+    fn parse_assembly(input: &mut ParseStream) -> AsmPResult<OpRef>
+    where
+        Self: Sized,
+    {
+        let ops = single_block_region.parse_next(input)?;
+        let context = input.state.get_context();
+        let module = CompInstrOp::builder(&context).build();
+        for op in ops {
+            module.borrow_mut().get_body().push(&op);
+        }
+        Ok(module)
+    }
+
+    fn print_assembly(&self, fmt: &mut dyn IRFormatter) {
+        fmt.start_region();
+        let body = self.get_body();
+        for op in body.iter() {
+            op.borrow().print(fmt);
+        }
+        fmt.end_region();
+    }
+}
+
+// Three-register operations
+
+macro_rules! three_reg_ops {
+    ($($struct_name:ident => { name = $op_name:literal, doc = $doc:literal })*) => {
+        $(
+            #[doc = $doc]
+            #[derive(Op, Debug, Clone, OpAssembly)]
+            #[operation(name = $op_name, known_attrs(rs1: String, rs2: String, rd: String))]
+            pub struct $struct_name {
+                r#impl: OpImpl,
+            }
+        )*
+    };
+}
+
+three_reg_ops! {
+    AddOp => {name = "add", doc = "Compute rs1 + rs2 and store result to rd"}
+    SubOp => {name = "sub", doc = "Compute rs1 - rs2 and store result to rd"}
+    AndOp => {name = "and", doc = "Compute bitwise rs1 `and` rs2 and store result to rd"}
+    OrOp => {name = "or", doc = "Compute bitwise rs1 `or` rs2 and store result to rd"}
+    XorOp => {name = "xor", doc = "Compute bitwise rs1 `xor` rs2 and store result to rd"}
+    SllOp => {name = "sll", doc = "Compute shift left logical rs1 << rs2 and store result to rd"}
+    SrlOp => {name = "srl", doc = "Compute shift right logical rs1 >> rs2 and store result to rd"}
+    SraOp => {name = "sra", doc = "Compute shift right arithmetic rs1 >> rs2 and store result to rd"}
+}

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -1,6 +1,7 @@
 mod lexer;
 pub mod parser;
 pub mod target;
+pub mod isema;
 mod target_options;
 
 pub use lexer::*;

--- a/core/src/assembly/parser.rs
+++ b/core/src/assembly/parser.rs
@@ -7,7 +7,6 @@ use ariadne::Report;
 use ariadne::ReportKind;
 use thiserror::Error;
 use winnow::ascii::alpha1;
-use winnow::ascii::alphanumeric0;
 use winnow::ascii::line_ending;
 use winnow::ascii::multispace0;
 use winnow::ascii::space0;
@@ -29,7 +28,9 @@ use winnow::error::StrContext;
 use winnow::error::StrContextValue;
 use winnow::stream::Stateful;
 use winnow::stream::Stream;
+use winnow::stream::AsChar;
 use winnow::token::take_till;
+use winnow::token::take_while;
 use winnow::Parser;
 
 use crate::Attr;
@@ -151,7 +152,8 @@ pub fn expected_token(token: &'static str, input: &mut ParseStream<'_>) -> AsmPR
 }
 
 pub fn identifier<'s>(input: &mut ParseStream<'s>) -> AsmPResult<&'s str> {
-    (alpha1, alphanumeric0).recognize().parse_next(input)
+    let ident_sign = take_while(0.., |c: char| c.is_alphanum() || c.as_char() == '_');
+    (alpha1, ident_sign).recognize().parse_next(input)
 }
 
 fn dialect_op<'s>(input: &mut ParseStream<'s>) -> AsmPResult<(&'s str, &'s str)> {

--- a/tools/main.rs
+++ b/tools/main.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: refactor into a separate function available to every downstream crate
     context.add_dialect(tir_riscv::create_dialect());
     context.add_dialect(tir_backend::target::create_dialect());
+    context.add_dialect(tir_backend::isema::create_dialect());
 
     tir_main(context)
 }


### PR DESCRIPTION
The instruction semantics `isema` dialect provides a set of low-level utilities to model the behavior of particular machine instructions. This can be used for a number of applications:
1. Verify low-level optimizations
2. Emulate the execution of a piece of assembly code
3. Search for new optimization patterns