### PR TITLE
feat(lpl): parser tracing

### DIFF
--- a/lpl/Cargo.toml
+++ b/lpl/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0"
+cfg-if = "1.0.0"

--- a/lpl/src/combinators/lang.rs
+++ b/lpl/src/combinators/lang.rs
@@ -12,6 +12,7 @@ where
     reset(literal(comment_start))
         .and_then(take_while(|c| *c != '\n'))
         .map(|(_, c)| c)
+        .label("line_comment")
 }
 
 /// Parses an identifier based on a custom predicate.

--- a/lpl/src/combinators/whitespace.rs
+++ b/lpl/src/combinators/whitespace.rs
@@ -17,14 +17,18 @@ pub fn any_whitespace0<'a, Input>() -> impl Parser<'a, Input, ()>
 where
     Input: ParseStream<'a> + 'a,
 {
-    zero_or_more(any_whitespace()).map(|_| ())
+    zero_or_more(any_whitespace())
+        .map(|_| ())
+        .label("any_wgitespace0")
 }
 
 pub fn any_whitespace1<'a, Input>() -> impl Parser<'a, Input, ()>
 where
     Input: ParseStream<'a> + 'a,
 {
-    one_or_more(any_whitespace()).map(|_| ())
+    one_or_more(any_whitespace())
+        .map(|_| ())
+        .label("any_whitespace1")
 }
 
 pub fn space<'a, Input>() -> impl Parser<'a, Input, char>
@@ -38,14 +42,14 @@ pub fn space0<'a, Input>() -> impl Parser<'a, Input, ()>
 where
     Input: ParseStream<'a> + 'a,
 {
-    zero_or_more(space()).map(|_| ())
+    zero_or_more(space()).map(|_| ()).label("space0")
 }
 
 pub fn space1<'a, Input>() -> impl Parser<'a, Input, ()>
 where
     Input: ParseStream<'a> + 'a,
 {
-    one_or_more(space()).map(|_| ())
+    one_or_more(space()).map(|_| ()).label("space1")
 }
 
 pub fn spaced<'a, P, Input, Output>(parser: P) -> impl Parser<'a, Input, Output>

--- a/lpl/src/debug.rs
+++ b/lpl/src/debug.rs
@@ -1,0 +1,59 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::{BoxedParser, ParseResult, ParseStream, Parser};
+
+static DEPTH_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+pub struct LabelledParser<'a, Input, Output>
+where
+    Input: ParseStream<'a> + 'a,
+{
+    label: &'static str,
+    parser: BoxedParser<'a, Input, Output>,
+}
+
+impl<'a, Input, Output> LabelledParser<'a, Input, Output>
+where
+    Input: ParseStream<'a> + 'a,
+{
+    pub fn new(label: &'static str, parser: BoxedParser<'a, Input, Output>) -> Self {
+        LabelledParser { label, parser }
+    }
+}
+
+impl<'a, Input, Output> Parser<'a, Input, Output> for LabelledParser<'a, Input, Output>
+where
+    Input: ParseStream<'a> + 'a,
+{
+    fn parse(&self, input: Input) -> ParseResult<Input, Output> {
+        let print_info = std::env::var("LPL_TRACE").is_ok();
+        let offset = DEPTH_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        if print_info {
+            eprintln!();
+            for _ in 0..offset {
+                eprint!(" |");
+            }
+            eprint!(" |- {} -> {:?} - '{:?}'", self.label, input.span(), &input);
+        }
+
+        let result = self.parser.parse(input);
+
+        if print_info {
+            eprintln!();
+            for _ in 0..offset {
+                eprint!(" |");
+            }
+
+            if result.is_ok() {
+                eprint!(" |-> ok");
+            } else {
+                eprintln!(" |-> err {:?}", result.as_ref().err().unwrap());
+            }
+        }
+
+        DEPTH_COUNTER.fetch_sub(1, Ordering::SeqCst);
+
+        result
+    }
+}

--- a/lpl/src/parse_stream.rs
+++ b/lpl/src/parse_stream.rs
@@ -1,8 +1,11 @@
-use std::ops::{Range, RangeBounds};
+use std::{
+    fmt,
+    ops::{Range, RangeBounds},
+};
 
 use crate::Span;
 
-pub trait ParseStream<'a>: Clone {
+pub trait ParseStream<'a>: Clone + fmt::Debug {
     type Slice;
     type Extra;
     type Item;
@@ -45,7 +48,7 @@ pub trait ParseStream<'a>: Clone {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct StrStream<'a> {
     string: &'a str,
     offset: usize,
@@ -122,5 +125,11 @@ impl<'a> ParseStream<'a> for StrStream<'a> {
 impl<'a> From<&'a str> for StrStream<'a> {
     fn from(string: &'a str) -> Self {
         StrStream { string, offset: 0 }
+    }
+}
+
+impl<'a> fmt::Debug for StrStream<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:30}", self.string)
     }
 }


### PR DESCRIPTION
Add labelling and tracing system for LPL. To name a parser, use `.label("parser_name")`. To trace the parser, compile application with debug assertion and run it with `LPL_TRACE=1` set.