### PR TITLE
feat: builtin br/cond_br terminators with block args, lowered to per-target virtual branches

### DIFF
--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -60,11 +60,74 @@ operation! {
     }
 }
 
+// Virtual control-flow ops: the lowered form of `builtin.br`/`builtin.cond_br`.
+// They carry the successor block references and the values forwarded to each
+// successor's block arguments, deferring branch-target encoding to a later pass
+// (mirroring how `vret` defers the return sequence).
+operation! {
+    VirtualBranchOp {
+        name: "vbr",
+        dialect: "arm64",
+        format: "custom",
+        operands: O {
+            dest_args: "*Any",
+        },
+        attributes: A {
+            dest: "Block",
+        },
+    }
+}
+
+impl VirtualBranchOp {
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        tir_be_common::print_branch(fmt, self, "arm64.vbr")
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        _context: &tir::Context,
+    ) -> Result<Box<dyn tir::Operation>, (tir::parse::Span, tir::Error)> {
+        Err((tir::parse::Span(parser.pos()), tir::Error::ExpectedOpName))
+    }
+}
+
+operation! {
+    VirtualCondBranchOp {
+        name: "vcond_br",
+        dialect: "arm64",
+        format: "custom",
+        operands: O {
+            condition: "Any",
+            true_args: "*Any",
+            false_args: "*Any",
+        },
+        attributes: A {
+            true_dest: "Block",
+            false_dest: "Block",
+        },
+    }
+}
+
+impl VirtualCondBranchOp {
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        tir_be_common::print_branch(fmt, self, "arm64.vcond_br")
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        _context: &tir::Context,
+    ) -> Result<Box<dyn tir::Operation>, (tir::parse::Span, tir::Error)> {
+        Err((tir::parse::Span(parser.pos()), tir::Error::ExpectedOpName))
+    }
+}
+
 dialect! {
     Arm64Dialect {
         name: "arm64",
         operations: [
             VirtualReturnOp,
+            VirtualBranchOp,
+            VirtualCondBranchOp,
             AddOp,
             SubOp,
             AddImmediateOp,
@@ -173,9 +236,44 @@ impl Arm64Dialect {
     }
 }
 
+/// Lower the builtin control-flow terminators to AArch64 virtual branch ops,
+/// preserving successor block references and forwarded block arguments.
+fn lower_branches(
+    context: &tir::Context,
+    op: &tir::OperationRef,
+    rewriter: &mut tir::Rewriter,
+) -> Result<bool, tir::PassError> {
+    use tir::attributes::AttributeValue;
+    use tir::builtin::{BranchOp, CondBranchOp};
+
+    if let Some(br) = op.as_op::<BranchOp>() {
+        let lowered = VirtualBranchOpBuilder::new(context)
+            .dest_args(br.dest_args())
+            .attr("dest", AttributeValue::Block(br.dest()))
+            .build();
+        rewriter.replace_op(op, &lowered)?;
+        return Ok(true);
+    }
+
+    if let Some(cond_br) = op.as_op::<CondBranchOp>() {
+        let lowered = VirtualCondBranchOpBuilder::new(context)
+            .condition(cond_br.condition())
+            .true_args(cond_br.true_args())
+            .false_args(cond_br.false_args())
+            .attr("true_dest", AttributeValue::Block(cond_br.true_dest()))
+            .attr("false_dest", AttributeValue::Block(cond_br.false_dest()))
+            .build();
+        rewriter.replace_op(op, &lowered)?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
 pub fn create_isel_pass(context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
     tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context))
         .with_op_lowering(lower_func_and_return_to_asm_symbol)
+        .with_op_lowering(lower_branches)
 }
 
 /// The AArch64 frame base register (`x29`/`fp`), reserved from allocation and used
@@ -319,11 +417,70 @@ tir_be_common::register_target!(select_arm64, ["arm64"]);
 mod tests {
     use tir::{
         Context, IRBuilder, IRFormatter, Operation, PassManager,
-        builtin::{FuncOp, IntegerType, ops},
+        builtin::{FuncOp, IntegerType, UnitType, ops},
     };
     use tir_be_common::AsmDialect;
 
     use crate::{Arm64Dialect, create_isel_pass, create_regalloc_pass};
+
+    #[test]
+    fn arm64_builtin_cond_br_lowers_to_virtual() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<Arm64Dialect>();
+
+        let i1 = IntegerType::new(&context, 1);
+        let i64 = IntegerType::new(&context, 64);
+        let module = ops::module(&context, None).build();
+
+        let cond = context.create_value(i1, None);
+        let x = context.create_value(i64, None);
+        let region = context.create_region();
+        let block = context.create_block(vec![cond, x]);
+        region.add_block(block.id());
+
+        let func = ops::func(&context, "demo", UnitType::new(&context), Some(region.id())).build();
+        let fbody = func.body();
+        let args = fbody.arguments();
+        let (cond_id, x_id) = (args[0].id(), args[1].id());
+
+        let t = context.create_block(vec![]);
+        let f = context.create_block(vec![]);
+
+        let mut fb = IRBuilder::new(func.body());
+        let add = ops::addi(&context, x_id, x_id, i64).build();
+        let add_r = add.result();
+        fb.insert(add);
+        fb.insert(ops::cond_br(&context, cond_id, vec![add_r], vec![], t.id(), f.id()).build());
+
+        let mut mb = IRBuilder::new(module.body());
+        mb.insert(func);
+        mb.insert(ops::module_end(&context).build());
+
+        let mut pm = PassManager::new();
+        pm.nest(FuncOp::name()).add_pass(create_isel_pass(&context));
+        pm.run(&context, context.get_op(module.id()))
+            .expect("isel should lower the conditional branch");
+
+        let body: Vec<_> = context
+            .get_region(region.id())
+            .iter(context.clone())
+            .next()
+            .unwrap()
+            .op_ids()
+            .into_iter()
+            .map(|id| context.get_op(id).name)
+            .collect();
+        assert_eq!(body, vec!["add", "vcond_br", "symbol_end"]);
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        module.print(&mut fmt).expect("print lowered module");
+        assert!(
+            !buf.contains("builtin"),
+            "no builtin ops should remain:\n{buf}"
+        );
+    }
 
     fn phys_of(op: &std::sync::Arc<tir::OpInstance>, name: &str) -> Option<(String, u16)> {
         use tir::attributes::{AttributeValue, RegisterAttr};

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -96,6 +96,27 @@ pub fn register_attr(
     })
 }
 
+/// Print a virtual branch/terminator op for debugging: its mnemonic, operands as
+/// `%N`, then each block-reference attribute as `^bbN`. Shared by the targets'
+/// virtual branch ops so successor formatting is not duplicated per target.
+pub fn print_branch(
+    fmt: &mut tir::IRFormatter,
+    op: &dyn tir::Operation,
+    mnemonic: &str,
+) -> Result<(), std::fmt::Error> {
+    fmt.write(mnemonic)?;
+    for (i, value) in op.operands().iter().enumerate() {
+        fmt.write(if i == 0 { " " } else { ", " })?;
+        fmt.write(format!("%{}", value.number()))?;
+    }
+    for attr in op.attributes() {
+        if let AttributeValue::Block(block) = &attr.value {
+            fmt.write(format!(" ^bb{}", block.number()))?;
+        }
+    }
+    fmt.write("\n")
+}
+
 pub fn int_attr(attrs: &[tir::attributes::NamedAttribute], name: &str) -> Option<i64> {
     attrs.iter().find_map(|attr| {
         if attr.name != name {

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -158,6 +158,67 @@ operation! {
     }
 }
 
+// Virtual control-flow ops: the lowered form of `builtin.br`/`builtin.cond_br`.
+// They carry the successor block references and the values forwarded to each
+// successor's block arguments, deferring branch-target encoding to a later pass
+// (mirroring how `vret` defers the return sequence).
+operation! {
+    VirtualBranchOp {
+        name: "vbr",
+        dialect: "riscv",
+        format: "custom",
+        operands: O {
+            dest_args: "*Any",
+        },
+        attributes: A {
+            dest: "Block",
+        },
+    }
+}
+
+impl VirtualBranchOp {
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        tir_be_common::print_branch(fmt, self, "riscv.vbr")
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        _context: &tir::Context,
+    ) -> Result<Box<dyn tir::Operation>, (tir::parse::Span, tir::Error)> {
+        Err((tir::parse::Span(parser.pos()), tir::Error::ExpectedOpName))
+    }
+}
+
+operation! {
+    VirtualCondBranchOp {
+        name: "vcond_br",
+        dialect: "riscv",
+        format: "custom",
+        operands: O {
+            condition: "Any",
+            true_args: "*Any",
+            false_args: "*Any",
+        },
+        attributes: A {
+            true_dest: "Block",
+            false_dest: "Block",
+        },
+    }
+}
+
+impl VirtualCondBranchOp {
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        tir_be_common::print_branch(fmt, self, "riscv.vcond_br")
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        _context: &tir::Context,
+    ) -> Result<Box<dyn tir::Operation>, (tir::parse::Span, tir::Error)> {
+        Err((tir::parse::Span(parser.pos()), tir::Error::ExpectedOpName))
+    }
+}
+
 dialect! {
     RiscvDialect {
         name: "riscv",
@@ -217,7 +278,9 @@ dialect! {
             BranchGeUnsignedOp,
             JumpAndLinkOp,
             JumpAndLinkRegOp,
-            VirtualReturnOp
+            VirtualReturnOp,
+            VirtualBranchOp,
+            VirtualCondBranchOp
         ],
     }
 }
@@ -298,9 +361,44 @@ fn lower_func_and_return_to_asm_symbol(
     Ok(false)
 }
 
+/// Lower the builtin control-flow terminators to RISC-V virtual branch ops,
+/// preserving successor block references and forwarded block arguments.
+fn lower_branches(
+    context: &tir::Context,
+    op: &tir::OperationRef,
+    rewriter: &mut tir::Rewriter,
+) -> Result<bool, tir::PassError> {
+    use tir::attributes::AttributeValue;
+    use tir::builtin::{BranchOp, CondBranchOp};
+
+    if let Some(br) = op.as_op::<BranchOp>() {
+        let lowered = VirtualBranchOpBuilder::new(context)
+            .dest_args(br.dest_args())
+            .attr("dest", AttributeValue::Block(br.dest()))
+            .build();
+        rewriter.replace_op(op, &lowered)?;
+        return Ok(true);
+    }
+
+    if let Some(cond_br) = op.as_op::<CondBranchOp>() {
+        let lowered = VirtualCondBranchOpBuilder::new(context)
+            .condition(cond_br.condition())
+            .true_args(cond_br.true_args())
+            .false_args(cond_br.false_args())
+            .attr("true_dest", AttributeValue::Block(cond_br.true_dest()))
+            .attr("false_dest", AttributeValue::Block(cond_br.false_dest()))
+            .build();
+        rewriter.replace_op(op, &lowered)?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
 pub fn create_isel_pass(context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
     tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context))
         .with_op_lowering(lower_func_and_return_to_asm_symbol)
+        .with_op_lowering(lower_branches)
 }
 
 /// The RISC-V stack pointer (`sp` = `x2`).
@@ -443,11 +541,108 @@ tir_be_common::register_target!(select_riscv, ["riscv32", "riscv64"]);
 mod tests {
     use tir::{
         Context, IRBuilder, IRFormatter, Operation, PassManager,
-        builtin::{FuncOp, IntegerType, ops},
+        builtin::{FuncOp, IntegerType, UnitType, ops},
     };
     use tir_be_common::AsmDialect;
 
     use crate::{RiscvDialect, create_isel_pass, create_regalloc_pass};
+
+    fn body_op_names(context: &Context, region_id: tir::RegionId) -> Vec<&'static str> {
+        context
+            .get_region(region_id)
+            .iter(context.clone())
+            .next()
+            .unwrap()
+            .op_ids()
+            .into_iter()
+            .map(|id| context.get_op(id).name)
+            .collect()
+    }
+
+    #[test]
+    fn builtin_br_lowers_to_virtual() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let module = ops::module(&context, None).build();
+        let region = context.create_region();
+        let entry = context.create_block(vec![]);
+        region.add_block(entry.id());
+        let target = context.create_block(vec![]);
+
+        let func = ops::func(&context, "demo", UnitType::new(&context), Some(region.id())).build();
+        let mut fb = IRBuilder::new(func.body());
+        fb.insert(ops::br(&context, vec![], target.id()).build());
+
+        let mut mb = IRBuilder::new(module.body());
+        mb.insert(func);
+        mb.insert(ops::module_end(&context).build());
+
+        let mut pm = PassManager::new();
+        pm.nest(FuncOp::name()).add_pass(create_isel_pass(&context));
+        pm.run(&context, context.get_op(module.id()))
+            .expect("isel should lower the branch");
+
+        assert_eq!(
+            body_op_names(&context, region.id()),
+            vec!["vbr", "symbol_end"]
+        );
+    }
+
+    #[test]
+    fn builtin_cond_br_lowers_to_virtual() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let i1 = IntegerType::new(&context, 1);
+        let i32 = IntegerType::new(&context, 32);
+        let module = ops::module(&context, None).build();
+
+        let cond = context.create_value(i1, None);
+        let x = context.create_value(i32, None);
+        let region = context.create_region();
+        let block = context.create_block(vec![cond, x]);
+        region.add_block(block.id());
+
+        let func = ops::func(&context, "demo", UnitType::new(&context), Some(region.id())).build();
+        let fbody = func.body();
+        let args = fbody.arguments();
+        let (cond_id, x_id) = (args[0].id(), args[1].id());
+
+        let t = context.create_block(vec![]);
+        let f = context.create_block(vec![]);
+
+        let mut fb = IRBuilder::new(func.body());
+        let add = ops::addi(&context, x_id, x_id, i32).build();
+        let add_r = add.result();
+        fb.insert(add);
+        fb.insert(ops::cond_br(&context, cond_id, vec![add_r], vec![], t.id(), f.id()).build());
+
+        let mut mb = IRBuilder::new(module.body());
+        mb.insert(func);
+        mb.insert(ops::module_end(&context).build());
+
+        let mut pm = PassManager::new();
+        pm.nest(FuncOp::name()).add_pass(create_isel_pass(&context));
+        pm.run(&context, context.get_op(module.id()))
+            .expect("isel should lower the conditional branch");
+
+        // The data op selects (addw), the conditional branch lowers to the virtual
+        // op, and no builtin control flow remains.
+        assert_eq!(
+            body_op_names(&context, region.id()),
+            vec!["addw", "vcond_br", "symbol_end"]
+        );
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        module.print(&mut fmt).expect("print lowered module");
+        assert!(
+            !buf.contains("builtin"),
+            "no builtin ops should remain:\n{buf}"
+        );
+    }
 
     #[test]
     fn machine_models_resolve_scheduling_classes() {

--- a/core/src/attributes.rs
+++ b/core/src/attributes.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::{Context, TypeId};
+use crate::{BlockId, Context, TypeId};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AttributeValue {
@@ -14,6 +14,9 @@ pub enum AttributeValue {
     Dict(BTreeMap<String, AttributeValue>),
     Register(RegisterAttr),
     Type(TypeId),
+    /// A reference to a basic block, used by terminators to name their successors
+    /// (e.g. the targets of `br`/`cond_br`).
+    Block(BlockId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +101,7 @@ impl AttributeValue {
                 }
             },
             AttributeValue::Type(ty) => context.print_type(*ty, fmt),
+            AttributeValue::Block(block) => fmt.write(format!("^bb{}", block.number())),
         }
     }
 }
