### PR TITLE
Add ASM preprocessing with label resolution, extend lexer and RISC-V ECALL instruction

### DIFF
--- a/backends/common/src/lexer.rs
+++ b/backends/common/src/lexer.rs
@@ -24,6 +24,12 @@ pub enum Token<'src> {
     #[token(".global")]
     Global,
 
+    #[regex(r#"\.[a-zA-Z][a-zA-Z0-9_\.]*"#, |directive| directive.slice())]
+    Directive(&'src str),
+
+    #[regex(r#""([^"\\]|\\.)*""#, |string| string.slice())]
+    StringLit(&'src str),
+
     #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]*:", |n| { let n = n.slice(); &n[0..n.len() - 1] })]
     Label(&'src str),
 

--- a/backends/common/src/parser.rs
+++ b/backends/common/src/parser.rs
@@ -16,12 +16,24 @@ pub struct AsmParser {
     /// can name several instruction forms (register vs. immediate), so each key
     /// maps to a list tried in turn with backtracking.
     instruction_parsers: HashMap<String, Vec<AsmInstructionParser>>,
+    preprocessor: Option<fn(&str) -> String>,
 }
 
 impl AsmParser {
     pub fn new(instruction_parsers: HashMap<String, Vec<AsmInstructionParser>>) -> Self {
         AsmParser {
             instruction_parsers,
+            preprocessor: None,
+        }
+    }
+
+    pub fn with_preprocessor(
+        instruction_parsers: HashMap<String, Vec<AsmInstructionParser>>,
+        preprocessor: fn(&str) -> String,
+    ) -> Self {
+        AsmParser {
+            instruction_parsers,
+            preprocessor: Some(preprocessor),
         }
     }
 
@@ -29,6 +41,13 @@ impl AsmParser {
     pub fn parse_asm(&self, context: &tir::Context, src: &str) -> Result<ModuleOp, ()> {
         let module = ModuleOpBuilder::new(context).build();
 
+        let preprocessed;
+        let src = if let Some(preprocessor) = self.preprocessor {
+            preprocessed = preprocessor(src);
+            preprocessed.as_str()
+        } else {
+            src
+        };
         let tokens = lex(src)?;
 
         let mut parser = Parser::new(&tokens);

--- a/backends/riscv/checks/asm/arithmetic-rv64.S
+++ b/backends/riscv/checks/asm/arithmetic-rv64.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
 
     .section .data
 bigval: .dword 0x100000000
@@ -10,3 +10,8 @@ _start64:
     ld   x6, 0(x5)
     addi x7, x6, 42
     sd   x7, 0(x5)
+
+# CHECK:      riscv.addi {rd = x5, rs1 = x0, imm = 0}
+# CHECK-NEXT: riscv.ld {rd = x6, imm = 0, rs1 = x5}
+# CHECK-NEXT: riscv.addi {rd = x7, rs1 = x6, imm = 42}
+# CHECK-NEXT: riscv.sd {rs2 = x7, imm = 0, rs1 = x5}

--- a/backends/riscv/checks/asm/branches-rv32.S
+++ b/backends/riscv/checks/asm/branches-rv32.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
 
     .section .text
     .global _branch_test
@@ -12,3 +12,11 @@ mismatch:
     addi x3, x0, -1
 done:
     nop
+
+# CHECK:      riscv.addi {rd = x1, rs1 = x0, imm = 3}
+# CHECK-NEXT: riscv.addi {rd = x2, rs1 = x0, imm = 3}
+# CHECK-NEXT: riscv.bne {rs1 = x1, rs2 = x2, imm = 12}
+# CHECK-NEXT: riscv.addi {rd = x3, rs1 = x0, imm = 1}
+# CHECK-NEXT: riscv.jal {rd = x0, imm = 8}
+# CHECK-NEXT: riscv.addi {rd = x3, rs1 = x0, imm = -1}
+# CHECK-NEXT: riscv.addi {rd = x0, rs1 = x0, imm = 0}

--- a/backends/riscv/checks/asm/memory_strings-rv32.S
+++ b/backends/riscv/checks/asm/memory_strings-rv32.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
 
     .section .rodata
 msg: .string "Hello, RISC-V!"
@@ -15,3 +15,9 @@ _memtest:
     lw   x3, 0(x1)
     sw   x3, 0(x2)
     nop
+
+# CHECK:      riscv.addi {rd = x1, rs1 = x0, imm = 0}
+# CHECK-NEXT: riscv.addi {rd = x2, rs1 = x0, imm = 16}
+# CHECK-NEXT: riscv.lw {rd = x3, imm = 0, rs1 = x1}
+# CHECK-NEXT: riscv.sw {rs2 = x3, imm = 0, rs1 = x2}
+# CHECK-NEXT: riscv.addi {rd = x0, rs1 = x0, imm = 0}

--- a/backends/riscv/checks/asm/shifts-rv64.S
+++ b/backends/riscv/checks/asm/shifts-rv64.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
 
     .section .text
 shift_test:

--- a/backends/riscv/checks/asm/syscall-rv32.S
+++ b/backends/riscv/checks/asm/syscall-rv32.S
@@ -1,5 +1,4 @@
 # RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
-# XFAIL: *
 
     .section .text
     .global _exit
@@ -10,4 +9,4 @@ _exit:
 
 # CHECK: riscv.addi {rd = x10, rs1 = x0, imm = 0}
 # CHECK-NEXT: riscv.addi {rd = x17, rs1 = x0, imm = 93}
-# CHECK-NEXT: ecall
+# CHECK-NEXT: riscv.ecall

--- a/backends/riscv/defs/base.tmdl
+++ b/backends/riscv/defs/base.tmdl
@@ -61,6 +61,24 @@ instruction JumpAndLinkReg for [RV32I, RV64I] : IType {
     }
 }
 
+instruction EnvironmentCall for [RV32I, RV64I] {
+    param MNEMONIC: String = "ecall";
+
+    operands {
+    }
+
+    encoding {
+        0..31 => 0x00000073,
+    }
+
+    asm {
+        "{self.MNEMONIC}"
+    }
+
+    behavior {
+    }
+}
+
 template BranchOp for [RV32I, RV64I] : BType {
     param OPCODE: bits<7> = 0b1100011;
 }

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -217,6 +217,7 @@ dialect! {
             BranchGeUnsignedOp,
             JumpAndLinkOp,
             JumpAndLinkRegOp,
+            EnvironmentCallOp,
             VirtualReturnOp
         ],
     }
@@ -228,8 +229,210 @@ pub mod ops {
 
 impl RiscvDialect {
     pub fn get_asm_parser(&self) -> tir_be_common::AsmParser {
-        tir_be_common::AsmParser::new(get_instruction_parsers())
+        tir_be_common::AsmParser::with_preprocessor(get_instruction_parsers(), preprocess_asm)
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AsmSection {
+    Text,
+    Data,
+}
+
+fn preprocess_asm(src: &str) -> String {
+    let labels = collect_asm_labels(src);
+    let mut section = AsmSection::Text;
+    let mut text_offset = 0i64;
+    let mut out = String::new();
+
+    for line in src.lines() {
+        let Some((prefix, body)) = split_label(line) else {
+            let rewritten = rewrite_asm_line(line, section, text_offset, &labels);
+            text_offset += text_size(&rewritten, section);
+            update_section(&rewritten, &mut section);
+            out.push_str(&rewritten);
+            out.push('\n');
+            continue;
+        };
+
+        out.push_str(prefix);
+        out.push('\n');
+        let rewritten = rewrite_asm_line(body, section, text_offset, &labels);
+        text_offset += text_size(&rewritten, section);
+        update_section(&rewritten, &mut section);
+        if !rewritten.trim().is_empty() {
+            out.push_str(&rewritten);
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+fn collect_asm_labels(src: &str) -> std::collections::HashMap<String, i64> {
+    let mut labels = std::collections::HashMap::new();
+    let mut section = AsmSection::Text;
+    let mut text_offset = 0i64;
+    let mut data_offset = 0i64;
+
+    for line in src.lines() {
+        let body = if let Some((label, rest)) = split_label(line) {
+            let addr = if section == AsmSection::Text {
+                text_offset
+            } else {
+                data_offset
+            };
+            labels.insert(label.trim_end_matches(':').trim().to_string(), addr);
+            rest
+        } else {
+            line
+        };
+
+        let clean = strip_asm_comment(body).trim();
+        update_section(clean, &mut section);
+        match section {
+            AsmSection::Text => text_offset += text_size(clean, section),
+            AsmSection::Data => data_offset = data_offset_after(clean, data_offset),
+        }
+    }
+
+    labels
+}
+
+fn rewrite_asm_line(
+    line: &str,
+    section: AsmSection,
+    text_offset: i64,
+    labels: &std::collections::HashMap<String, i64>,
+) -> String {
+    if section != AsmSection::Text {
+        return line.to_string();
+    }
+
+    let clean = strip_asm_comment(line);
+    let indent_len = line.len() - line.trim_start().len();
+    let indent = &line[..indent_len];
+    let parts = asm_words(clean);
+    if parts.is_empty() {
+        return line.to_string();
+    }
+
+    match parts[0] {
+        "la" if parts.len() == 3 => {
+            if let Some(addr) = labels.get(parts[2]) {
+                return format!("{indent}addi {}, x0, {addr}", parts[1]);
+            }
+        }
+        "j" if parts.len() == 2 => {
+            if let Some(target) = labels.get(parts[1]) {
+                return format!("{indent}jal x0, {}", target - text_offset);
+            }
+        }
+        "nop" if parts.len() == 1 => return format!("{indent}addi x0, x0, 0"),
+        "beq" | "bne" | "blt" | "bge" | "bltu" | "bgeu" if parts.len() == 4 => {
+            if let Some(target) = labels.get(parts[3]) {
+                return format!(
+                    "{indent}{} {}, {}, {}",
+                    parts[0],
+                    parts[1],
+                    parts[2],
+                    target - text_offset
+                );
+            }
+        }
+        "jal" if parts.len() == 3 => {
+            if let Some(target) = labels.get(parts[2]) {
+                return format!("{indent}jal {}, {}", parts[1], target - text_offset);
+            }
+        }
+        _ => {}
+    }
+
+    line.to_string()
+}
+
+fn split_label(line: &str) -> Option<(&str, &str)> {
+    let clean = strip_asm_comment(line);
+    let colon = clean.find(':')?;
+    let label = &clean[..colon];
+    let trimmed = label.trim();
+    if trimmed.is_empty()
+        || !trimmed
+            .chars()
+            .all(|c| c == '_' || c == '.' || c.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+    Some((&line[..colon + 1], &line[colon + 1..]))
+}
+
+fn strip_asm_comment(line: &str) -> &str {
+    line.split_once('#').map_or(line, |(line, _)| line)
+}
+
+fn asm_words(line: &str) -> Vec<&str> {
+    line.split(|c: char| c == ',' || c.is_ascii_whitespace())
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+fn update_section(line: &str, section: &mut AsmSection) {
+    let clean = strip_asm_comment(line).trim();
+    if clean.starts_with(".text") || clean.starts_with(".section .text") {
+        *section = AsmSection::Text;
+    } else if clean.starts_with(".data")
+        || clean.starts_with(".section .data")
+        || clean.starts_with(".section .rodata")
+        || clean.starts_with(".section .bss")
+    {
+        *section = AsmSection::Data;
+    }
+}
+
+fn text_size(line: &str, section: AsmSection) -> i64 {
+    if section == AsmSection::Text && is_asm_instruction(line) {
+        4
+    } else {
+        0
+    }
+}
+
+fn is_asm_instruction(line: &str) -> bool {
+    let clean = strip_asm_comment(line).trim();
+    !clean.is_empty() && !clean.starts_with('.')
+}
+
+fn data_offset_after(line: &str, offset: i64) -> i64 {
+    let clean = strip_asm_comment(line).trim();
+    let parts = asm_words(clean);
+    match parts.as_slice() {
+        [".dword", ..] => offset + 8,
+        [".word", ..] => offset + 4,
+        [".space", n, ..] => offset + n.parse::<i64>().unwrap_or(0),
+        [".align", n, ..] => {
+            let align = 1i64 << n.parse::<u32>().unwrap_or(0);
+            ((offset + align - 1) / align) * align
+        }
+        [".string", rest @ ..] => {
+            let text = rest.join(" ");
+            offset + string_literal_len(&text).unwrap_or(0) + 1
+        }
+        _ => offset,
+    }
+}
+
+fn string_literal_len(text: &str) -> Option<i64> {
+    let text = text.trim();
+    let text = text.strip_prefix('"')?.strip_suffix('"')?;
+    let mut len = 0;
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            let _ = chars.next();
+        }
+        len += 1;
+    }
+    Some(len)
 }
 
 fn lower_func_and_return_to_asm_symbol(

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -537,8 +537,10 @@ fn emit_instructions<'a>(
 
                 fn execute(
                     &self,
-                    machine: &mut dyn tir_be_common::MachineContext,
+                    _machine: &mut dyn tir_be_common::MachineContext,
                 ) -> Result<(), tir_be_common::SimTrap> {
+                    let machine = _machine;
+                    let _ = &mut *machine;
                     #execute_body
                 }
             }
@@ -616,12 +618,8 @@ fn emit_instructions<'a>(
                             }
                         }
                     }
-                    AsmAction::Skip => {
-                        parse_steps.push(quote! {});
-                    }
-                    AsmAction::SkipMnemonic => {
-                        parse_steps.push(quote! {});
-                    }
+                    AsmAction::Skip => {}
+                    AsmAction::SkipMnemonic => {}
                     AsmAction::LParen => {
                         parse_steps.push(quote! {
                             match parser.bump() {
@@ -642,19 +640,35 @@ fn emit_instructions<'a>(
             }
 
             let parse_fn_ident = format_ident!("parse_{}_inst", &inst.name.to_lowercase());
-            instruction_parsers_impls.push(quote! {
-                fn #parse_fn_ident<'src>(
-                    context: &tir::Context,
-                    builder: &mut tir::IRBuilder,
-                    parser: &mut tir::parse::tokens::Parser<'src, tir_be_common::Token<'src>>,
-                ) -> Result<(), ()> {
-                    let mut op_builder = #builder_ident::new(context);
-                    #(#parse_steps)*
-                    let op = op_builder.build();
-                    builder.insert(op);
-                    Ok(())
+            let parser_impl = if parse_steps.is_empty() {
+                quote! {
+                    fn #parse_fn_ident<'src>(
+                        context: &tir::Context,
+                        builder: &mut tir::IRBuilder,
+                        _parser: &mut tir::parse::tokens::Parser<'src, tir_be_common::Token<'src>>,
+                    ) -> Result<(), ()> {
+                        let op_builder = #builder_ident::new(context);
+                        let op = op_builder.build();
+                        builder.insert(op);
+                        Ok(())
+                    }
                 }
-            });
+            } else {
+                quote! {
+                    fn #parse_fn_ident<'src>(
+                        context: &tir::Context,
+                        builder: &mut tir::IRBuilder,
+                        parser: &mut tir::parse::tokens::Parser<'src, tir_be_common::Token<'src>>,
+                    ) -> Result<(), ()> {
+                        let mut op_builder = #builder_ident::new(context);
+                        #(#parse_steps)*
+                        let op = op_builder.build();
+                        builder.insert(op);
+                        Ok(())
+                    }
+                }
+            };
+            instruction_parsers_impls.push(parser_impl);
 
             if let Some(mn) = mnemonic.as_deref().or(Some(op_name)) {
                 let mn_lit = proc_macro2::Literal::string(mn);


### PR DESCRIPTION
### Motivation

- Enable simple assembly preprocessing to resolve local labels, rewrite pseudo-instructions (e.g. `la`, `j`, `nop`, PC-relative branches) and compute text/data offsets so backend assembly parsing can be simplified and tests can use human-friendly assembly with labels and directives.
- Extend the common lexer to recognize assembler directives and string literals so `.string`/other data directives parse cleanly.
- Add explicit support for the RISC-V `ecall` instruction in the ISA model so generated lowering/emission and filecheck expectations are consistent.

### Description

- Added `Directive(&str)` and `StringLit(&str)` tokens to the assembler `Token` enum in `backends/common/src/lexer.rs` and corresponding regexes for directives and quoted strings.
- Extended `AsmParser` in `backends/common/src/parser.rs` with an optional preprocessor hook and a `with_preprocessor` constructor, and applied the preprocessor from `parse_asm` when present.
- Implemented `preprocess_asm` and helpers in `backends/riscv/src/lib.rs` to collect labels and rewrite assembly lines for the text section (resolving `la`, `j`, `jal`, branch targets, `nop`, and computing data offsets and string lengths) and added `EnvironmentCall` (`ecall`) instruction and `EnvironmentCallOp` wiring into the dialect and `base.tmdl` ISA file.
- Switched the RISC-V dialect to use the new `preprocess_asm` via `get_asm_parser`, and added parsing/rewriting helpers such as `collect_asm_labels`, `rewrite_asm_line`, `split_label`, `strip_asm_comment`, `asm_words`, `update_section`, `text_size`, `is_asm_instruction`, `data_offset_after`, and `string_literal_len`.
- Updated the TMDL Rust generator at `tmdl/src/rustgen.rs` to avoid unused-mut/parser warnings by adjusting parameter names and to emit parser functions that don't reference the `parser` when there are no parse steps, and simplified `AsmAction::Skip`/`SkipMnemonic` handling.
- Updated a number of RISC-V assertion test files under `backends/riscv/checks/asm/` to enable `RUN` lines and add `CHECK` expectations consistent with the rewritten assembly and the added `ecall` handling.

### Testing

- Ran `cargo build` for the workspace and the build succeeded without errors.
- Ran the Rust unit test suite with `cargo test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2321de3f2483288597126c1c225353)