### PR TITLE
fix: reject invalid assembly tokens

### DIFF
--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -312,6 +312,17 @@ mod tests {
     }
 
     #[test]
+    fn arm64_assembly_parser_rejects_fuzzer_crash_without_panicking() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<Arm64Dialect>();
+        let arm64 = context.find_dialect::<Arm64Dialect>().unwrap();
+        let parser = arm64.get_asm_parser();
+
+        assert!(parser.parse_asm(&context, ".0").is_err());
+    }
+
+    #[test]
     fn arm64_add_lowers_to_arm64_add() {
         let context = Context::with_default_dialects();
         context.register_dialect::<AsmDialect>();

--- a/backends/common/src/lexer.rs
+++ b/backends/common/src/lexer.rs
@@ -39,15 +39,14 @@ pub enum Token<'src> {
 
 #[allow(clippy::result_unit_err)]
 pub fn lex<'src>(source: &'src str) -> Result<Vec<Token<'src>>, ()> {
-    let mut lexer = Token::lexer(source);
+    let lexer = Token::lexer(source);
 
     let mut tokens = vec![];
 
-    while let Some(token) = lexer.next() {
+    for token in lexer {
         match token {
             Ok(token) => tokens.push(token),
-            // FIXME: technically, lexers are not supposed to fail. Need to decide whether to throw an error or just panic.
-            Err(_) => panic!("Error at {:?}", lexer.span()),
+            Err(_) => return Err(()),
         }
     }
 
@@ -73,6 +72,11 @@ impl<'src> tir::parse::tokens::TokenLike<'src> for Token<'src> {
 #[cfg(test)]
 mod tests {
     use crate::lexer::lex;
+
+    #[test]
+    fn asm_rejects_unknown_punctuation_without_panicking() {
+        assert_eq!(lex(".0"), Err(()));
+    }
 
     #[test]
     fn asm_smoke() {


### PR DESCRIPTION
### Motivation
- A fuzzer input (`.0`) caused the assembly lexer to panic, taking down the `arm64` assembly parser; the lexer must reject invalid tokens without panicking.
- Add regression coverage so the fuzz-case cannot regress into a panic again.

### Description
- Change `lex` in `backends/common/src/lexer.rs` to iterate with `for token in lexer` and return `Err(())` on lexer errors instead of `panic!`.
- Add a unit test `asm_rejects_unknown_punctuation_without_panicking` in `backends/common/src/lexer.rs` that asserts `lex(".0") == Err(())`.
- Add a unit test `arm64_assembly_parser_rejects_fuzzer_crash_without_panicking` in `backends/arm64/src/lib.rs` that builds a `Context`/`AsmDialect` and asserts `parser.parse_asm(&context, ".0").is_err()`.
- Addressed a Clippy suggestion by replacing the `while let` iterator loop with a `for` loop in the lexer.

### Testing
- Ran `cargo test -p tir-be-common asm_rejects_unknown_punctuation_without_panicking` and the test passed.
- Ran `cargo test -p arm64 arm64_assembly_parser_rejects_fuzzer_crash_without_panicking` and the test passed.
- Ran `cargo fmt --check` and it passed.
- Ran `cargo clippy -p tir-be-common -p arm64 --all-targets -- -D warnings` and it passed.
- Executed the fuzz binary on the minimized input with `cargo run -p tir-fuzz --bin arm64-assembly-fuzz -- /tmp/arm64-crash -runs=1` and the input executed without crashing (no panic).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2279205f348328b3b65da57e551e9c)