### PR TITLE
fix(be-common): lex single-character assembly symbols

### DIFF
--- a/backends/common/src/lexer.rs
+++ b/backends/common/src/lexer.rs
@@ -24,10 +24,10 @@ pub enum Token<'src> {
     #[token(".global")]
     Global,
 
-    #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]+:", |n| { let n = n.slice(); &n[0..n.len() - 1] })]
+    #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]*:", |n| { let n = n.slice(); &n[0..n.len() - 1] })]
     Label(&'src str),
 
-    #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]+", |name| name.slice())]
+    #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]*", |name| name.slice())]
     Ident(&'src str),
 
     #[regex("-?[0-9]+", |num| num.slice())]
@@ -71,11 +71,16 @@ impl<'src> tir::parse::tokens::TokenLike<'src> for Token<'src> {
 
 #[cfg(test)]
 mod tests {
-    use crate::lexer::lex;
+    use crate::lexer::{Token, lex};
 
     #[test]
     fn asm_rejects_unknown_punctuation_without_panicking() {
         assert_eq!(lex(".0"), Err(()));
+    }
+
+    #[test]
+    fn asm_accepts_single_character_identifiers_and_labels() {
+        assert_eq!(lex("a b:"), Ok(vec![Token::Ident("a"), Token::Label("b")]));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The assembly lexer rejected single-character identifiers/labels due to regex requiring at least one trailing identifier character, breaking small-symbol code and tests.

### Description
- Relaxed the identifier/label regexes from `+[…]` to `*[…]` in `backends/common/src/lexer.rs` so one-character `Ident` and `Label` tokens are accepted and added a regression test covering single-character identifiers and labels.

### Testing
- Ran `cargo test -p tir-be-common` and all unit tests passed; ran `cargo clippy -p tir-be-common -- -D warnings` and `cargo build -p tir-be-common`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22992a9a30832897d9917e842b6f73)