### PR TITLE
fix(lit): avoid `tir-mc` cargo-run race causing flaky lit tests

### DIFF
--- a/backends/arm64/tests/lit.rs
+++ b/backends/arm64/tests/lit.rs
@@ -3,36 +3,9 @@
 //! The tests live with the backend because they exercise ARM64 instruction
 //! selection and register allocation through the `tir-mc` driver.
 
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    let tir_mc = cargo_tir_mc_wrapper();
-    let tir_mc = tir_mc
-        .to_str()
-        .expect("tir-mc wrapper path must be valid UTF-8");
+    let tir_mc = tir_lit::cargo_test_bin("tir-mc", "tir-mc");
+    let tir_mc = tir_mc.to_str().expect("tir-mc path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir-mc", tir_mc)]);
-}
-
-fn cargo_tir_mc_wrapper() -> PathBuf {
-    let mut path = std::env::current_exe().expect("current test executable path");
-    path.pop();
-    path.push("tir-mc-wrapper.sh");
-
-    let mut file = std::fs::File::create(&path).expect("create tir-mc wrapper");
-    writeln!(file, "#!/usr/bin/env bash").expect("write wrapper shebang");
-    writeln!(file, "exec cargo run -q -p tir-mc -- \"$@\"").expect("write wrapper body");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(&path)
-            .expect("wrapper metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions).expect("make wrapper executable");
-    }
-
-    path
 }

--- a/backends/riscv/tests/lit.rs
+++ b/backends/riscv/tests/lit.rs
@@ -3,36 +3,9 @@
 //! The tests live with the backend because they exercise RISC-V instruction
 //! selection and register allocation through the `tir-mc` driver.
 
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    let tir_mc = cargo_tir_mc_wrapper();
-    let tir_mc = tir_mc
-        .to_str()
-        .expect("tir-mc wrapper path must be valid UTF-8");
+    let tir_mc = tir_lit::cargo_test_bin("tir-mc", "tir-mc");
+    let tir_mc = tir_mc.to_str().expect("tir-mc path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir-mc", tir_mc)]);
-}
-
-fn cargo_tir_mc_wrapper() -> PathBuf {
-    let mut path = std::env::current_exe().expect("current test executable path");
-    path.pop();
-    path.push("tir-mc-wrapper.sh");
-
-    let mut file = std::fs::File::create(&path).expect("create tir-mc wrapper");
-    writeln!(file, "#!/usr/bin/env bash").expect("write wrapper shebang");
-    writeln!(file, "exec cargo run -q -p tir-mc -- \"$@\"").expect("write wrapper body");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(&path)
-            .expect("wrapper metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions).expect("make wrapper executable");
-    }
-
-    path
 }

--- a/backends/targets/tests/lit.rs
+++ b/backends/targets/tests/lit.rs
@@ -1,35 +1,8 @@
 //! LIT-style FileCheck tests for target selection through `tir-mc`.
 
-use std::io::Write;
-use std::path::PathBuf;
-
 fn main() {
-    let tir_mc = cargo_tir_mc_wrapper();
-    let tir_mc = tir_mc
-        .to_str()
-        .expect("tir-mc wrapper path must be valid UTF-8");
+    let tir_mc = tir_lit::cargo_test_bin("tir-mc", "tir-mc");
+    let tir_mc = tir_mc.to_str().expect("tir-mc path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir-mc", tir_mc)]);
-}
-
-fn cargo_tir_mc_wrapper() -> PathBuf {
-    let mut path = std::env::current_exe().expect("current test executable path");
-    path.pop();
-    path.push("tir-mc-wrapper.sh");
-
-    let mut file = std::fs::File::create(&path).expect("create tir-mc wrapper");
-    writeln!(file, "#!/usr/bin/env bash").expect("write wrapper shebang");
-    writeln!(file, "exec cargo run -q -p tir-mc -- \"$@\"").expect("write wrapper body");
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut permissions = std::fs::metadata(&path)
-            .expect("wrapper metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions).expect("make wrapper executable");
-    }
-
-    path
 }

--- a/utils/lit/src/lib.rs
+++ b/utils/lit/src/lib.rs
@@ -37,6 +37,48 @@ struct TestCase {
     run_lines: Vec<String>,
 }
 
+/// Build a workspace binary once and copy it beside the current test executable.
+///
+/// Running `cargo run` from every parallel lit test can race with Cargo rewriting
+/// the target binary while another test tries to execute it. Tests should run
+/// this stable copy instead.
+pub fn cargo_test_bin(package: &str, bin: &str) -> PathBuf {
+    let test_exe = std::env::current_exe().expect("current test executable path");
+    let deps_dir = test_exe.parent().expect("test executable directory");
+    let profile_dir = deps_dir.parent().expect("test profile directory");
+    let profile = profile_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("test profile name");
+
+    let mut cargo = Command::new("cargo");
+    cargo.args(["build", "-q", "-p", package]);
+    if profile == "release" {
+        cargo.arg("--release");
+    }
+    let status = cargo.status().expect("spawn cargo build");
+    assert!(
+        status.success(),
+        "cargo build -p {package} failed: {status}"
+    );
+
+    let source = profile_dir.join(bin.to_owned() + std::env::consts::EXE_SUFFIX);
+    let dest = deps_dir.join(format!(
+        "{}-lit-{}{}",
+        bin,
+        std::process::id(),
+        std::env::consts::EXE_SUFFIX
+    ));
+    std::fs::copy(&source, &dest).unwrap_or_else(|e| {
+        panic!(
+            "copy built binary from '{}' to '{}': {e}",
+            source.display(),
+            dest.display()
+        )
+    });
+    dest
+}
+
 /// Collect tests, run them through libtest-mimic and exit the process.
 ///
 /// `manifest_dir` is typically `env!("CARGO_MANIFEST_DIR")`, `checks_subdir`


### PR DESCRIPTION
### Motivation
- Parallel LIT tests were racing with `cargo run` that rebuilt `tir-mc`, causing spurious spawn errors like `Text file busy (os error 26)` when the test harness tried to execute the binary.
- Provide a stable, per-test-execution copy of the built tool so many lit tests can run in parallel without colliding on the same target file.

### Description
- Added `cargo_test_bin(package: &str, bin: &str) -> PathBuf` in `utils/lit/src/lib.rs` that runs a single `cargo build -p <package>` and copies the built binary next to the test executable for stable execution.
- Switched the RISC-V, ARM64 and targets lit test mains (`backends/riscv/tests/lit.rs`, `backends/arm64/tests/lit.rs`, `backends/targets/tests/lit.rs`) to use `tir_lit::cargo_test_bin("tir-mc", "tir-mc")` instead of creating per-test wrapper scripts that invoked `cargo run`.
- Use the built binary path plus `std::env::consts::EXE_SUFFIX` when locating the built executable to be portable across platforms.

### Testing
- Ran `cargo fmt --check` and `git diff --check` which passed with no formatting issues.
- Ran `cargo test -p tir-riscv --test lit -- --exact isel/single-add.tir --nocapture` which passed and reproduced the stable run.
- Ran `cargo test -p tir-riscv --test lit` which ran 5 LIT tests and all passed (`5 passed`).
- Ran `cargo test -p arm64 --test lit` and `cargo test -p tir-targets --test lit` which both completed successfully with their respective lit suites passing.
- Ran `cargo clippy -p tir-lit -p tir-riscv -p arm64 -p tir-targets --tests -- -D warnings` which completed without warnings.
- Ran `cargo test -p tir-lit` which completed successfully for the test crate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2289aab3a88328bd9c5c014cf77c24)