@@ -201,5 +205,11 @@ impl From<RegisterAttr> for AttributeValue {
 impl From<TypeId> for AttributeValue {
     fn from(value: TypeId) -> Self {
         AttributeValue::Type(value)
+    }
+}
+
+impl From<BlockId> for AttributeValue {
+    fn from(value: BlockId) -> Self {
+        AttributeValue::Block(value)
     }
 }

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -20,6 +20,14 @@ impl BlockId {
     pub(crate) fn new(id: u32) -> Self {
         Self(id)
     }
+
+    pub fn number(&self) -> u32 {
+        self.0
+    }
+
+    pub fn from_number(n: u32) -> Self {
+        Self(n)
+    }
 }
 
 impl Block {

--- a/core/src/dialects/builtin/control.rs
+++ b/core/src/dialects/builtin/control.rs
@@ -1,0 +1,262 @@
+use crate::attributes::AttributeValue;
+use crate::{BlockId, Error, Operation, Terminator, ValueId, operation};
+
+use crate as tir;
+
+operation! {
+    BranchOp {
+        name: "br",
+        dialect: "builtin",
+        format: "custom",
+        attributes: A {
+            dest: "Block",
+        },
+        interfaces: [Terminator],
+    }
+}
+
+impl Terminator for BranchOp {}
+
+impl BranchOp {
+    pub fn dest(&self) -> BlockId {
+        block_attr(self, "dest")
+    }
+
+    pub fn successors(&self) -> Vec<BlockId> {
+        vec![self.dest()]
+    }
+
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        fmt.writeln(format!("br ^bb{}", self.dest().number()))
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        context: &tir::Context,
+    ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
+        let dest = parse_block_ref(parser)?;
+        Ok(Box::new(
+            BranchOpBuilder::new(context)
+                .attr("dest", AttributeValue::Block(dest))
+                .build(),
+        ))
+    }
+}
+
+operation! {
+    CondBranchOp {
+        name: "cond_br",
+        dialect: "builtin",
+        format: "custom",
+        operands: O {
+            condition: "crate::Integer<1>",
+        },
+        attributes: A {
+            true_dest: "Block",
+            false_dest: "Block",
+        },
+        interfaces: [Terminator],
+    }
+}
+
+impl Terminator for CondBranchOp {}
+
+impl CondBranchOp {
+    pub fn condition(&self) -> ValueId {
+        self.operands()[0]
+    }
+
+    pub fn true_dest(&self) -> BlockId {
+        block_attr(self, "true_dest")
+    }
+
+    pub fn false_dest(&self) -> BlockId {
+        block_attr(self, "false_dest")
+    }
+
+    pub fn successors(&self) -> Vec<BlockId> {
+        vec![self.true_dest(), self.false_dest()]
+    }
+
+    fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
+        fmt.writeln(format!(
+            "cond_br %{}, ^bb{}, ^bb{}",
+            self.condition().number(),
+            self.true_dest().number(),
+            self.false_dest().number()
+        ))
+    }
+
+    fn custom_parse(
+        parser: &mut tir::parse::text::Parser,
+        context: &tir::Context,
+    ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
+        let condition = parse_value_id(parser)?;
+        expect_token(parser, ",")?;
+        let true_dest = parse_block_ref(parser)?;
+        expect_token(parser, ",")?;
+        let false_dest = parse_block_ref(parser)?;
+
+        Ok(Box::new(
+            CondBranchOpBuilder::new(context)
+                .condition(condition)
+                .attr("true_dest", AttributeValue::Block(true_dest))
+                .attr("false_dest", AttributeValue::Block(false_dest))
+                .build(),
+        ))
+    }
+}
+
+fn block_attr(op: &impl Operation, name: &str) -> BlockId {
+    op.attributes()
+        .iter()
+        .find(|a| a.name == name)
+        .and_then(|a| match a.value {
+            AttributeValue::Block(id) => Some(id),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{} must be a block reference", name))
+}
+
+fn parse_value_id(
+    parser: &mut tir::parse::text::Parser,
+) -> Result<ValueId, (tir::parse::Span, Error)> {
+    use tir::parse::common::Cursor;
+    let value_ref = parser
+        .parse_value_ref()
+        .ok_or_else(|| (parser.span(), Error::ExpectedValueRef))?;
+    let id = value_ref
+        .parse::<u32>()
+        .map_err(|_| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))?;
+    Ok(ValueId::from_number(id))
+}
+
+fn parse_block_ref(
+    parser: &mut tir::parse::text::Parser,
+) -> Result<BlockId, (tir::parse::Span, Error)> {
+    use tir::parse::common::Cursor;
+    parser
+        .parse_block_ref()
+        .ok_or_else(|| (parser.span(), Error::ExpectedToken("^bb")))
+}
+
+fn expect_token(
+    parser: &mut tir::parse::text::Parser,
+    token: &'static str,
+) -> Result<(), (tir::parse::Span, Error)> {
+    use tir::parse::common::Cursor;
+    if parser.parse_token(token) {
+        Ok(())
+    } else {
+        Err((parser.span(), Error::ExpectedToken(token)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Context, IRBuilder, IRFormatter, Operation, Terminator,
+        builtin::{IntegerType, ops},
+        parse::ir::parse_ir,
+    };
+
+    use super::{BranchOp, CondBranchOp};
+
+    #[test]
+    fn br_roundtrip() {
+        let context = Context::with_default_dialects();
+        let dest = context.create_block(vec![]);
+
+        let op = ops::br(&context, dest.id()).build();
+        assert_eq!(op.dest(), dest.id());
+        assert_eq!(op.successors(), vec![dest.id()]);
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+        assert_eq!(buf.trim_end(), format!("br ^bb{}", dest.id().number()));
+
+        let parsed = parse_ir::<BranchOp>(&context, &buf).expect("parse br");
+        assert_eq!(parsed.dest(), dest.id());
+    }
+
+    #[test]
+    fn cond_br_roundtrip() {
+        let context = Context::with_default_dialects();
+        let cond = context.create_value(IntegerType::new(&context, 1), None);
+        let cond_id = cond.id();
+        let _block = context.create_block(vec![cond]);
+        let t = context.create_block(vec![]);
+        let f = context.create_block(vec![]);
+
+        let op = ops::cond_br(&context, cond_id, t.id(), f.id()).build();
+        assert_eq!(op.condition(), cond_id);
+        assert_eq!(op.successors(), vec![t.id(), f.id()]);
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+        assert_eq!(
+            buf.trim_end(),
+            format!(
+                "cond_br %{}, ^bb{}, ^bb{}",
+                cond_id.number(),
+                t.id().number(),
+                f.id().number()
+            )
+        );
+
+        let parsed = parse_ir::<CondBranchOp>(&context, &buf).expect("parse cond_br");
+        assert_eq!(parsed.true_dest(), t.id());
+        assert_eq!(parsed.false_dest(), f.id());
+    }
+
+    #[test]
+    fn branches_are_terminators() {
+        let context = Context::with_default_dialects();
+        let dest = context.create_block(vec![]);
+        let br = ops::br(&context, dest.id()).build();
+        let instance = context.get_op(br.id());
+        assert!(instance.as_interface::<dyn Terminator>().is_some());
+    }
+
+    #[test]
+    fn cond_br_requires_i1_condition() {
+        let context = Context::with_default_dialects();
+        let cond = context.create_value(IntegerType::new(&context, 32), None);
+        let cond_id = cond.id();
+        let _block = context.create_block(vec![cond]);
+        let t = context.create_block(vec![]);
+        let f = context.create_block(vec![]);
+
+        let op = ops::cond_br(&context, cond_id, t.id(), f.id()).build();
+        let error = op.verify(&context).expect_err("condition must be i1");
+        assert!(
+            error
+                .to_string()
+                .contains("expected constraint crate::Integer<1>")
+        );
+    }
+
+    #[test]
+    fn branch_terminates_function_block() {
+        let context = Context::with_default_dialects();
+        let region = context.create_region();
+        let entry = context.create_block(vec![]);
+        region.add_block(entry.id());
+        let target = context.create_block(vec![]);
+
+        let func = ops::func(
+            &context,
+            "jump",
+            crate::builtin::UnitType::new(&context),
+            Some(region.id()),
+        )
+        .build();
+
+        let mut builder = IRBuilder::new(func.body());
+        builder.insert(ops::br(&context, target.id()).build());
+
+        assert!(func.verify(&context).is_ok());
+    }
+}

--- a/core/src/dialects/builtin/control.rs
+++ b/core/src/dialects/builtin/control.rs
@@ -1,5 +1,6 @@
+use crate::Any;
 use crate::attributes::AttributeValue;
-use crate::{BlockId, Error, Operation, Terminator, ValueId, operation};
+use crate::{BlockId, Context, Error, Operation, Terminator, ValueId, operation};
 
 use crate as tir;
 
@@ -8,6 +9,9 @@ operation! {
         name: "br",
         dialect: "builtin",
         format: "custom",
+        operands: O {
+            dest_args: "*Any",
+        },
         attributes: A {
             dest: "Block",
         },
@@ -22,21 +26,30 @@ impl BranchOp {
         block_attr(self, "dest")
     }
 
+    /// The values forwarded to the destination block's arguments.
+    pub fn dest_args(&self) -> Vec<ValueId> {
+        self.operands().to_vec()
+    }
+
     pub fn successors(&self) -> Vec<BlockId> {
         vec![self.dest()]
     }
 
     fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
-        fmt.writeln(format!("br ^bb{}", self.dest().number()))
+        let context = self.0.context.upgrade();
+        fmt.write("br ")?;
+        print_successor(fmt, &context, self.dest(), &self.dest_args())?;
+        fmt.write("\n")
     }
 
     fn custom_parse(
         parser: &mut tir::parse::text::Parser,
-        context: &tir::Context,
+        context: &Context,
     ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
-        let dest = parse_block_ref(parser)?;
+        let (dest, dest_args) = parse_successor(parser, context)?;
         Ok(Box::new(
             BranchOpBuilder::new(context)
+                .dest_args(dest_args)
                 .attr("dest", AttributeValue::Block(dest))
                 .build(),
         ))
@@ -50,6 +63,8 @@ operation! {
         format: "custom",
         operands: O {
             condition: "crate::Integer<1>",
+            true_args: "*Any",
+            false_args: "*Any",
         },
         attributes: A {
             true_dest: "Block",
@@ -74,32 +89,61 @@ impl CondBranchOp {
         block_attr(self, "false_dest")
     }
 
+    /// The values forwarded to the true successor's block arguments.
+    pub fn true_args(&self) -> Vec<ValueId> {
+        let (start, end) = self.true_range();
+        self.operands()[start..end].to_vec()
+    }
+
+    /// The values forwarded to the false successor's block arguments.
+    pub fn false_args(&self) -> Vec<ValueId> {
+        let (start, end) = self.false_range();
+        self.operands()[start..end].to_vec()
+    }
+
     pub fn successors(&self) -> Vec<BlockId> {
         vec![self.true_dest(), self.false_dest()]
     }
 
+    // Operand layout is [condition, true_args.., false_args..]; the segment sizes
+    // [1, t, f] recovered from the op tell where each successor's args sit.
+    fn true_range(&self) -> (usize, usize) {
+        let segs = operand_segments(self);
+        let t = segs.get(1).copied().unwrap_or(0);
+        (1, 1 + t)
+    }
+
+    fn false_range(&self) -> (usize, usize) {
+        let segs = operand_segments(self);
+        let t = segs.get(1).copied().unwrap_or(0);
+        let f = segs.get(2).copied().unwrap_or(0);
+        (1 + t, 1 + t + f)
+    }
+
     fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
-        fmt.writeln(format!(
-            "cond_br %{}, ^bb{}, ^bb{}",
-            self.condition().number(),
-            self.true_dest().number(),
-            self.false_dest().number()
-        ))
+        let context = self.0.context.upgrade();
+        fmt.write(format!("cond_br %{}, ", self.condition().number()))?;
+        print_successor(fmt, &context, self.true_dest(), &self.true_args())?;
+        fmt.write(", ")?;
+        print_successor(fmt, &context, self.false_dest(), &self.false_args())?;
+        fmt.write("\n")
     }
 
     fn custom_parse(
         parser: &mut tir::parse::text::Parser,
-        context: &tir::Context,
+        context: &Context,
     ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
         let condition = parse_value_id(parser)?;
         expect_token(parser, ",")?;
-        let true_dest = parse_block_ref(parser)?;
+        let (true_dest, true_args) = parse_successor(parser, context)?;
         expect_token(parser, ",")?;
-        let false_dest = parse_block_ref(parser)?;
+        let (false_dest, false_args) = parse_successor(parser, context)?;
 
         Ok(Box::new(
             CondBranchOpBuilder::new(context)
                 .condition(condition)
+                .true_args(true_args)
+                .false_args(false_args)
                 .attr("true_dest", AttributeValue::Block(true_dest))
                 .attr("false_dest", AttributeValue::Block(false_dest))
                 .build(),
@@ -116,6 +160,84 @@ fn block_attr(op: &impl Operation, name: &str) -> BlockId {
             _ => None,
         })
         .unwrap_or_else(|| panic!("{} must be a block reference", name))
+}
+
+fn operand_segments(op: &impl Operation) -> Vec<usize> {
+    op.attributes()
+        .iter()
+        .find(|a| a.name == "operand_segment_sizes")
+        .and_then(|a| match &a.value {
+            AttributeValue::Array(items) => Some(items),
+            _ => None,
+        })
+        .map(|items| {
+            items
+                .iter()
+                .map(|v| match v {
+                    AttributeValue::UInt(n) => *n as usize,
+                    _ => 0,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Print a successor as `^bbN` followed by an optional MLIR-style argument list
+/// `(%a, %b : t1, t2)` when the branch forwards block arguments.
+fn print_successor(
+    fmt: &mut tir::IRFormatter,
+    context: &Context,
+    block: BlockId,
+    args: &[ValueId],
+) -> Result<(), std::fmt::Error> {
+    fmt.write(format!("^bb{}", block.number()))?;
+    if args.is_empty() {
+        return Ok(());
+    }
+    fmt.write("(")?;
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            fmt.write(", ")?;
+        }
+        fmt.write(format!("%{}", arg.number()))?;
+    }
+    fmt.write(" : ")?;
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            fmt.write(", ")?;
+        }
+        context.print_type(context.get_value(*arg).ty(), fmt)?;
+    }
+    fmt.write(")")
+}
+
+fn parse_successor(
+    parser: &mut tir::parse::text::Parser,
+    context: &Context,
+) -> Result<(BlockId, Vec<ValueId>), (tir::parse::Span, Error)> {
+    let block = parse_block_ref(parser)?;
+    let mut args = vec![];
+    if parser.parse_token("(") {
+        loop {
+            args.push(parse_value_id(parser)?);
+            if parser.parse_token(",") {
+                continue;
+            }
+            break;
+        }
+        expect_token(parser, ":")?;
+        // Argument types are carried by the values themselves; parse and discard
+        // them so the textual form round-trips.
+        loop {
+            parse_arg_type(parser, context)?;
+            if parser.parse_token(",") {
+                continue;
+            }
+            break;
+        }
+        expect_token(parser, ")")?;
+    }
+    Ok((block, args))
 }
 
 fn parse_value_id(
@@ -140,6 +262,16 @@ fn parse_block_ref(
         .ok_or_else(|| (parser.span(), Error::ExpectedToken("^bb")))
 }
 
+fn parse_arg_type(
+    parser: &mut tir::parse::text::Parser,
+    context: &Context,
+) -> Result<tir::TypeId, (tir::parse::Span, Error)> {
+    use tir::parse::common::Cursor;
+    parser
+        .parse_type(context)?
+        .ok_or_else(|| (parser.span(), Error::ExpectedType))
+}
+
 fn expect_token(
     parser: &mut tir::parse::text::Parser,
     token: &'static str,
@@ -156,20 +288,20 @@ fn expect_token(
 mod tests {
     use crate::{
         Context, IRBuilder, IRFormatter, Operation, Terminator,
-        builtin::{IntegerType, ops},
+        builtin::{IntegerType, UnitType, ops},
         parse::ir::parse_ir,
     };
 
     use super::{BranchOp, CondBranchOp};
 
     #[test]
-    fn br_roundtrip() {
+    fn br_no_args_roundtrip() {
         let context = Context::with_default_dialects();
         let dest = context.create_block(vec![]);
 
-        let op = ops::br(&context, dest.id()).build();
+        let op = ops::br(&context, vec![], dest.id()).build();
         assert_eq!(op.dest(), dest.id());
-        assert_eq!(op.successors(), vec![dest.id()]);
+        assert!(op.dest_args().is_empty());
 
         let mut buf = String::new();
         let mut fmt = IRFormatter::new(&mut buf);
@@ -181,16 +313,53 @@ mod tests {
     }
 
     #[test]
-    fn cond_br_roundtrip() {
+    fn br_with_args_roundtrip() {
         let context = Context::with_default_dialects();
-        let cond = context.create_value(IntegerType::new(&context, 1), None);
-        let cond_id = cond.id();
-        let _block = context.create_block(vec![cond]);
+        let i32_ty = IntegerType::new(&context, 32);
+        let a = context.create_value(i32_ty, None);
+        let b = context.create_value(i32_ty, None);
+        let (a_id, b_id) = (a.id(), b.id());
+        let _block = context.create_block(vec![a, b]);
+        let dest = context.create_block(vec![]);
+
+        let op = ops::br(&context, vec![a_id, b_id], dest.id()).build();
+        assert_eq!(op.dest_args(), vec![a_id, b_id]);
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+        assert_eq!(
+            buf.trim_end(),
+            format!(
+                "br ^bb{}(%{}, %{} : !i32, !i32)",
+                dest.id().number(),
+                a_id.number(),
+                b_id.number()
+            )
+        );
+
+        let parsed = parse_ir::<BranchOp>(&context, &buf).expect("parse br");
+        assert_eq!(parsed.dest_args(), vec![a_id, b_id]);
+        assert!(parsed.verify(&context).is_ok());
+    }
+
+    #[test]
+    fn cond_br_with_args_roundtrip() {
+        let context = Context::with_default_dialects();
+        let i1_ty = IntegerType::new(&context, 1);
+        let i32_ty = IntegerType::new(&context, 32);
+        let cond = context.create_value(i1_ty, None);
+        let a = context.create_value(i32_ty, None);
+        let b = context.create_value(i32_ty, None);
+        let (cond_id, a_id, b_id) = (cond.id(), a.id(), b.id());
+        let _block = context.create_block(vec![cond, a, b]);
         let t = context.create_block(vec![]);
         let f = context.create_block(vec![]);
 
-        let op = ops::cond_br(&context, cond_id, t.id(), f.id()).build();
+        let op = ops::cond_br(&context, cond_id, vec![a_id], vec![b_id], t.id(), f.id()).build();
         assert_eq!(op.condition(), cond_id);
+        assert_eq!(op.true_args(), vec![a_id]);
+        assert_eq!(op.false_args(), vec![b_id]);
         assert_eq!(op.successors(), vec![t.id(), f.id()]);
 
         let mut buf = String::new();
@@ -199,23 +368,63 @@ mod tests {
         assert_eq!(
             buf.trim_end(),
             format!(
-                "cond_br %{}, ^bb{}, ^bb{}",
+                "cond_br %{}, ^bb{}(%{} : !i32), ^bb{}(%{} : !i32)",
                 cond_id.number(),
                 t.id().number(),
-                f.id().number()
+                a_id.number(),
+                f.id().number(),
+                b_id.number()
             )
         );
 
         let parsed = parse_ir::<CondBranchOp>(&context, &buf).expect("parse cond_br");
         assert_eq!(parsed.true_dest(), t.id());
         assert_eq!(parsed.false_dest(), f.id());
+        assert_eq!(parsed.true_args(), vec![a_id]);
+        assert_eq!(parsed.false_args(), vec![b_id]);
+        assert!(parsed.verify(&context).is_ok());
+    }
+
+    #[test]
+    fn cond_br_asymmetric_args() {
+        let context = Context::with_default_dialects();
+        let i1_ty = IntegerType::new(&context, 1);
+        let i32_ty = IntegerType::new(&context, 32);
+        let cond = context.create_value(i1_ty, None);
+        let a = context.create_value(i32_ty, None);
+        let b = context.create_value(i32_ty, None);
+        let c = context.create_value(i32_ty, None);
+        let (cond_id, a_id, b_id, c_id) = (cond.id(), a.id(), b.id(), c.id());
+        let _block = context.create_block(vec![cond, a, b, c]);
+        let t = context.create_block(vec![]);
+        let f = context.create_block(vec![]);
+
+        // Two args to true, one to false: segment split must stay correct.
+        let op = ops::cond_br(
+            &context,
+            cond_id,
+            vec![a_id, b_id],
+            vec![c_id],
+            t.id(),
+            f.id(),
+        )
+        .build();
+        assert_eq!(op.true_args(), vec![a_id, b_id]);
+        assert_eq!(op.false_args(), vec![c_id]);
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+        let parsed = parse_ir::<CondBranchOp>(&context, &buf).expect("parse cond_br");
+        assert_eq!(parsed.true_args(), vec![a_id, b_id]);
+        assert_eq!(parsed.false_args(), vec![c_id]);
     }
 
     #[test]
     fn branches_are_terminators() {
         let context = Context::with_default_dialects();
         let dest = context.create_block(vec![]);
-        let br = ops::br(&context, dest.id()).build();
+        let br = ops::br(&context, vec![], dest.id()).build();
         let instance = context.get_op(br.id());
         assert!(instance.as_interface::<dyn Terminator>().is_some());
     }
@@ -229,7 +438,7 @@ mod tests {
         let t = context.create_block(vec![]);
         let f = context.create_block(vec![]);
 
-        let op = ops::cond_br(&context, cond_id, t.id(), f.id()).build();
+        let op = ops::cond_br(&context, cond_id, vec![], vec![], t.id(), f.id()).build();
         let error = op.verify(&context).expect_err("condition must be i1");
         assert!(
             error
@@ -246,16 +455,10 @@ mod tests {
         region.add_block(entry.id());
         let target = context.create_block(vec![]);
 
-        let func = ops::func(
-            &context,
-            "jump",
-            crate::builtin::UnitType::new(&context),
-            Some(region.id()),
-        )
-        .build();
+        let func = ops::func(&context, "jump", UnitType::new(&context), Some(region.id())).build();
 
         let mut builder = IRBuilder::new(func.body());
-        builder.insert(ops::br(&context, target.id()).build());
+        builder.insert(ops::br(&context, vec![], target.id()).build());
 
         assert!(func.verify(&context).is_ok());
     }

--- a/core/src/dialects/builtin/mod.rs
+++ b/core/src/dialects/builtin/mod.rs
@@ -1,4 +1,5 @@
 mod arith;
+mod control;
 mod func;
 mod module;
 
@@ -11,11 +12,13 @@ use crate::{Context, Error, IRFormatter, Type, TypeId, dialect, parse::Span};
 use crate as tir;
 
 pub use arith::*;
+pub use control::*;
 pub use func::*;
 pub use module::*;
 
 pub mod ops {
     pub use super::arith::*;
+    pub use super::control::*;
     pub use super::func::*;
     pub use super::module::*;
 }
@@ -42,6 +45,8 @@ dialect! {
             ExtSIOp,
             ExtUIOp,
             TruncIOp,
+            BranchOp,
+            CondBranchOp,
         ],
         types: [IntegerType, IndexType, UnitType],
     }

--- a/core/src/parse/text.rs
+++ b/core/src/parse/text.rs
@@ -162,6 +162,22 @@ impl<'src> Parser<'src> {
         }
     }
 
+    /// Parse a basic block reference of the form `^bb<number>` (e.g. `^bb2`),
+    /// returning the referenced [`BlockId`](crate::BlockId).
+    pub fn parse_block_ref(&mut self) -> Option<crate::BlockId> {
+        let mark = self.position;
+        if !self.parse_token("^bb") {
+            return None;
+        }
+        match self.parse_number() {
+            Some(n) if n >= 0 => Some(crate::BlockId::from_number(n as u32)),
+            _ => {
+                self.position = mark;
+                None
+            }
+        }
+    }
+
     pub fn parse_symbol_name(&mut self) -> Option<&'src str> {
         if self
             .src

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -556,6 +556,7 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
                         "Dict" => matches!(attr.value, tir::attributes::AttributeValue::Dict(_)),
                         "Register" => matches!(attr.value, tir::attributes::AttributeValue::Register(_)),
                         "Type" => matches!(attr.value, tir::attributes::AttributeValue::Type(_)),
+                        "Block" => matches!(attr.value, tir::attributes::AttributeValue::Block(_)),
                         _ => false,
                     };
 

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -97,42 +97,114 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
     let mut operand_fn_params = vec![];
     let mut operand_fn_builders = vec![];
 
+    let has_variadic = operands.iter().any(|o| o.variadic);
+
     for operand in &operands {
         let field = format_ident!("{}", operand.name);
-        operand_fields.push(quote! {
-            #field: Option<tir::ValueId>
-        });
-        operand_defaults.push(quote! {
-            #field: None
-        });
-        operand_builders.push(quote! {
-            pub fn #field(mut self, v: tir::ValueId) -> Self {
-                self.#field = Some(v);
-                self
-            }
-        });
-        operand_fn_params.push(quote! {
-            #field: impl Into<tir::Operand>
-        });
-        operand_fn_builders.push(quote! {
-            let #field = #field.into();
-            if let Some(value) = #field.into_option() {
-                builder = builder.#field(value);
-            }
-        });
+        if operand.variadic {
+            operand_fields.push(quote! {
+                #field: Vec<tir::ValueId>
+            });
+            operand_defaults.push(quote! {
+                #field: Vec::new()
+            });
+            operand_builders.push(quote! {
+                pub fn #field(mut self, v: Vec<tir::ValueId>) -> Self {
+                    self.#field = v;
+                    self
+                }
+            });
+            operand_fn_params.push(quote! {
+                #field: Vec<tir::ValueId>
+            });
+            operand_fn_builders.push(quote! {
+                builder = builder.#field(#field);
+            });
+        } else {
+            operand_fields.push(quote! {
+                #field: Option<tir::ValueId>
+            });
+            operand_defaults.push(quote! {
+                #field: None
+            });
+            operand_builders.push(quote! {
+                pub fn #field(mut self, v: tir::ValueId) -> Self {
+                    self.#field = Some(v);
+                    self
+                }
+            });
+            operand_fn_params.push(quote! {
+                #field: impl Into<tir::Operand>
+            });
+            operand_fn_builders.push(quote! {
+                let #field = #field.into();
+                if let Some(value) = #field.into_option() {
+                    builder = builder.#field(value);
+                }
+            });
+        }
     }
 
+    // Collect operands in declaration order. Variadic ops additionally record each
+    // declared operand's segment size in the `operand_segment_sizes` attribute so
+    // groups can be recovered; fixed-arity ops keep the original simple collection.
     let operand_collect: Vec<_> = operands
         .iter()
         .map(|operand| {
             let field = format_ident!("{}", operand.name);
-            quote! {
-                if let Some(v) = self.#field {
-                    operand_vec.push(v);
+            if !has_variadic {
+                quote! {
+                    if let Some(v) = self.#field {
+                        operand_vec.push(v);
+                    }
+                }
+            } else if operand.variadic {
+                quote! {
+                    operand_segment_sizes.push(self.#field.len() as u64);
+                    operand_vec.extend(self.#field.iter().copied());
+                }
+            } else {
+                quote! {
+                    if let Some(v) = self.#field {
+                        operand_segment_sizes.push(1);
+                        operand_vec.push(v);
+                    } else {
+                        operand_segment_sizes.push(0);
+                    }
                 }
             }
         })
         .collect();
+
+    let segment_sizes_setup = if has_variadic {
+        quote! { let mut operand_segment_sizes: Vec<u64> = vec![]; }
+    } else {
+        quote! {}
+    };
+
+    // `attributes` only needs to be mutable when a variadic op appends its segment
+    // sizes, so bind it accordingly to avoid an `unused_mut` warning otherwise.
+    let attributes_binding = if has_variadic {
+        quote! { let mut attributes = self.attributes; }
+    } else {
+        quote! { let attributes = self.attributes; }
+    };
+
+    let segment_sizes_attr = if has_variadic {
+        quote! {
+            attributes.push(tir::attributes::NamedAttribute::new(
+                "operand_segment_sizes",
+                tir::attributes::AttributeValue::Array(
+                    operand_segment_sizes
+                        .iter()
+                        .map(|n| tir::attributes::AttributeValue::UInt(*n))
+                        .collect(),
+                ),
+            ));
+        }
+    } else {
+        quote! {}
+    };
 
     // Result support
     let result_accessor = if has_results {
@@ -382,6 +454,139 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
         quote! { impl tir::Verifiable for #struct_name {} }
     };
 
+    // Per-operand value checks (existence, defining-op/block-arg, type constraint),
+    // shared by the fixed-arity and variadic validation loops. Expects `value_id`,
+    // `operand_name`, and `idx` in scope.
+    let operand_value_checks = quote! {
+        if !context.has_value(value_id) {
+            return Err(tir::Error::VerificationError(format!(
+                "{} operand '{}' references unknown value %{id}",
+                <Self as tir::Operation>::name(),
+                operand_name,
+                id = value_id.number()
+            )));
+        }
+
+        let value = context.get_value(value_id);
+        match value.defining_op() {
+            Some(def_op) => {
+                if !context.has_operation(def_op) {
+                    return Err(tir::Error::VerificationError(format!(
+                        "{} operand '{}' value %{id} references missing defining op",
+                        <Self as tir::Operation>::name(),
+                        operand_name,
+                        id = value_id.number()
+                    )));
+                }
+            }
+            None => {
+                if !context.is_block_argument(value_id) {
+                    return Err(tir::Error::VerificationError(format!(
+                        "{} operand '{}' value %{id} has no defining op and is not a block argument",
+                        <Self as tir::Operation>::name(),
+                        operand_name,
+                        id = value_id.number()
+                    )));
+                }
+            }
+        }
+
+        let actual_ty = value.ty();
+        let actual_ty_data = context.get_type_data(actual_ty);
+        if !operand_constraint_checkers[idx](actual_ty_data.as_ref()) {
+            return Err(tir::Error::VerificationError(format!(
+                "{} operand '{}' expected constraint {}, got {}",
+                <Self as tir::Operation>::name(),
+                operand_name,
+                operand_constraint_names[idx],
+                context.type_to_string(actual_ty)
+            )));
+        }
+    };
+
+    let operand_validation = if has_variadic {
+        quote! {
+            // Variadic ops recover their operand grouping from the segment sizes
+            // recorded at build time, then validate each declared operand's segment.
+            let segment_sizes: Vec<usize> = match <Self as tir::Operation>::attributes(self)
+                .iter()
+                .find(|a| a.name == "operand_segment_sizes")
+                .map(|a| &a.value)
+            {
+                Some(tir::attributes::AttributeValue::Array(items)) => items
+                    .iter()
+                    .map(|v| match v {
+                        tir::attributes::AttributeValue::UInt(n) => *n as usize,
+                        _ => 0usize,
+                    })
+                    .collect(),
+                _ => {
+                    return Err(tir::Error::VerificationError(format!(
+                        "{} missing operand_segment_sizes attribute",
+                        <Self as tir::Operation>::name()
+                    )));
+                }
+            };
+
+            if segment_sizes.len() != operand_specs.len() {
+                return Err(tir::Error::VerificationError(format!(
+                    "{} expects {} operand segments, got {}",
+                    <Self as tir::Operation>::name(),
+                    operand_specs.len(),
+                    segment_sizes.len()
+                )));
+            }
+
+            let total: usize = segment_sizes.iter().sum();
+            if total != operands.len() {
+                return Err(tir::Error::VerificationError(format!(
+                    "{} operand segment sizes sum to {}, but it has {} operands",
+                    <Self as tir::Operation>::name(),
+                    total,
+                    operands.len()
+                )));
+            }
+
+            let mut __cursor = 0usize;
+            for (idx, (operand_name, _type_spec)) in operand_specs.iter().enumerate() {
+                let __count = segment_sizes[idx];
+                for __k in 0..__count {
+                    let value_id = operands[__cursor + __k];
+                    #operand_value_checks
+                }
+                __cursor += __count;
+            }
+        }
+    } else {
+        quote! {
+            if operands.len() > operand_specs.len() {
+                return Err(tir::Error::VerificationError(format!(
+                    "{} expects at most {} operands, got {}",
+                    <Self as tir::Operation>::name(),
+                    operand_specs.len(),
+                    operands.len()
+                )));
+            }
+
+            for (idx, (operand_name, type_spec)) in operand_specs.iter().enumerate() {
+                let is_optional = type_spec.starts_with('?');
+
+                let Some(value_id) = operands.get(idx).copied() else {
+                    if is_optional {
+                        continue;
+                    }
+                    return Err(tir::Error::VerificationError(format!(
+                        "{} missing required operand '{}'",
+                        <Self as tir::Operation>::name(),
+                        operand_name
+                    )));
+                };
+
+                #operand_value_checks
+            }
+        }
+    };
+
     quote! {
         pub struct #struct_name(std::sync::Arc<tir::OpInstance>);
 
@@ -406,74 +611,7 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
                 ];
                 let operands = <Self as tir::Operation>::operands(self);
 
-                if operands.len() > operand_specs.len() {
-                    return Err(tir::Error::VerificationError(format!(
-                        "{} expects at most {} operands, got {}",
-                        <Self as tir::Operation>::name(),
-                        operand_specs.len(),
-                        operands.len()
-                    )));
-                }
-
-                for (idx, (operand_name, type_spec)) in operand_specs.iter().enumerate() {
-                    let is_optional = type_spec.starts_with('?');
-
-                    let Some(value_id) = operands.get(idx).copied() else {
-                        if is_optional {
-                            continue;
-                        }
-                        return Err(tir::Error::VerificationError(format!(
-                            "{} missing required operand '{}'",
-                            <Self as tir::Operation>::name(),
-                            operand_name
-                        )));
-                    };
-
-                    if !context.has_value(value_id) {
-                        return Err(tir::Error::VerificationError(format!(
-                            "{} operand '{}' references unknown value %{id}",
-                            <Self as tir::Operation>::name(),
-                            operand_name,
-                            id = value_id.number()
-                        )));
-                    }
-
-                    let value = context.get_value(value_id);
-                    match value.defining_op() {
-                        Some(def_op) => {
-                            if !context.has_operation(def_op) {
-                                return Err(tir::Error::VerificationError(format!(
-                                    "{} operand '{}' value %{id} references missing defining op",
-                                    <Self as tir::Operation>::name(),
-                                    operand_name,
-                                    id = value_id.number()
-                                )));
-                            }
-                        }
-                        None => {
-                            if !context.is_block_argument(value_id) {
-                                return Err(tir::Error::VerificationError(format!(
-                                    "{} operand '{}' value %{id} has no defining op and is not a block argument",
-                                    <Self as tir::Operation>::name(),
-                                    operand_name,
-                                    id = value_id.number()
-                                )));
-                            }
-                        }
-                    }
-
-                    let actual_ty = value.ty();
-                    let actual_ty_data = context.get_type_data(actual_ty);
-                    if !operand_constraint_checkers[idx](actual_ty_data.as_ref()) {
-                        return Err(tir::Error::VerificationError(format!(
-                            "{} operand '{}' expected constraint {}, got {}",
-                            <Self as tir::Operation>::name(),
-                            operand_name,
-                            operand_constraint_names[idx],
-                            context.type_to_string(actual_ty)
-                        )));
-                    }
-                }
+                #operand_validation
 
                 if self.0.results.len() != result_specs.len() {
                     return Err(tir::Error::VerificationError(format!(
@@ -679,9 +817,13 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
                 #attribute_verifier
 
                 let mut operand_vec: Vec<tir::ValueId> = vec![];
+                #segment_sizes_setup
                 #(#operand_collect)*
 
                 #result_build
+
+                #attributes_binding
+                #segment_sizes_attr
 
                 let instance = tir::OpInstance {
                     id: tir::OpId::invalid(),
@@ -691,7 +833,7 @@ pub fn construct_operation(item: TokenStream) -> TokenStream {
                     operands: operand_vec,
                     results: result_vec,
                     regions,
-                    attributes: self.attributes,
+                    attributes,
                     attribute_roles: #struct_name::attribute_roles(),
                 };
 
@@ -743,6 +885,10 @@ struct Region {
 struct ValueSpec {
     name: String,
     ty: String,
+    /// A `*`-prefixed operand accepts zero or more values (an MLIR-style variadic
+    /// segment). Operand grouping is then recovered from the stored
+    /// `operand_segment_sizes` attribute.
+    variadic: bool,
 }
 
 impl Parse for Operation {
@@ -1194,9 +1340,13 @@ fn get_value_specs(expr: &Expr) -> Option<Vec<ValueSpec>> {
         Expr::Struct(s) => Some(
             s.fields
                 .iter()
-                .map(|f| ValueSpec {
-                    name: field_name(f),
-                    ty: expr_as_string(&f.expr),
+                .map(|f| {
+                    let ty = expr_as_string(&f.expr);
+                    ValueSpec {
+                        name: field_name(f),
+                        variadic: ty.starts_with('*'),
+                        ty,
+                    }
                 })
                 .collect(),
         ),
@@ -1211,6 +1361,7 @@ fn get_value_specs(expr: &Expr) -> Option<Vec<ValueSpec>> {
                     ValueSpec {
                         name: p.path.get_ident().unwrap().to_string(),
                         ty: "Any".to_string(),
+                        variadic: false,
                     }
                 })
                 .collect(),
@@ -1220,7 +1371,10 @@ fn get_value_specs(expr: &Expr) -> Option<Vec<ValueSpec>> {
 }
 
 fn normalize_constraint_name(spec: &str) -> String {
-    spec.strip_prefix('?').unwrap_or(spec).to_string()
+    spec.strip_prefix('?')
+        .or_else(|| spec.strip_prefix('*'))
+        .unwrap_or(spec)
+        .to_string()
 }
 
 fn parse_constraint_tokens(spec: &str) -> proc_macro2::TokenStream {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `builtin.br`/`builtin.cond_br` control-flow terminators, the block-reference primitive and MLIR-style successor block-argument passing they need, and makes them lowerable through instruction selection via per-target virtual branch ops.

## Changes

### Core IR — block reference capability
- `AttributeValue::Block(BlockId)` (printed `^bbN`), `From<BlockId>`, `BlockId::number()`/`from_number()`, `Parser::parse_block_ref()`, and `Block` attribute-type support in the `operation!` macro verifier.

### `operation!` macro — variadic operands
- A `*`-prefixed operand accepts zero or more values; group sizes are recorded in an `operand_segment_sizes` attribute and used to recover groups in operand verification. Fixed-arity ops are unchanged.

### builtin dialect — branch ops
- `BranchOp` (`br ^bbN(args)`) and `CondBranchOp` (`cond_br %c, ^bbT(args), ^bbF(args)`): terminators whose successor arguments are real SSA operands, so def-use tracks values forwarded across edges. Custom print/parse round-trip the `^bbN(%a, %b : t1, t2)` syntax.

### Lowering — virtual branch ops per target
Instruction selection previously **ignored** `br`/`cond_br` (result-less, no semantic expression), leaving builtin ops in the lowered machine IR. Now:
- Each target dialect gains virtual branch ops `vbr`/`vcond_br` (mirroring `vret`) that carry the successor block references and forwarded block arguments, deferring branch-target encoding to a later pass.
- An isel op-lowering rewrites `builtin.br`→`vbr` and `builtin.cond_br`→`vcond_br` (registered via `with_op_lowering`, the same mechanism used for `return`→`vret`).
- A shared `tir_be_common::print_branch` helper formats them so successor syntax isn't duplicated per target.

This is the op-lowering route (consistent with `return`→`vret`), chosen because builtin branches name blocks (`^bbN`) while target branches are PC-relative — the addresses aren't known until layout, so a pure e-graph match isn't possible pre-layout.

## Testing
- `cargo test -p tir --lib` — 137 passed (branch round-trips incl. asymmetric arg counts, terminator interface, i1 verification).
- `cargo test -p tir-riscv -p arm64 --lib` — passed, incl. new tests asserting `builtin.br`/`cond_br` lower to `vbr`/`vcond_br` with no builtin ops remaining (RISC-V and ARM64).
- `cargo fmt` + `cargo clippy` clean across core, macros, and the three backend crates.

## Notes / follow-ups
- Block-argument resolution to copies/phis at edges, and final branch-target encoding (label → PC-relative), remain follow-ups; the virtual ops carry the information those passes need.
- Pre-existing `tests/lit.rs` harness failure (missing `tir` binary) reproduces on clean `master`; unrelated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45dd8046-b420-4a1f-94e2-bdfe20768441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45dd8046-b420-4a1f-94e2-bdfe20768441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

