### PR TITLE
fix(core): handle zero arithmetic shift in APInt::ashr

### DIFF
--- a/core/src/utils/apint.rs
+++ b/core/src/utils/apint.rs
@@ -256,6 +256,9 @@ impl APInt {
 
     /// Arithmetic shift right (preserves sign for signed integers)
     pub fn ashr(&self, shift: u32) -> Self {
+        if shift == 0 {
+            return self.clone();
+        }
         if shift >= self.width {
             // Fill with sign bit
             if self.is_negative() {
@@ -964,6 +967,16 @@ mod tests {
     fn test_arithmetic_shift() {
         let a = APInt::new_signed(8, -16); // 0b11110000
         assert_eq!(a.ashr(2).to_u64(), 0b11111100); // Still negative
+    }
+
+    #[test]
+    fn test_arithmetic_shift_64_bit_by_zero() {
+        let a = APInt::new_signed(64, -16);
+        let shifted = a.ashr(0);
+
+        assert_eq!(shifted.width(), 64);
+        assert_eq!(shifted.to_i64(), -16);
+        assert!(shifted.is_signed());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `APInt::ashr(0)` could hit a left-shift-by-`width` when computing sign-extension for negative signed values (e.g. 64-bit), causing an overflow/panic; return the original value for a zero shift to avoid this.

### Description
- Add an early return in `APInt::ashr` to return `self.clone()` when `shift == 0` to avoid invalid left shifts (`core/src/utils/apint.rs`).
- Add a regression test `test_arithmetic_shift_64_bit_by_zero` that checks a signed 64-bit `ashr(0)` preserves width, value, and signedness (`core/src/utils/apint.rs` tests).

### Testing
- Ran `cargo fmt` (ok).
- Ran `cargo test -p tir` and unit test suite (all tests passed; the new test passed as part of the suite).
- Ran `cargo clippy -p tir --all-targets -- -D warnings` (no warnings/failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2296a9e4fc832886914a3e0825c4ba)