### PR TITLE
fix(core): wrap signed APInt division overflow

### DIFF
--- a/core/src/utils/apint.rs
+++ b/core/src/utils/apint.rs
@@ -456,7 +456,7 @@ impl APInt {
         assert_eq!(self.width, other.width, "Widths must match");
         assert!(!other.is_zero(), "Division by zero");
         let mask = Self::mask_for_width(self.width);
-        let result = self.to_i64() / other.to_i64();
+        let result = self.to_i64().wrapping_div(other.to_i64());
         APInt {
             width: self.width,
             signed: true,
@@ -480,7 +480,7 @@ impl APInt {
         assert_eq!(self.width, other.width, "Widths must match");
         assert!(!other.is_zero(), "Division by zero");
         let mask = Self::mask_for_width(self.width);
-        let result = self.to_i64() % other.to_i64();
+        let result = self.to_i64().wrapping_rem(other.to_i64());
         APInt {
             width: self.width,
             signed: true,
@@ -964,6 +964,15 @@ mod tests {
     fn test_arithmetic_shift() {
         let a = APInt::new_signed(8, -16); // 0b11110000
         assert_eq!(a.ashr(2).to_u64(), 0b11111100); // Still negative
+    }
+
+    #[test]
+    fn test_signed_division_overflow_wraps() {
+        let min = APInt::min_value(64, true);
+        let minus_one = APInt::new_signed(64, -1);
+
+        assert_eq!(min.sdiv(&minus_one).to_i64(), i64::MIN);
+        assert_eq!(min.srem(&minus_one).to_i64(), 0);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Signed division of `APInt` could panic on the `i64::MIN / -1` edge because a plain `/` and `%` on `i64` overflow in that case; the intent is two's-complement wrapping semantics rather than a debug panic.

### Description
- Replace `self.to_i64() / other.to_i64()` with `self.to_i64().wrapping_div(other.to_i64())` in `APInt::sdiv` in `core/src/utils/apint.rs`.
- Replace `self.to_i64() % other.to_i64()` with `self.to_i64().wrapping_rem(other.to_i64())` in `APInt::srem` in `core/src/utils/apint.rs`.
- Add regression test `test_signed_division_overflow_wraps` that checks 64-bit signed min divided and rem'd by `-1` yields wrapped results.

### Testing
- Ran the added unit test explicitly with `cargo test -p tir test_signed_division_overflow_wraps -- --nocapture` and it passed.
- Ran the full test suite with `cargo test` (including crate-level and lit tests), `cargo fmt`, and `cargo clippy`, and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2286785a9c8328a15ff2db64609625)