### PR TITLE
fix: error out when trying to parse type from unknown dialect

### DIFF
--- a/core/checks/fuzz/00001.tir
+++ b/core/checks/fuzz/00001.tir
@@ -1,0 +1,5 @@
+; RUN: not tir opt %s 2>&1 | filecheck %s
+
+; CHECK: unknown dialect 'fu'
+
+func@x(%t:!fu.c@\012-\012

--- a/core/src/type.rs
+++ b/core/src/type.rs
@@ -84,7 +84,9 @@ impl Parsable<Type> for Type {
         let (dialect, ty) = preceded("!", op_tuple).parse_next(input)?;
 
         let context = input.state.get_context();
-        let dialect = context.get_dialect_by_name(dialect).unwrap();
+        let dialect = context
+            .get_dialect_by_name(dialect)
+            .ok_or(ErrMode::Cut(PError::UnknownDialect(dialect.to_string())))?;
         let id = dialect
             .get_type_id(ty)
             .ok_or(ErrMode::Cut(PError::UnknownType(ty.to_string())))?;


### PR DESCRIPTION
Instead of just crashing, put a proper diagnostict for the user. Found by the fuzzer: https://github.com/perf-toolbox/tir/actions/runs/9839410300/job/27161432136