### PR TITLE
fix: switch isasim to little endian

### DIFF
--- a/isasim/src/lib.rs
+++ b/isasim/src/lib.rs
@@ -46,18 +46,22 @@ pub fn sim_main(
     }
     if let Some(memory) = config.memory {
         for entry in &memory {
-            let bytes = entry.value.to_be_bytes();
+            let bytes = entry.value.to_le_bytes();
             mem.borrow_mut()
                 .add_region(entry.address, entry.region_size);
             for i in 0..(entry.region_size / entry.value_size as u64) {
                 mem.borrow_mut()
                     .store(
                         entry.address + i * entry.value_size as u64,
-                        &bytes[bytes.len() - entry.value_size as usize..bytes.len()],
+                        &bytes[0..entry.value_size as usize],
                     )
                     .expect("err handling");
             }
         }
+    }
+
+    if args.dump_memory_before {
+        println!("{}", mem.borrow().dump());
     }
 
     let asm = std::fs::read_to_string(args.input)?;
@@ -77,6 +81,10 @@ pub fn sim_main(
     simulator.run(&reg_file, &mem);
 
     println!("{}", reg_file.borrow().dump());
+
+    if args.dump_memory_after {
+        println!("{}", mem.borrow().dump());
+    }
 
     Ok(())
 }

--- a/isasim/src/options.rs
+++ b/isasim/src/options.rs
@@ -22,4 +22,8 @@ pub struct Cli {
     #[arg(short, long)]
     pub experiment: String,
     pub input: String,
+    #[arg(long, default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub dump_memory_before: bool,
+    #[arg(long, default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub dump_memory_after: bool,
 }

--- a/isasim/src/regfile.rs
+++ b/isasim/src/regfile.rs
@@ -13,11 +13,10 @@ macro_rules! value_from_impl {
         impl From<$ty> for Value {
             fn from(value: $ty) -> Self {
                 let mut data: [u8; MAX_REG_SIZE] = [0; MAX_REG_SIZE];
-                let value_bytes = value.to_be_bytes();
-                let offset = MAX_REG_SIZE - std::mem::size_of::<$vty>();
+                let value_bytes = value.to_le_bytes();
 
                 for i in 0..std::mem::size_of::<$vty>() {
-                    data[offset + i] = value_bytes[i];
+                    data[i] = value_bytes[i];
                 }
 
                 Self { data }
@@ -42,10 +41,9 @@ impl TryFrom<Vec<u8>> for Value {
         }
 
         let mut data: [u8; MAX_REG_SIZE] = [0; MAX_REG_SIZE];
-        let offset = MAX_REG_SIZE - value.len();
 
         for i in 0..value.len() {
-            data[offset + i] = value[i];
+            data[i] = value[i];
         }
 
         Ok(Self { data })
@@ -54,11 +52,7 @@ impl TryFrom<Vec<u8>> for Value {
 
 impl Value {
     pub fn get_lower(&self) -> u32 {
-        u32::from_be_bytes(
-            self.data[MAX_REG_SIZE - 4..MAX_REG_SIZE]
-                .try_into()
-                .unwrap(),
-        )
+        u32::from_le_bytes(self.data[0..4].try_into().unwrap())
     }
 
     pub fn raw_bytes(&self, width: usize) -> Result<Vec<u8>, ()> {
@@ -66,7 +60,7 @@ impl Value {
             return Err(());
         }
 
-        Ok(self.data[MAX_REG_SIZE - width..MAX_REG_SIZE].to_vec())
+        Ok(self.data[0..width].to_vec())
     }
 
     pub fn dump(&self) -> String {

--- a/isasim/src/simulator.rs
+++ b/isasim/src/simulator.rs
@@ -76,13 +76,13 @@ fn execute_load(
 
     let sign_extend: bool = op.borrow().get_sign_extend_attr().try_into().expect("");
 
-    let extent: u8 = if sign_extend && data.first().unwrap().bitand(1 << 7) != 0 {
+    let extent: u8 = if sign_extend && data.last().unwrap().bitand(1 << 7) != 0 {
         255
     } else {
         0
     };
     for _ in 0..(reg_file.borrow().base_width() as usize - data.len()) {
-        data.insert(0, extent);
+        data.push(extent);
     }
 
     let reg_value: crate::Value = data.try_into().expect("");


### PR DESCRIPTION
To avoid problems with byte order, switch everything to little endian as it's more convineint for representing memory pages via vectors.