### PR TITLE
feat: dynamic pass and target registration via linkme

### DIFF
--- a/backends/arm64/defs/perf.tmdl
+++ b/backends/arm64/defs/perf.tmdl
@@ -10,7 +10,7 @@ unit WriteLoad { latency = 3; }
 
 // Generic in-order core: a single narrow pipeline, hardware-interlocked, paired
 // with the in-order execution model in the Rust simulator.
-machine InOrderCore for [ARMv8A64] {
+machine InOrderCore ("in-order") for [ARMv8A64] {
     issue_width = 1;
 
     buffers {
@@ -37,7 +37,7 @@ machine InOrderCore for [ARMv8A64] {
 
 // Generic out-of-order core: wider issue with a reorder buffer and load/store
 // queue. Same per-instruction latencies; the difference is structural.
-machine OutOfOrderCore for [ARMv8A64] {
+machine OutOfOrderCore ("ooo") for [ARMv8A64] {
     issue_width = 4;
 
     buffers {

--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -268,6 +268,57 @@ pub fn create_regalloc_pass() -> tir_be_common::regalloc::RegisterAllocationPass
     tir_be_common::regalloc::RegisterAllocationPass::new(Box::new(Arm64RegAlloc))
 }
 
+/// The AArch64 (ARMv8-A) target, selected via `--march`/`--mcpu`.
+pub struct Arm64Target {
+    config: TargetConfig,
+}
+
+impl tir_be_common::TargetMachine for Arm64Target {
+    fn name(&self) -> &'static str {
+        self.config.canonical_name()
+    }
+
+    fn register_dialects(&self, context: &tir::Context) {
+        context.register_dialect::<tir_be_common::AsmDialect>();
+        context.register_dialect::<Arm64Dialect>();
+    }
+
+    fn isel_pass(&self, context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
+        create_isel_pass(context)
+    }
+
+    fn regalloc_pass(&self) -> tir_be_common::regalloc::RegisterAllocationPass {
+        create_regalloc_pass()
+    }
+
+    fn register_info(&self) -> tir_be_common::regalloc::RegisterInfo {
+        use tir_be_common::regalloc::TargetRegAlloc;
+        Arm64RegAlloc.register_info()
+    }
+
+    fn asm_parser(&self, context: &tir::Context) -> tir_be_common::AsmParser {
+        context
+            .find_dialect::<Arm64Dialect>()
+            .expect("arm64 dialect must be registered before building an asm parser")
+            .get_asm_parser()
+    }
+
+    fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
+        match name {
+            "in-order" | "inorder" => Some(in_order_core_model()),
+            "ooo" | "out-of-order" => Some(out_of_order_core_model()),
+            _ => None,
+        }
+    }
+}
+
+fn select_arm64(march: &str, mcpu: Option<&str>) -> Option<Box<dyn tir_be_common::TargetMachine>> {
+    let config = TargetConfig::parse(march, mcpu)?;
+    Some(Box::new(Arm64Target { config }))
+}
+
+tir_be_common::register_target!(select_arm64, ["arm64"]);
+
 #[cfg(test)]
 mod tests {
     use tir::{

--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -304,11 +304,7 @@ impl tir_be_common::TargetMachine for Arm64Target {
     }
 
     fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
-        match name {
-            "in-order" | "inorder" => Some(in_order_core_model()),
-            "ooo" | "out-of-order" => Some(out_of_order_core_model()),
-            _ => None,
-        }
+        crate::machine_model(name)
     }
 }
 

--- a/backends/common/Cargo.toml
+++ b/backends/common/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 tir = { path = "../../core" }
+linkme = "0.3"
 logos = "0.15.0"
 
 [dev-dependencies]

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -10,7 +10,11 @@ pub mod sched;
 pub mod target;
 
 pub use operations::*;
-pub use target::TargetMachine;
+pub use target::{TARGETS, TargetInfo, TargetMachine, select_target, supported_targets};
+
+// Re-exported so the `register_target!` macro can reference linkme from the
+// backend crates without each of them depending on it directly.
+pub use linkme;
 
 pub use lexer::Token;
 pub use lexer::lex;

--- a/backends/common/src/target.rs
+++ b/backends/common/src/target.rs
@@ -3,11 +3,11 @@
 //! A [`TargetMachine`] bundles everything a backend exposes behind a single
 //! object: dialect registration, the instruction-selection and register
 //! allocation passes, an assembly parser and the cycle-approximate machine
-//! models. The concrete implementations live in the `tir-targets` crate (which
-//! can depend on the individual backend crates); this trait lives in
-//! `backends/common` so the passes and parser types are in scope without a
-//! dependency cycle.
+//! models. Each backend crate implements this trait and registers itself with
+//! the [`TARGETS`] registry via `register_target!`; the `tir-targets` crate
+//! links the backends and re-exports the registry's lookup helpers.
 
+use linkme::distributed_slice;
 use tir::Context;
 
 use crate::AsmParser;
@@ -49,4 +49,57 @@ pub trait TargetMachine {
     /// A cycle-approximate machine model by name (e.g. `in-order`, `ooo`), or
     /// `None` if this target has no model under that name.
     fn machine_model(&self, name: &str) -> Option<MachineModel>;
+}
+
+/// A target made selectable by `--march`/`--mcpu`.
+///
+/// Backends contribute entries with [`register_target!`]; tools resolve targets
+/// purely through this registry, so adding a backend never requires touching
+/// `tir-mc`, `isasim` or the `tir-targets` aggregator.
+pub struct TargetInfo {
+    /// Canonical names this backend answers to, for help text and diagnostics.
+    pub canonical_names: &'static [&'static str],
+    /// Parse a `--march`/`--mcpu` pair, returning a target if this backend owns it.
+    pub select: SelectFn,
+}
+
+/// Parses a `--march`/`--mcpu` pair into a target, if the backend owns it.
+pub type SelectFn = fn(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>>;
+
+/// Link-time registry of every target reachable in the final binary.
+#[distributed_slice]
+pub static TARGETS: [TargetInfo];
+
+/// Resolve a `--march`/`--mcpu` pair to a target, or `None` if no backend accepts it.
+pub fn select_target(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>> {
+    TARGETS.iter().find_map(|t| (t.select)(march, mcpu))
+}
+
+/// Canonical names accepted by [`select_target`], sorted and de-duplicated.
+pub fn supported_targets() -> Vec<&'static str> {
+    let mut names: Vec<_> = TARGETS
+        .iter()
+        .flat_map(|t| t.canonical_names.iter().copied())
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// Register a target backend so the tools can select it.
+///
+/// `select` is a `fn(&str, Option<&str>) -> Option<Box<dyn TargetMachine>>`;
+/// `names` lists the canonical spellings shown in help and error text.
+#[macro_export]
+macro_rules! register_target {
+    ($select:path, [$($name:expr),+ $(,)?]) => {
+        const _: () = {
+            #[$crate::linkme::distributed_slice($crate::TARGETS)]
+            #[linkme(crate = $crate::linkme)]
+            static REGISTRATION: $crate::TargetInfo = $crate::TargetInfo {
+                canonical_names: &[$($name),+],
+                select: $select,
+            };
+        };
+    };
 }

--- a/backends/riscv/defs/perf.tmdl
+++ b/backends/riscv/defs/perf.tmdl
@@ -11,7 +11,7 @@ unit WriteLoad { latency = 3; }
 // Generic in-order core: a single narrow pipeline with no reorder buffer (just a
 // small store buffer). The Rust simulator pairs this with an in-order execution
 // model.
-machine InOrderCore for [RV64I] {
+machine InOrderCore ("in-order") for [RV64I] {
     issue_width = 1;
 
     buffers {
@@ -45,7 +45,7 @@ machine InOrderCore for [RV64I] {
 // Generic out-of-order core: wider issue plus a reorder buffer, load/store queue,
 // and issue queue. Same per-instruction latencies; the difference is structural
 // (buffer sizes, unit counts) and in the Rust execution model that consumes it.
-machine OutOfOrderCore for [RV64I] {
+machine OutOfOrderCore ("ooo") for [RV64I] {
     issue_width = 4;
 
     buffers {

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -428,11 +428,7 @@ impl tir_be_common::TargetMachine for RiscvTarget {
     }
 
     fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
-        match name {
-            "in-order" | "inorder" => Some(in_order_core_model()),
-            "ooo" | "out-of-order" => Some(out_of_order_core_model()),
-            _ => None,
-        }
+        crate::machine_model(name)
     }
 }
 

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -392,6 +392,57 @@ pub fn create_regalloc_pass() -> tir_be_common::regalloc::RegisterAllocationPass
     tir_be_common::regalloc::RegisterAllocationPass::new(Box::new(RiscvRegAlloc))
 }
 
+/// The RISC-V target, selected via `--march`/`--mcpu`.
+pub struct RiscvTarget {
+    config: TargetConfig,
+}
+
+impl tir_be_common::TargetMachine for RiscvTarget {
+    fn name(&self) -> &'static str {
+        self.config.canonical_name()
+    }
+
+    fn register_dialects(&self, context: &tir::Context) {
+        context.register_dialect::<tir_be_common::AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+    }
+
+    fn isel_pass(&self, context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
+        create_isel_pass(context)
+    }
+
+    fn regalloc_pass(&self) -> tir_be_common::regalloc::RegisterAllocationPass {
+        create_regalloc_pass()
+    }
+
+    fn register_info(&self) -> tir_be_common::regalloc::RegisterInfo {
+        use tir_be_common::regalloc::TargetRegAlloc;
+        RiscvRegAlloc.register_info()
+    }
+
+    fn asm_parser(&self, context: &tir::Context) -> tir_be_common::AsmParser {
+        context
+            .find_dialect::<RiscvDialect>()
+            .expect("riscv dialect must be registered before building an asm parser")
+            .get_asm_parser()
+    }
+
+    fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
+        match name {
+            "in-order" | "inorder" => Some(in_order_core_model()),
+            "ooo" | "out-of-order" => Some(out_of_order_core_model()),
+            _ => None,
+        }
+    }
+}
+
+fn select_riscv(march: &str, mcpu: Option<&str>) -> Option<Box<dyn tir_be_common::TargetMachine>> {
+    let config = TargetConfig::parse(march, mcpu)?;
+    Some(Box::new(RiscvTarget { config }))
+}
+
+tir_be_common::register_target!(select_riscv, ["riscv32", "riscv64"]);
+
 #[cfg(test)]
 mod tests {
     use tir::{

--- a/backends/targets/src/lib.rs
+++ b/backends/targets/src/lib.rs
@@ -1,120 +1,15 @@
-//! Target registry shared by `tir-mc` and `isasim`.
+//! Target aggregator shared by `tir-mc` and `isasim`.
 //!
-//! [`select`] asks each backend to parse the requested `--march`/`--mcpu` pair
-//! and wraps the first backend that accepts it as a concrete [`TargetMachine`].
-//! Backend-specific spelling rules stay in the backend crates instead of being
-//! duplicated in this registry.
+//! Each backend crate registers its own [`TargetMachine`] with the link-time
+//! registry in `tir-be-common` via `register_target!`. This crate exists to
+//! pull those backends into the dependency graph so their registrations are
+//! linked, and to re-export the registry's lookup helpers under stable names.
+//! Adding a backend means depending on its crate here — nothing in the tools
+//! changes.
 
-use tir::Context;
-use tir_be_common::AsmDialect;
-use tir_be_common::AsmParser;
-use tir_be_common::TargetMachine;
-use tir_be_common::isel::InstructionSelectPass;
-use tir_be_common::regalloc::{RegisterAllocationPass, RegisterInfo, TargetRegAlloc};
-use tir_be_common::sched::MachineModel;
+// Force the backend crates to be linked so their `register_target!` entries are
+// included in the final binary; the registry is otherwise the only user.
+use arm64 as _;
+use tir_riscv as _;
 
-use arm64::Arm64Dialect;
-use tir_riscv::RiscvDialect;
-
-/// Resolve a `--march`/`--mcpu` pair to a target, or `None` if no backend accepts it.
-pub fn select(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>> {
-    if let Some(config) = tir_riscv::TargetConfig::parse(march, mcpu) {
-        return Some(Box::new(RiscvTarget { config }));
-    }
-
-    if let Some(config) = arm64::TargetConfig::parse(march, mcpu) {
-        return Some(Box::new(Arm64Target { config }));
-    }
-
-    None
-}
-
-/// Names accepted by [`select`], one canonical spelling per target family, for
-/// help text and error messages.
-pub const SUPPORTED_TARGETS: &[&str] = &["riscv32", "riscv64", "arm64"];
-
-/// The RISC-V target.
-pub struct RiscvTarget {
-    config: tir_riscv::TargetConfig,
-}
-
-impl TargetMachine for RiscvTarget {
-    fn name(&self) -> &'static str {
-        self.config.canonical_name()
-    }
-
-    fn register_dialects(&self, context: &Context) {
-        context.register_dialect::<AsmDialect>();
-        context.register_dialect::<RiscvDialect>();
-    }
-
-    fn isel_pass(&self, context: &Context) -> InstructionSelectPass {
-        tir_riscv::create_isel_pass(context)
-    }
-
-    fn regalloc_pass(&self) -> RegisterAllocationPass {
-        tir_riscv::create_regalloc_pass()
-    }
-
-    fn register_info(&self) -> RegisterInfo {
-        tir_riscv::RiscvRegAlloc.register_info()
-    }
-
-    fn asm_parser(&self, context: &Context) -> AsmParser {
-        context
-            .find_dialect::<RiscvDialect>()
-            .expect("riscv dialect must be registered before building an asm parser")
-            .get_asm_parser()
-    }
-
-    fn machine_model(&self, name: &str) -> Option<MachineModel> {
-        match name {
-            "in-order" | "inorder" => Some(tir_riscv::in_order_core_model()),
-            "ooo" | "out-of-order" => Some(tir_riscv::out_of_order_core_model()),
-            _ => None,
-        }
-    }
-}
-
-/// The AArch64 (ARMv8-A) target.
-pub struct Arm64Target {
-    config: arm64::TargetConfig,
-}
-
-impl TargetMachine for Arm64Target {
-    fn name(&self) -> &'static str {
-        self.config.canonical_name()
-    }
-
-    fn register_dialects(&self, context: &Context) {
-        context.register_dialect::<AsmDialect>();
-        context.register_dialect::<Arm64Dialect>();
-    }
-
-    fn isel_pass(&self, context: &Context) -> InstructionSelectPass {
-        arm64::create_isel_pass(context)
-    }
-
-    fn regalloc_pass(&self) -> RegisterAllocationPass {
-        arm64::create_regalloc_pass()
-    }
-
-    fn register_info(&self) -> RegisterInfo {
-        arm64::Arm64RegAlloc.register_info()
-    }
-
-    fn asm_parser(&self, context: &Context) -> AsmParser {
-        context
-            .find_dialect::<Arm64Dialect>()
-            .expect("arm64 dialect must be registered before building an asm parser")
-            .get_asm_parser()
-    }
-
-    fn machine_model(&self, name: &str) -> Option<MachineModel> {
-        match name {
-            "in-order" | "inorder" => Some(arm64::in_order_core_model()),
-            "ooo" | "out-of-order" => Some(arm64::out_of_order_core_model()),
-            _ => None,
-        }
-    }
-}
+pub use tir_be_common::{select_target as select, supported_targets};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 tir-macros = { path = "../utils/macros" }
+linkme = "0.3"
 parking_lot = "0.12.3"
 thiserror = "2.0.12"
 ariadne = "0.3"

--- a/core/checks/Mem2Reg/basic.tir
+++ b/core/checks/Mem2Reg/basic.tir
@@ -1,4 +1,6 @@
 // RUN: tir opt --pass mem2reg %s | filecheck %s
+// RUN: tir opt --pass builtin.func(mem2reg) %s | filecheck %s
+// RUN: not tir opt --pass builtin.func(nope) %s
 
 module {
   func @f(%0: !i32, %1: !i32) -> !i32 {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,9 @@
 extern crate self as tir;
 
+// Re-exported so the `register_pass!` macro can reference linkme from
+// downstream crates without each of them depending on it directly.
+pub use linkme;
+
 pub mod attributes;
 mod block;
 mod builder;
@@ -43,7 +47,10 @@ pub use operation::{
     OpInterfaceConverter, Operation, Verifiable, downcast_op_interface, erase_op_interface,
     op_interface_converter,
 };
-pub use pass::{OperationRef, Pass, PassError, PassManager, PassTarget, Rewriter};
+pub use pass::{
+    OperationRef, PASSES, Pass, PassError, PassInfo, PassManager, PassTarget, Rewriter, build_pass,
+    parse_pipeline, registered_passes,
+};
 pub use region::{Region, RegionId};
 pub use ty::{Any, Type, TypeConstraint, TypeId, TypeParser};
 pub use value::{Use, UseSite, Value, ValueId};

--- a/core/src/pass.rs
+++ b/core/src/pass.rs
@@ -1,6 +1,136 @@
 use std::sync::Arc;
 
+use linkme::distributed_slice;
+
 use crate::{Block, Context, OpId, OpInstance, Operation};
+
+/// A pass made available to the pipeline parser by name.
+///
+/// Backends and libraries contribute entries with [`register_pass!`]; the opt
+/// tool builds pipelines purely from this registry, so adding a pass never
+/// requires touching the tool.
+pub struct PassInfo {
+    pub name: &'static str,
+    pub ctor: fn() -> Box<dyn Pass>,
+}
+
+/// Link-time registry of every pass reachable in the final binary.
+#[distributed_slice]
+pub static PASSES: [PassInfo];
+
+/// Construct a registered pass by name, or `None` if no pass owns that name.
+pub fn build_pass(name: &str) -> Option<Box<dyn Pass>> {
+    PASSES.iter().find(|p| p.name == name).map(|p| (p.ctor)())
+}
+
+/// Names of all registered passes, for help text and diagnostics.
+pub fn registered_passes() -> Vec<&'static str> {
+    let mut names: Vec<_> = PASSES.iter().map(|p| p.name).collect();
+    names.sort_unstable();
+    names
+}
+
+/// Register a pass under `name` so the pipeline parser can build it.
+///
+/// `ty` must implement [`Pass`] and expose a `new() -> Self` constructor.
+#[macro_export]
+macro_rules! register_pass {
+    ($ty:ty, $name:expr) => {
+        const _: () = {
+            #[$crate::linkme::distributed_slice($crate::PASSES)]
+            #[linkme(crate = $crate::linkme)]
+            static REGISTRATION: $crate::PassInfo = $crate::PassInfo {
+                name: $name,
+                ctor: || ::std::boxed::Box::new(<$ty>::new()),
+            };
+        };
+    };
+}
+
+/// Parse an MLIR-style pass pipeline into a [`PassManager`].
+///
+/// The grammar is a comma-separated list of elements, where each element is
+/// either a registered pass name or an op-nesting `op(inner-pipeline)`. The op
+/// name may be dialect-qualified (`builtin.func`) or bare (`func`). Example:
+/// `builtin.func(mem2reg)` runs `mem2reg` nested inside every function.
+pub fn parse_pipeline(spec: &str) -> Result<PassManager, String> {
+    let mut parser = PipelineParser {
+        bytes: spec.as_bytes(),
+        pos: 0,
+    };
+    let mut pm = PassManager::new();
+    parser.parse_list(&mut pm)?;
+    parser.skip_ws();
+    if parser.pos != parser.bytes.len() {
+        return Err(format!(
+            "unexpected '{}' in pass pipeline",
+            &spec[parser.pos..]
+        ));
+    }
+    Ok(pm)
+}
+
+struct PipelineParser<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl PipelineParser<'_> {
+    fn skip_ws(&mut self) {
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn parse_ident(&mut self) -> Result<String, String> {
+        let start = self.pos;
+        while self.pos < self.bytes.len() {
+            let c = self.bytes[self.pos];
+            if c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos == start {
+            return Err("expected a pass or op name".to_string());
+        }
+        Ok(String::from_utf8_lossy(&self.bytes[start..self.pos]).into_owned())
+    }
+
+    fn parse_list(&mut self, pm: &mut PassManager) -> Result<(), String> {
+        loop {
+            self.parse_element(pm)?;
+            self.skip_ws();
+            if self.pos < self.bytes.len() && self.bytes[self.pos] == b',' {
+                self.pos += 1;
+                continue;
+            }
+            return Ok(());
+        }
+    }
+
+    fn parse_element(&mut self, pm: &mut PassManager) -> Result<(), String> {
+        self.skip_ws();
+        let name = self.parse_ident()?;
+        self.skip_ws();
+        if self.pos < self.bytes.len() && self.bytes[self.pos] == b'(' {
+            self.pos += 1;
+            let nested = pm.nest(name);
+            self.parse_list(nested)?;
+            self.skip_ws();
+            if self.pos >= self.bytes.len() || self.bytes[self.pos] != b')' {
+                return Err("missing ')' in pass pipeline".to_string());
+            }
+            self.pos += 1;
+            Ok(())
+        } else {
+            let pass = build_pass(&name).ok_or_else(|| format!("unknown pass '{name}'"))?;
+            pm.add_boxed_pass(pass);
+            Ok(())
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum PassError {
@@ -165,10 +295,19 @@ impl Rewriter {
     }
 }
 
+/// Match an op against a nesting spec that is either a bare op name (`func`)
+/// or a dialect-qualified name (`builtin.func`).
+fn matches_op_name(op: &OpInstance, spec: &str) -> bool {
+    match spec.split_once('.') {
+        Some((dialect, name)) => op.dialect == dialect && op.name == name,
+        None => op.name == spec,
+    }
+}
+
 enum PassNode {
     Pass(Box<dyn Pass>),
     Nested {
-        op_name: &'static str,
+        op_name: String,
         manager: PassManager,
     },
 }
@@ -183,13 +322,19 @@ impl PassManager {
     }
 
     pub fn add_pass<P: Pass + 'static>(&mut self, pass: P) -> &mut Self {
-        self.passes.push(PassNode::Pass(Box::new(pass)));
+        self.add_boxed_pass(Box::new(pass))
+    }
+
+    pub fn add_boxed_pass(&mut self, pass: Box<dyn Pass>) -> &mut Self {
+        self.passes.push(PassNode::Pass(pass));
         self
     }
 
-    pub fn nest(&mut self, op_name: &'static str) -> &mut PassManager {
+    /// Nest a sub-pipeline under every op matching `op_name`. The name may be
+    /// dialect-qualified (`builtin.func`) or bare (`func`).
+    pub fn nest(&mut self, op_name: impl Into<String>) -> &mut PassManager {
         self.passes.push(PassNode::Nested {
-            op_name,
+            op_name: op_name.into(),
             manager: PassManager::new(),
         });
         match self.passes.last_mut() {
@@ -234,7 +379,7 @@ impl PassManager {
             }),
             PassNode::Nested { op_name, manager } => {
                 PassManager::walk_ops(context, root, &mut |op_ref| {
-                    if op_ref.name() == *op_name {
+                    if matches_op_name(op_ref.op(), op_name) {
                         manager.run_on_op_ref(context, op_ref.clone())?;
                     }
                     Ok(())
@@ -416,5 +561,40 @@ mod tests {
             !context.has_operation(neg_id),
             "erased op should leave the arena"
         );
+    }
+
+    #[test]
+    fn pipeline_parses_bare_and_nested() {
+        use super::{PassNode, parse_pipeline};
+
+        let pm = parse_pipeline("mem2reg").expect("bare pass should parse");
+        assert!(matches!(pm.passes.as_slice(), [PassNode::Pass(_)]));
+
+        let pm = parse_pipeline(" builtin.func( mem2reg ) ").expect("nested should parse");
+        match pm.passes.as_slice() {
+            [PassNode::Nested { op_name, manager }] => {
+                assert_eq!(op_name, "builtin.func");
+                assert!(matches!(manager.passes.as_slice(), [PassNode::Pass(_)]));
+            }
+            _ => panic!("expected a single nested node"),
+        }
+    }
+
+    #[test]
+    fn pipeline_reports_errors() {
+        assert!(super::parse_pipeline("definitely-not-a-pass").is_err());
+        assert!(super::parse_pipeline("builtin.func(mem2reg").is_err());
+        assert!(super::parse_pipeline("mem2reg)").is_err());
+    }
+
+    #[test]
+    fn matches_bare_and_qualified_op_names() {
+        let context = Context::with_default_dialects();
+        let func = ops::func(&context, "demo", IntegerType::new(&context, 32), None).build();
+        let op = context.get_op(func.id());
+        assert!(super::matches_op_name(&op, "func"));
+        assert!(super::matches_op_name(&op, "builtin.func"));
+        assert!(!super::matches_op_name(&op, "scf.func"));
+        assert!(!super::matches_op_name(&op, "module"));
     }
 }

--- a/core/src/passes/mem2reg.rs
+++ b/core/src/passes/mem2reg.rs
@@ -24,6 +24,8 @@ impl Mem2RegPass {
     }
 }
 
+tir::register_pass!(Mem2RegPass, "mem2reg");
+
 impl Pass for Mem2RegPass {
     fn name(&self) -> &'static str {
         "mem2reg"

--- a/simulator/isasim/src/main.rs
+++ b/simulator/isasim/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
         eprintln!(
             "unknown target '{}' (supported: {})",
             args.march,
-            tir_targets::SUPPORTED_TARGETS.join(", ")
+            tir_targets::supported_targets().join(", ")
         );
         std::process::exit(2);
     });

--- a/simulator/sched/src/main.rs
+++ b/simulator/sched/src/main.rs
@@ -37,11 +37,7 @@ struct Inst {
 }
 
 fn select_machine(name: &str) -> Option<MachineModel> {
-    match name {
-        "in-order" | "inorder" => Some(tir_riscv::in_order_core_model()),
-        "ooo" | "out-of-order" => Some(tir_riscv::out_of_order_core_model()),
-        _ => None,
-    }
+    tir_riscv::machine_model(name)
 }
 
 fn phys_regs(refs: &[RegRef]) -> Vec<(String, u16)> {

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -243,6 +243,10 @@ pub struct Forward {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Machine {
     pub name: String,
+    /// Optional friendly name used to select this machine (e.g. `in-order`),
+    /// declared as `machine Name ("alias") for [...]`. Keeps tool-facing names
+    /// single-sourced in TMDL alongside the machine itself.
+    pub alias: Option<String>,
     pub for_isas: Vec<String>,
     pub issue_width: Option<i64>,
     /// Structural buffer sizes by name (e.g. `rob`, `lsq`, `iq`).

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -687,8 +687,14 @@ where
             })
         });
 
+    let machine_alias = just(Token::LParen)
+        .ignore_then(select! { Token::StringLit(s) => s.to_string() })
+        .then_ignore(just(Token::RParen))
+        .or_not();
+
     just(Token::KwMachine)
         .ignore_then(ident)
+        .then(machine_alias)
         .then(for_isas())
         .then(
             choice((
@@ -704,7 +710,7 @@ where
             .collect::<Vec<_>>()
             .delimited_by(just(Token::LBrace), just(Token::RBrace)),
         )
-        .map_with(|((name, for_isas), body), e| {
+        .map_with(|(((name, alias), for_isas), body), e| {
             let mut issue_width = None;
             let mut buffers = Vec::new();
             let mut pipeline = Vec::new();
@@ -725,6 +731,7 @@ where
             }
             Machine {
                 name,
+                alias,
                 for_isas,
                 issue_width,
                 buffers,
@@ -1528,6 +1535,7 @@ mod tests {
         );
         let m = parsed.output().expect("machine should parse").0.clone();
         assert_eq!(m.name, "RocketCore");
+        assert_eq!(m.alias, None);
         assert_eq!(m.for_isas, vec!["RV64I".to_string()]);
         assert_eq!(m.issue_width, Some(2));
         assert_eq!(m.buffers, vec![("rob".into(), 64), ("lsq".into(), 16)]);
@@ -1538,6 +1546,24 @@ mod tests {
         assert_eq!(m.binds[0].unit, "WriteIALU");
         assert_eq!(m.binds[0].latency, Some(1));
         assert_eq!(m.binds[0].uses, vec!["ALU".to_string()]);
+    }
+
+    #[test]
+    fn smoke_machine_alias() {
+        let code = "machine InOrderCore (\"in-order\") for [RV64I] {
+            issue_width = 1;
+        }";
+        let (tokens, _e) = lexer().parse(code).into_output_errors();
+        let tokens = tokens.unwrap();
+        let parsed = machine_def().then(end()).parse(
+            tokens
+                .as_slice()
+                .map((code.len()..code.len()).into(), |(t, s)| (t, s)),
+        );
+        let m = parsed.output().expect("machine should parse").0.clone();
+        assert_eq!(m.name, "InOrderCore");
+        assert_eq!(m.alias.as_deref(), Some("in-order"));
+        assert_eq!(m.for_isas, vec!["RV64I".to_string()]);
     }
 
     #[test]

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -873,6 +873,8 @@ fn emit_machine_models<'a>(
     let scheduled = collect_scheduled(files, item_cache);
 
     let mut model_fns = Vec::new();
+    let mut lookup_arms = Vec::new();
+    let mut machine_names = Vec::new();
     for machine in files.iter().flat_map(|f| f.machines()) {
         let binds: HashMap<&str, &ast::UnitBind> =
             machine.binds.iter().map(|b| (b.unit.as_str(), b)).collect();
@@ -969,9 +971,32 @@ fn emit_machine_models<'a>(
                 }
             }
         });
+
+        // Select by the machine name, and by its alias when one is declared, so
+        // the tool-facing name lives in TMDL next to the machine.
+        let mut keys = vec![machine.name.clone()];
+        if let Some(alias) = &machine.alias {
+            keys.push(alias.clone());
+        }
+        let key_lits = keys.iter().map(|k| proc_macro2::Literal::string(k));
+        machine_names.push(proc_macro2::Literal::string(keys.last().unwrap()));
+        lookup_arms.push(quote! { #(#key_lits)|* => Some(#fn_ident()) });
     }
 
-    Ok(quote! { #(#model_fns)* })
+    Ok(quote! {
+        #(#model_fns)*
+
+        /// Resolve a machine by its TMDL name or alias, or `None` if unknown.
+        pub fn machine_model(name: &str) -> Option<tir_be_common::sched::MachineModel> {
+            match name {
+                #(#lookup_arms,)*
+                _ => None,
+            }
+        }
+
+        /// Tool-facing names of every machine defined in TMDL (alias preferred).
+        pub const MACHINES: &[&str] = &[#(#machine_names),*];
+    })
 }
 
 /// Resource-agnostic `unit` defaults, keyed by name. Used both when a machine

--- a/tools/src/mc/mod.rs
+++ b/tools/src/mc/mod.rs
@@ -50,7 +50,7 @@ pub fn run(args: ToolArgs) -> Result<(), Box<dyn Error>> {
         format!(
             "unknown target '{}' (supported: {})",
             args.march,
-            tir_targets::SUPPORTED_TARGETS.join(", ")
+            tir_targets::supported_targets().join(", ")
         )
     })?;
 

--- a/tools/src/opt/mod.rs
+++ b/tools/src/opt/mod.rs
@@ -1,13 +1,14 @@
 use std::{error::Error, ffi::OsString};
 
 use clap::Args;
-use tir::{Context, IRFormatter, Operation, PassManager, builtin::ModuleOp, passes::Mem2RegPass};
+use tir::{Context, IRFormatter, Operation, builtin::ModuleOp};
 
 use crate::common::{read_input, write_output};
 
 #[derive(Args)]
 pub struct ToolArgs {
-    /// Pass to run. May be repeated; currently supports `mem2reg`.
+    /// Pass pipeline in MLIR-style syntax, e.g. `builtin.func(mem2reg)`. May be
+    /// repeated; repeated values are joined into one comma-separated pipeline.
     #[arg(long = "pass", short = 'p')]
     passes: Vec<String>,
 
@@ -26,15 +27,13 @@ pub fn run(args: ToolArgs) -> Result<(), Box<dyn Error>> {
     let module = tir::parse::ir::parse_ir::<ModuleOp>(&context, &input)
         .map_err(|(span, err)| format!("failed to parse input at byte {}: {err:?}", span.0))?;
 
-    let mut pm = PassManager::new();
-    for pass in &args.passes {
-        match pass.as_str() {
-            "mem2reg" => {
-                pm.add_pass(Mem2RegPass::new());
-            }
-            other => return Err(format!("unknown pass '{other}'").into()),
-        }
-    }
+    let pipeline = args.passes.join(",");
+    let mut pm = tir::parse_pipeline(&pipeline).map_err(|e| {
+        format!(
+            "{e} (available passes: {})",
+            tir::registered_passes().join(", ")
+        )
+    })?;
     pm.run(&context, context.get_op(module.id()))
         .map_err(|e| format!("pass pipeline failed: {e}"))?;
 


### PR DESCRIPTION
Passes and targets now self-register through link-time `linkme`
distributed slices, so `tir opt` and `tir mc` need no changes when a
new pass or backend is added.

- core: `PASSES` registry + `register_pass!` macro, and an MLIR-style
  pipeline parser (`parse_pipeline`) supporting nested op syntax like
  `builtin.func(mem2reg)`. `PassManager::nest` matches bare (`func`) or
  dialect-qualified (`builtin.func`) op names.
- be-common: `TARGETS` registry + `register_target!` macro.
- riscv/arm64: each backend now owns its `TargetMachine` impl and
  registers itself; `tir-targets` is a thin aggregator that links the
  backends and re-exports `select`/`supported_targets`.
- opt: builds its pipeline from the registry instead of a hardcoded match.