### PR TITLE
fix: allow ops with the same name in different dialects

### DIFF
--- a/backends/common/src/isema/ops.rs
+++ b/backends/common/src/isema/ops.rs
@@ -13,7 +13,7 @@ use crate::isema::DIALECT_NAME;
 /// and still preserve operation atomicity, introduce a container operation, that can represent
 /// instructions as a combination of simpler operations.
 #[derive(Op, Debug, Clone, OpValidator)]
-#[operation(name = "comp_instr", known_attrs(asm: String))]
+#[operation(name = "comp_instr", dialect = isema, known_attrs(asm: String))]
 pub struct CompInstrOp {
     #[region(single_block, no_args)]
     body: RegionRef,
@@ -22,12 +22,12 @@ pub struct CompInstrOp {
 
 /// Terminator for compound instructions
 #[derive(Op, Debug, Clone, OpAssembly, OpValidator)]
-#[operation(name = "comp_instr_end")]
+#[operation(name = "comp_instr_end", dialect = isema)]
 pub struct CompInstrEndOp {
     r#impl: OpImpl,
 }
 
-#[op_implements]
+#[op_implements(dialect = isema)]
 impl Terminator for CompInstrEndOp {}
 
 impl OpAssembly for CompInstrOp {
@@ -61,7 +61,7 @@ macro_rules! three_reg_ops {
         $(
             #[doc = $doc]
             #[derive(Op, Debug, Clone, OpAssembly, OpValidator)]
-            #[operation(name = $op_name, known_attrs(rs1: String, rs2: String, rd: String))]
+            #[operation(name = $op_name, dialect = isema, known_attrs(rs1: String, rs2: String, rd: String))]
             pub struct $struct_name {
                 r#impl: OpImpl,
             }

--- a/backends/common/src/target/ops.rs
+++ b/backends/common/src/target/ops.rs
@@ -10,7 +10,7 @@ use winnow::{
 use crate::target::DIALECT_NAME;
 
 #[derive(Op, Debug, Clone, OpValidator)]
-#[operation(name = "section", known_attrs(name: String))]
+#[operation(name = "section", dialect = target, known_attrs(name: String))]
 pub struct SectionOp {
     #[region]
     body: RegionRef,

--- a/backends/riscv/src/ops/alu.rs
+++ b/backends/riscv/src/ops/alu.rs
@@ -21,7 +21,7 @@ const ALU_OPCODE: u8 = 0b110011;
 macro_rules! alu_op_base {
     ($struct_name:ident, $op_name:literal) => {
         #[derive(Op, OpAssembly, OpValidator)]
-        #[operation(name = $op_name)]
+        #[operation(name = $op_name, dialect = riscv)]
         pub struct $struct_name {
             #[operand]
             rd: Register,

--- a/core/src/builtin/arith.rs
+++ b/core/src/builtin/arith.rs
@@ -10,7 +10,7 @@ use winnow::Parser;
 use crate as tir_core;
 
 #[derive(Op, OpAssembly, Clone, OpValidator)]
-#[operation(name = "const", known_attrs(value: IntegerAttr))]
+#[operation(name = "const", dialect = builtin, known_attrs(value: IntegerAttr))]
 pub struct ConstOp {
     #[ret_type]
     return_type: Type,

--- a/core/src/builtin/func.rs
+++ b/core/src/builtin/func.rs
@@ -13,7 +13,7 @@ use self::parser::identifier;
 use super::FuncType;
 
 #[derive(Op, OpValidator)]
-#[operation(name = "func", known_attrs(sym_name: String, func_type: Type))]
+#[operation(name = "func", dialect = builtin, known_attrs(sym_name: String, func_type: Type))]
 pub struct FuncOp {
     #[region]
     body: RegionRef,
@@ -22,13 +22,13 @@ pub struct FuncOp {
 
 /// Return from a function
 #[derive(Op, OpValidator, OpAssembly)]
-#[operation(name = "return")]
+#[operation(name = "return", dialect = builtin)]
 pub struct ReturnOp {
     // TODO add an optional return value
     r#impl: OpImpl,
 }
 
-#[op_implements]
+#[op_implements(dialect = builtin)]
 impl Terminator for ReturnOp {}
 
 fn single_arg<'s>(input: &mut ParseStream<'s>) -> AsmPResult<(&'s str, Type)> {

--- a/core/src/builtin/module.rs
+++ b/core/src/builtin/module.rs
@@ -7,7 +7,7 @@ use winnow::Parser;
 use crate as tir_core;
 
 #[derive(Op, Debug, OpValidator)]
-#[operation(name = "module")]
+#[operation(name = "module", dialect = builtin)]
 pub struct ModuleOp {
     #[region(single_block, no_args)]
     body: RegionRef,
@@ -15,12 +15,12 @@ pub struct ModuleOp {
 }
 
 #[derive(Op, Debug, OpValidator, OpAssembly)]
-#[operation(name = "module_end")]
+#[operation(name = "module_end", dialect = builtin)]
 pub struct ModuleEndOp {
     r#impl: OpImpl,
 }
 
-#[op_implements]
+#[op_implements(dialect = builtin)]
 impl Terminator for ModuleEndOp {}
 
 impl OpAssembly for ModuleOp {

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -30,14 +30,14 @@ pub fn op_cast<T: Op>(op: OpRef) -> Option<Rc<RefCell<T>>> {
 /// # use tir_core::{Op, OpAssembly, OpRef, OpImpl, Printable};
 /// # use tir_core::builtin::DIALECT_NAME;
 /// # #[derive(Op, Debug, Clone, OpAssembly, OpValidator)]
-/// # #[operation(name = "test")]
+/// # #[operation(name = "test", dialect = test)]
 /// # pub struct TestOp {
 /// #   r#impl: OpImpl,
 /// # }
 /// #
 /// use tir_core::Terminator;
 ///
-/// #[tir_macros::op_implements]
+/// #[tir_macros::op_implements(dialect = test)]
 /// impl Terminator for TestOp {}
 /// ```
 ///

--- a/macros/src/op_impl.rs
+++ b/macros/src/op_impl.rs
@@ -46,6 +46,7 @@ pub struct OpReceiver {
     pub ident: syn::Ident,
     pub data: darling::ast::Data<(), OpFieldReceiver>,
     pub name: String,
+    pub dialect: syn::Ident,
     #[darling(default)]
     pub known_attrs: Option<OpAttrs>,
 }


### PR DESCRIPTION
linkme crate does not allow duplicate names in the application. To
workaround this limitation, ask op developers to also differentiate on
dialect name in op definitions as well as trait implementations. While
being a burden on a dialect developer, this allows multiple ops (like
AddOp) to co-exist in different dialects.