### PR TITLE
fix(fcc): parse nested preprocessor ternaries

### DIFF
--- a/fcc/checks/Inputs/if_nested_ternary.c
+++ b/fcc/checks/Inputs/if_nested_ternary.c
@@ -1,0 +1,5 @@
+#if 0 ? 1 : 1 ? 0 : 1
+int wrong;
+#else
+int right;
+#endif

--- a/fcc/checks/Preprocessor/if_nested_ternary.c
+++ b/fcc/checks/Preprocessor/if_nested_ternary.c
@@ -1,0 +1,5 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage preprocess -o - %S/../Inputs/if_nested_ternary.c | filecheck %s
+
+// CHECK: int right;

--- a/fcc/src/preprocessor.rs
+++ b/fcc/src/preprocessor.rs
@@ -169,11 +169,11 @@ impl<'a> IfExpr<'a> {
         let val = self.or();
         if matches!(self.peek(), Some(PreprocToken::Question)) {
             self.bump();
-            let then = self.or();
+            let then = self.ternary();
             if matches!(self.peek(), Some(PreprocToken::Colon)) {
                 self.bump();
             }
-            let else_ = self.or();
+            let else_ = self.ternary();
             if val != 0 { then } else { else_ }
         } else {
             val


### PR DESCRIPTION
### Motivation
- The preprocessor `#if` expression evaluator did not parse nested `?:` operators correctly, which could leave trailing conditional tokens unconsumed and choose the wrong branch.

### Description
- Change `IfExpr::ternary` to evaluate both `then` and `else` arms recursively using `ternary()` so nested ternary operators are parsed with correct precedence.
- Add a regression input `fcc/checks/Inputs/if_nested_ternary.c` containing a nested ternary that should select the `#else` branch.
- Add the generated FileCheck test `fcc/checks/Preprocessor/if_nested_ternary.c` asserting the expected preprocessor output.

### Testing
- Ran the focused lit test `cargo test -p fcc --test lit if_nested_ternary`, which passed.
- Ran the full `fcc` test suite `cargo test -p fcc`, which passed (27 preprocessor-related lit tests + unit tests reported OK).
- Ran `./utils/scripts/update_checks.py fcc` to generate the FileCheck file, and `cargo fmt --check` and `cargo clippy -p fcc --all-targets -- -D warnings`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22847e73a883288504e74444e26ef1)