### PR TITLE
fix(fuzz): avoid retaining assembly contexts

### DIFF
--- a/utils/fuzz/fuzz_targets/arm64-assembly.rs
+++ b/utils/fuzz/fuzz_targets/arm64-assembly.rs
@@ -1,13 +1,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::cell::OnceCell;
 
 const MAX_INPUT_LEN: usize = 16 * 1024;
-
-thread_local! {
-    static ARM64_CONTEXT: OnceCell<(tir::Context, tir_be_common::AsmParser)> = const { OnceCell::new() };
-}
 
 fuzz_target!(|data: &[u8]| {
     if data.len() > MAX_INPUT_LEN {
@@ -15,22 +10,16 @@ fuzz_target!(|data: &[u8]| {
     }
 
     if let Ok(input) = std::str::from_utf8(data) {
-        ARM64_CONTEXT.with(|cell| {
-            let (context, parser) = cell.get_or_init(|| {
-                let context = tir::Context::with_default_dialects();
-                context.register_dialect::<tir_be_common::AsmDialect>();
-                context.register_dialect::<arm64::Arm64Dialect>();
+        let context = tir::Context::with_default_dialects();
+        context.register_dialect::<tir_be_common::AsmDialect>();
+        context.register_dialect::<arm64::Arm64Dialect>();
 
-                let arm64 = context.find_dialect::<arm64::Arm64Dialect>().unwrap();
-                let parser = arm64.get_asm_parser();
+        let arm64 = context.find_dialect::<arm64::Arm64Dialect>().unwrap();
+        let parser = arm64.get_asm_parser();
 
-                (context, parser)
-            });
-
-            let Ok(module) = parser.parse_asm(context, input) else {
-                return;
-            };
-            let _ = tir::Operation::verify(&module, context);
-        });
+        let Ok(module) = parser.parse_asm(&context, input) else {
+            return;
+        };
+        let _ = tir::Operation::verify(&module, &context);
     }
 });

--- a/utils/fuzz/fuzz_targets/riscv-assembly.rs
+++ b/utils/fuzz/fuzz_targets/riscv-assembly.rs
@@ -1,13 +1,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::cell::OnceCell;
 
 const MAX_INPUT_LEN: usize = 16 * 1024;
-
-thread_local! {
-    static RISCV_CONTEXT: OnceCell<(tir::Context, tir_be_common::AsmParser)> = const { OnceCell::new() };
-}
 
 fuzz_target!(|data: &[u8]| {
     if data.len() > MAX_INPUT_LEN {
@@ -15,22 +10,16 @@ fuzz_target!(|data: &[u8]| {
     }
 
     if let Ok(input) = std::str::from_utf8(data) {
-        RISCV_CONTEXT.with(|cell| {
-            let (context, parser) = cell.get_or_init(|| {
-                let context = tir::Context::with_default_dialects();
-                context.register_dialect::<tir_be_common::AsmDialect>();
-                context.register_dialect::<tir_riscv::RiscvDialect>();
+        let context = tir::Context::with_default_dialects();
+        context.register_dialect::<tir_be_common::AsmDialect>();
+        context.register_dialect::<tir_riscv::RiscvDialect>();
 
-                let rv = context.find_dialect::<tir_riscv::RiscvDialect>().unwrap();
-                let parser = rv.get_asm_parser();
+        let rv = context.find_dialect::<tir_riscv::RiscvDialect>().unwrap();
+        let parser = rv.get_asm_parser();
 
-                (context, parser)
-            });
-
-            let Ok(module) = parser.parse_asm(context, input) else {
-                return;
-            };
-            let _ = tir::Operation::verify(&module, context);
-        });
+        let Ok(module) = parser.parse_asm(&context, input) else {
+            return;
+        };
+        let _ = tir::Operation::verify(&module, &context);
     }
 });


### PR DESCRIPTION
### Motivation
- Simplify the fuzz targets by removing the thread-local `OnceCell` caching of `(tir::Context, AsmParser)` which introduced extra complexity and potential lifetime/ownership issues.
- Ensure the parser and context are freshly created per input to avoid stale state across fuzz iterations.

### Description
- Remove `std::cell::OnceCell` and the `thread_local!` cached `ARM64_CONTEXT` and `RISCV_CONTEXT` from `utils/fuzz/fuzz_targets/arm64-assembly.rs` and `utils/fuzz/fuzz_targets/riscv-assembly.rs` respectively.
- Create a new `tir::Context` and register the assembly dialects inline for each fuzz invocation instead of reusing a stored instance.
- Adjust calls to `parse_asm` and `tir::Operation::verify` to pass references (`&context`) consistent with the updated local usage.

### Testing
- Built the crate and fuzz targets with `cargo build` which completed successfully.
- Ran the test suite with `cargo test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23216972488328a8c91177bdd33c7d)