### PR TITLE
feat: functional ISA simulator prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ members = [
     "fuzz",
     "utils/check-runner",
     "utils/filecheck",
-    "utils/not", "tools",
+    "utils/not", "tools", "isasim",
 ]

--- a/backends/riscv/src/registers.rs
+++ b/backends/riscv/src/registers.rs
@@ -25,6 +25,18 @@ macro_rules! register {
             }
         }
 
+        impl TryFrom<usize> for Register {
+            type Error = ();
+            fn try_from(value: usize) -> Result<Self, Self::Error> {
+                match value {
+                $(
+                    $num => Ok(Register::$case_name),
+                )*
+                    _ => Err(())
+                }
+            }
+        }
+
         pub fn get_reg_name(reg: &Register) -> &str {
             match reg {
             $(

--- a/backends/riscv/src/registers.rs
+++ b/backends/riscv/src/registers.rs
@@ -41,6 +41,14 @@ macro_rules! register {
             }
         }
 
+        pub fn get_reg_num(reg: &Register) -> usize {
+            match reg {
+            $(
+                Register::$case_name => $num,
+            )*
+            }
+        }
+
         pub fn assemble_reg<T>(reg: T) -> tir_core::Result<u8> where Register: TryFrom<T> {
             let reg = Register::try_from(reg).map_err(|_| tir_core::Error::Unknown)?;
             match reg {

--- a/isasim/Cargo.toml
+++ b/isasim/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 tir-core = { path = "../core" }
 tir-backend = { path = "../backends/common/" }
 tir-riscv = { path = "../backends/riscv/" }
+tir-macros = { path = "../macros/" }
 serde = "1.0.204"
 serde_yml = "0.0.10"
 clap = "4.5.9"
+winnow = "0.6.7"
 
 [[bin]]
 name = "isasim"

--- a/isasim/Cargo.toml
+++ b/isasim/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tir-isasim"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tir-core = { path = "../core" }
+tir-backend = { path = "../backends/common/" }
+tir-riscv = { path = "../backends/riscv/" }
+serde = "1.0.204"
+serde_yml = "0.0.10"
+clap = "4.5.9"
+
+[[bin]]
+name = "isasim"
+path = "src/bin.rs"

--- a/isasim/checks/Inputs/simple_riscv.yaml
+++ b/isasim/checks/Inputs/simple_riscv.yaml
@@ -1,0 +1,3 @@
+register_state:
+  x1: 42
+  x2: 31

--- a/isasim/checks/simple_riscv.s
+++ b/isasim/checks/simple_riscv.s
@@ -1,0 +1,19 @@
+; RUN: isasim --experiment %S/Inputs/simple_riscv.yaml %s | filecheck %s
+
+; CHECK: "x0": 0,
+; CHECK: "x1": 42,
+; CHECK: "x2": 31,
+; CHECK: "x3": 73,
+; CHECK: "x4": 11,
+; CHECK: "x5": 10,
+; CHECK: "x6": 63,
+; CHECK: "x7": 42,
+
+.text
+entry:
+add x0, x0, x0
+add x3, x1, x2
+sub x4, x1, x2
+and x5, x1, x2
+or x6, x1, x2
+add x7, x1, x0

--- a/isasim/checks/test_suite.toml
+++ b/isasim/checks/test_suite.toml
@@ -1,0 +1,4 @@
+[suite]
+name = "TIR ISA Simulator checks"
+glob = ["**/*.s"]
+

--- a/isasim/src/bin.rs
+++ b/isasim/src/bin.rs
@@ -1,0 +1,3 @@
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tir_isasim::sim_main(None, None)
+}

--- a/isasim/src/lib.rs
+++ b/isasim/src/lib.rs
@@ -55,5 +55,7 @@ pub fn sim_main(
     let simulator = Simulator::new(asm);
     simulator.run(&reg_file);
 
+    println!("{}", reg_file.borrow().dump());
+
     Ok(())
 }

--- a/isasim/src/lib.rs
+++ b/isasim/src/lib.rs
@@ -1,7 +1,7 @@
 use clap::{ArgMatches, FromArgMatches, Parser};
 use std::cell::RefCell;
 use std::rc::Rc;
-use tir_core::{Context, ContextRef};
+use tir_core::{builtin::ModuleOp, Context, ContextRef, OpRef, PassManager};
 
 mod options;
 mod regfile;
@@ -42,9 +42,18 @@ pub fn sim_main(
     }
 
     let asm = std::fs::read_to_string(args.input)?;
-    let asm = tir_riscv::parse_asm(&context, &asm).unwrap();
+    let asm: OpRef = tir_riscv::parse_asm(&context, &asm).unwrap();
+
+    let pm = PassManager::new_from_list(&["convert-asm-to-isema"])?;
+    if let Err(e) = pm.run(&asm) {
+        eprintln!("{:?}", e);
+        std::process::exit(0);
+    }
+
+    let asm = tir_core::utils::op_cast::<ModuleOp>(asm).unwrap();
 
     let simulator = Simulator::new(asm);
+    simulator.run(&reg_file);
 
     Ok(())
 }

--- a/isasim/src/lib.rs
+++ b/isasim/src/lib.rs
@@ -1,0 +1,50 @@
+use clap::{ArgMatches, FromArgMatches, Parser};
+use std::cell::RefCell;
+use std::rc::Rc;
+use tir_core::{Context, ContextRef};
+
+mod options;
+mod regfile;
+mod simulator;
+
+pub use options::*;
+pub use regfile::*;
+pub use simulator::*;
+
+pub fn sim_main(
+    context: Option<ContextRef>,
+    args: Option<&ArgMatches>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let args = match args {
+        Some(args) => Cli::from_arg_matches(args),
+        None => Ok(Cli::parse()),
+    }?;
+
+    let context = match context {
+        Some(context) => context,
+        None => {
+            let context = Context::new();
+            // TODO: refactor into a separate function available to every downstream crate
+            context.add_dialect(tir_riscv::create_dialect());
+            context.add_dialect(tir_backend::target::create_dialect());
+            context.add_dialect(tir_backend::isema::create_dialect());
+            context
+        }
+    };
+
+    let config = std::fs::read_to_string(args.experiment)?;
+    let config: Config = serde_yml::from_str(&config)?;
+
+    let reg_file: Rc<RefCell<dyn RegFile>> = RISCVRegFile::new();
+
+    for (name, value) in &config.register_state {
+        reg_file.borrow_mut().write_register(&name, &value.into());
+    }
+
+    let asm = std::fs::read_to_string(args.input)?;
+    let asm = tir_riscv::parse_asm(&context, &asm).unwrap();
+
+    let simulator = Simulator::new(asm);
+
+    Ok(())
+}

--- a/isasim/src/options.rs
+++ b/isasim/src/options.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub register_state: HashMap<String, u64>,
+}
+
+#[derive(Debug, Parser)]
+pub struct Cli {
+    #[arg(short, long)]
+    pub experiment: String,
+    pub input: String,
+}

--- a/isasim/src/regfile.rs
+++ b/isasim/src/regfile.rs
@@ -1,0 +1,39 @@
+use std::{cell::RefCell, rc::Rc};
+
+pub struct Value {
+    value: [u8; 256],
+}
+
+impl From<&u64> for Value {
+    fn from(value: &u64) -> Self {
+        todo!()
+    }
+}
+
+pub trait RegFile {
+    fn read_register(&self, reg_name: &str) -> Value;
+    fn write_register(&self, reg_name: &str, value: &Value);
+}
+
+pub struct RISCVRegFile {
+    registers: Vec<u64>,
+}
+
+impl RISCVRegFile {
+    pub fn new() -> Rc<RefCell<Self>> {
+        let mut registers = vec![];
+        registers.resize(32, 0);
+
+        Rc::new(RefCell::new(Self { registers }))
+    }
+}
+
+impl RegFile for RISCVRegFile {
+    fn read_register(&self, reg_name: &str) -> Value {
+        todo!()
+    }
+
+    fn write_register(&self, reg_name: &str, value: &Value) {
+        todo!()
+    }
+}

--- a/isasim/src/regfile.rs
+++ b/isasim/src/regfile.rs
@@ -1,28 +1,77 @@
 use std::{cell::RefCell, rc::Rc};
+use winnow::Parser;
 
+const MAX_REG_SIZE: usize = 256;
+
+#[derive(Debug, Clone)]
 pub struct Value {
-    value: [u8; 256],
+    data: [u8; MAX_REG_SIZE],
 }
 
-impl From<&u64> for Value {
-    fn from(value: &u64) -> Self {
-        todo!()
+macro_rules! value_from_impl {
+    ($ty:ty, $vty:ty) => {
+        impl From<$ty> for Value {
+            fn from(value: $ty) -> Self {
+                let mut data: [u8; MAX_REG_SIZE] = [0; MAX_REG_SIZE];
+                let value_bytes = value.to_le_bytes();
+                let offset = MAX_REG_SIZE - std::mem::size_of::<$vty>();
+
+                for i in 0..std::mem::size_of::<$vty>() {
+                    data[offset + i] = value_bytes[i];
+                }
+
+                Self { data }
+            }
+        }
+    };
+}
+
+macro_rules! value_from {
+    ($ty:ty) => {
+        value_from_impl!($ty, $ty);
+        value_from_impl!(&$ty, $ty);
+    };
+}
+
+impl Value {
+    pub fn get_lower(&self) -> u32 {
+        u32::from_le_bytes(
+            self.data[MAX_REG_SIZE - 4..MAX_REG_SIZE]
+                .try_into()
+                .unwrap(),
+        )
     }
 }
 
+impl Default for Value {
+    fn default() -> Self {
+        let data = [0; MAX_REG_SIZE];
+        Self { data }
+    }
+}
+
+value_from!(u64);
+value_from!(u32);
+value_from!(u16);
+value_from!(u8);
+value_from!(i64);
+value_from!(i32);
+value_from!(i16);
+value_from!(i8);
+
 pub trait RegFile {
     fn read_register(&self, reg_name: &str) -> Value;
-    fn write_register(&self, reg_name: &str, value: &Value);
+    fn write_register(&mut self, reg_name: &str, value: &Value);
 }
 
 pub struct RISCVRegFile {
-    registers: Vec<u64>,
+    registers: Vec<Value>,
 }
 
 impl RISCVRegFile {
     pub fn new() -> Rc<RefCell<Self>> {
         let mut registers = vec![];
-        registers.resize(32, 0);
+        registers.resize(32, Value::default());
 
         Rc::new(RefCell::new(Self { registers }))
     }
@@ -30,10 +79,18 @@ impl RISCVRegFile {
 
 impl RegFile for RISCVRegFile {
     fn read_register(&self, reg_name: &str) -> Value {
-        todo!()
+        let reg = tir_riscv::register_parser.parse(reg_name).unwrap();
+        self.registers[tir_riscv::get_reg_num(&reg)].clone()
     }
 
-    fn write_register(&self, reg_name: &str, value: &Value) {
-        todo!()
+    fn write_register(&mut self, reg_name: &str, value: &Value) {
+        let reg = tir_riscv::register_parser.parse(reg_name).unwrap();
+
+        // hardwired zero
+        if let tir_riscv::Register::X0 = reg {
+            return;
+        }
+
+        self.registers[tir_riscv::get_reg_num(&reg)] = value.clone();
     }
 }

--- a/isasim/src/simulator.rs
+++ b/isasim/src/simulator.rs
@@ -1,0 +1,20 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use tir_core::builtin::ModuleOp;
+use tir_core::ContextRef;
+
+use crate::RegFile;
+
+pub struct Simulator {
+    module: Rc<RefCell<ModuleOp>>,
+}
+
+impl Simulator {
+    pub fn new(module: Rc<RefCell<ModuleOp>>) -> Self {
+        Simulator { module }
+    }
+
+    pub fn run(&self, reg_file: &Rc<RefCell<dyn RegFile>>) {
+        todo!()
+    }
+}

--- a/isasim/src/simulator.rs
+++ b/isasim/src/simulator.rs
@@ -10,34 +10,47 @@ pub struct Simulator {
     module: Rc<RefCell<ModuleOp>>,
 }
 
-fn exec_add(add: &Rc<RefCell<tir_backend::isema::AddOp>>, reg_file: &Rc<RefCell<dyn RegFile>>) {
-    let rs1: String = add
-        .borrow()
-        .get_rs1_attr()
-        .clone()
-        .try_into()
-        .expect("reg name is a String attr");
-    let rs2: String = add
-        .borrow()
-        .get_rs2_attr()
-        .clone()
-        .try_into()
-        .expect("reg name is a String attr");
-    let rd: String = add
-        .borrow()
-        .get_rd_attr()
-        .clone()
-        .try_into()
-        .expect("reg name is a String attr");
+macro_rules! exec_alu {
+    ($name:ident, $op_ty:ty, $op:tt) => {
+        fn $name(op: &Rc<RefCell<$op_ty>>, reg_file: &Rc<RefCell<dyn RegFile>>) {
+            let rs1: String = op
+                .borrow()
+                .get_rs1_attr()
+                .clone()
+                .try_into()
+                .expect("reg name is a String attr");
+            let rs2: String = op
+                .borrow()
+                .get_rs2_attr()
+                .clone()
+                .try_into()
+                .expect("reg name is a String attr");
+            let rd: String = op
+                .borrow()
+                .get_rd_attr()
+                .clone()
+                .try_into()
+                .expect("reg name is a String attr");
 
-    let a = reg_file.borrow().read_register(&rs1).get_lower();
-    let b = reg_file.borrow().read_register(&rs2).get_lower();
+            let a = reg_file.borrow().read_register(&rs1).get_lower();
+            let b = reg_file.borrow().read_register(&rs2).get_lower();
 
-    let c = a + b;
-    let c = Value::from(c);
+            let c = a $op b;
+            let c = Value::from(c);
 
-    reg_file.borrow_mut().write_register(&rd, &c);
+            reg_file.borrow_mut().write_register(&rd, &c);
+        }
+
+    };
 }
+
+exec_alu!(exec_add, tir_backend::isema::AddOp, +);
+exec_alu!(exec_sub, tir_backend::isema::SubOp, -);
+exec_alu!(exec_and, tir_backend::isema::AndOp, &);
+exec_alu!(exec_or, tir_backend::isema::OrOp, |);
+exec_alu!(exec_xor, tir_backend::isema::XorOp, ^);
+exec_alu!(exec_sll, tir_backend::isema::SllOp, <<);
+exec_alu!(exec_srl, tir_backend::isema::SrlOp, >>);
 
 fn execute_op(op: &OpRef, reg_file: &Rc<RefCell<dyn RegFile>>) {
     use tir_backend::isema::*;
@@ -45,7 +58,12 @@ fn execute_op(op: &OpRef, reg_file: &Rc<RefCell<dyn RegFile>>) {
     let op = op.clone();
     match_op!(op {
         AddOp => |add| exec_add(&add, reg_file),
-        SubOp => |_| println!("Sub!"),
+        SubOp => |sub| exec_sub(&sub, reg_file),
+        AndOp => |and| exec_and(&and, reg_file),
+        OrOp => |or| exec_or(&or, reg_file),
+        XorOp => |xor| exec_xor(&xor, reg_file),
+        SllOp => |sll| exec_sll(&sll, reg_file),
+        SrlOp => |srl| exec_srl(&srl, reg_file),
         _ => || println!("FAIL"),
     });
 }

--- a/isasim/src/simulator.rs
+++ b/isasim/src/simulator.rs
@@ -1,12 +1,53 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use tir_core::builtin::ModuleOp;
-use tir_core::ContextRef;
+use tir_core::OpRef;
+use tir_macros::match_op;
 
-use crate::RegFile;
+use crate::{RegFile, Value};
 
 pub struct Simulator {
     module: Rc<RefCell<ModuleOp>>,
+}
+
+fn exec_add(add: &Rc<RefCell<tir_backend::isema::AddOp>>, reg_file: &Rc<RefCell<dyn RegFile>>) {
+    let rs1: String = add
+        .borrow()
+        .get_rs1_attr()
+        .clone()
+        .try_into()
+        .expect("reg name is a String attr");
+    let rs2: String = add
+        .borrow()
+        .get_rs2_attr()
+        .clone()
+        .try_into()
+        .expect("reg name is a String attr");
+    let rd: String = add
+        .borrow()
+        .get_rd_attr()
+        .clone()
+        .try_into()
+        .expect("reg name is a String attr");
+
+    let a = reg_file.borrow().read_register(&rs1).get_lower();
+    let b = reg_file.borrow().read_register(&rs2).get_lower();
+
+    let c = a + b;
+    let c = Value::from(c);
+
+    reg_file.borrow_mut().write_register(&rd, &c);
+}
+
+fn execute_op(op: &OpRef, reg_file: &Rc<RefCell<dyn RegFile>>) {
+    use tir_backend::isema::*;
+
+    let op = op.clone();
+    match_op!(op {
+        AddOp => |add| exec_add(&add, reg_file),
+        SubOp => |_| println!("Sub!"),
+        _ => || println!("FAIL"),
+    });
 }
 
 impl Simulator {
@@ -15,6 +56,26 @@ impl Simulator {
     }
 
     pub fn run(&self, reg_file: &Rc<RefCell<dyn RegFile>>) {
-        todo!()
+        let iter = self.module.borrow().get_body().iter();
+        for instr in iter {
+            if let Some(section) =
+                tir_core::utils::op_cast::<tir_backend::target::SectionOp>(instr.clone())
+            {
+                let attr = section.borrow().get_name_attr().clone();
+                let name: String = attr.try_into().unwrap();
+                if name != ".text" {
+                    continue;
+                }
+
+                let section_iter = section.borrow().get_body_region().iter();
+                for block in section_iter {
+                    let block_iter = block.iter();
+
+                    for op in block_iter {
+                        execute_op(&op, reg_file);
+                    }
+                }
+            }
+        }
     }
 }

--- a/utils/check-runner/src/main.rs
+++ b/utils/check-runner/src/main.rs
@@ -32,9 +32,14 @@ fn run_command(command: &str, test_path: &PathBuf) -> Result<Output, std::io::Er
     let words = shlex::split(command)
         .unwrap()
         .iter()
-        .map(|term| match term.as_str() {
-            "%s" => test_path.to_str().unwrap().to_string(),
-            _ => term.to_string(),
+        .map(|term| {
+            let term = term.to_string();
+            let term = term.replace("%s", &test_path.to_str().unwrap().to_string());
+            let term = term.replace(
+                "%S",
+                &test_path.parent().unwrap().to_str().unwrap().to_string(),
+            );
+            term
         })
         .collect::<Vec<String>>();
 


### PR DESCRIPTION
Only a few operations are supported for now. The idea is to give users an ability to set an initial point (registers state and allocated memory) and run a functional mini-simulation. This will not be indicative of the code performance, but allows one to observe the side effects of an assembly snippet. The tool can be used for multiple purposes:
1) Learn assembly by running small examples without the need of writing setup boilerplate
2) Study the behavior of an arbitrary piece of assembly
3) Writing functional tests to see if the generated code is equivalent to the original.

Getting cycle accurate performance estimations is not a priority for this kind of simulation and will not be considered in the near future.