### PR TITLE
feat(core): parse and print multi-block CFG regions

### DIFF
--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -113,7 +113,7 @@ pub fn print_branch(
     }
     for attr in op.attributes() {
         if let AttributeValue::Block(block) = &attr.value {
-            fmt.write(format!(" ^bb{}", block.number()))?;
+            fmt.write(format!(" ^bb{}", fmt.region_block_number(*block)))?;
         }
     }
     fmt.write("\n")

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -75,10 +75,8 @@ fn parse_riscv_isa_string(march: &str) -> Option<TargetConfig> {
     let rest = march.strip_prefix("rv")?;
     let (xlen, rest) = if let Some(rest) = rest.strip_prefix("32") {
         (32, rest)
-    } else if let Some(rest) = rest.strip_prefix("64") {
-        (64, rest)
     } else {
-        return None;
+        (64, rest.strip_prefix("64")?)
     };
 
     let mut chars = rest.chars().peekable();

--- a/core/checks/IRRoundtrip/br-with-args.tir
+++ b/core/checks/IRRoundtrip/br-with-args.tir
@@ -2,8 +2,8 @@
 
 module {
   func @fwd(%0: !i32) -> !i32 {
-    br ^bb2(%0 : !i32)
-  ^bb2(%1: !i32):
+    br ^bb1(%0 : !i32)
+  ^bb1(%1: !i32):
     return %1
   }
   module_end
@@ -11,8 +11,8 @@ module {
 
 // CHECK: module {
 // CHECK-NEXT: func @fwd(%{{[0-9]+}}: !i32) -> !i32 {
-// CHECK-NEXT: br ^bb2(%{{[0-9]+}} : !i32)
-// CHECK-NEXT: ^bb2(%{{[0-9]+}}: !i32):
+// CHECK-NEXT: br ^bb1(%{{[0-9]+}} : !i32)
+// CHECK-NEXT: ^bb1(%{{[0-9]+}}: !i32):
 // CHECK-NEXT: return %{{[0-9]+}}
 // CHECK-NEXT: }
 // CHECK-NEXT: module_end

--- a/core/checks/IRRoundtrip/br-with-args.tir
+++ b/core/checks/IRRoundtrip/br-with-args.tir
@@ -1,0 +1,19 @@
+// RUN: tir opt %s | filecheck %s
+
+module {
+  func @fwd(%0: !i32) -> !i32 {
+    br ^bb2(%0 : !i32)
+  ^bb2(%1: !i32):
+    return %1
+  }
+  module_end
+}
+
+// CHECK: module {
+// CHECK-NEXT: func @fwd(%{{[0-9]+}}: !i32) -> !i32 {
+// CHECK-NEXT: br ^bb2(%{{[0-9]+}} : !i32)
+// CHECK-NEXT: ^bb2(%{{[0-9]+}}: !i32):
+// CHECK-NEXT: return %{{[0-9]+}}
+// CHECK-NEXT: }
+// CHECK-NEXT: module_end
+// CHECK-NEXT: }

--- a/core/checks/IRRoundtrip/br.tir
+++ b/core/checks/IRRoundtrip/br.tir
@@ -2,8 +2,8 @@
 
 module {
   func @jump() -> !i32 {
-    br ^bb2
-  ^bb2:
+    br ^bb1
+  ^bb1:
     %0 = constant {value = 42} : !i32
     return %0
   }
@@ -12,8 +12,8 @@ module {
 
 // CHECK: module {
 // CHECK-NEXT: func @jump() -> !i32 {
-// CHECK-NEXT: br ^bb2
-// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: br ^bb1
+// CHECK-NEXT: ^bb1:
 // CHECK-NEXT: %{{[0-9]+}} = constant {value = 42} : !i32
 // CHECK-NEXT: return %{{[0-9]+}}
 // CHECK-NEXT: }

--- a/core/checks/IRRoundtrip/br.tir
+++ b/core/checks/IRRoundtrip/br.tir
@@ -1,0 +1,21 @@
+// RUN: tir opt %s | filecheck %s
+
+module {
+  func @jump() -> !i32 {
+    br ^bb2
+  ^bb2:
+    %0 = constant {value = 42} : !i32
+    return %0
+  }
+  module_end
+}
+
+// CHECK: module {
+// CHECK-NEXT: func @jump() -> !i32 {
+// CHECK-NEXT: br ^bb2
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: %{{[0-9]+}} = constant {value = 42} : !i32
+// CHECK-NEXT: return %{{[0-9]+}}
+// CHECK-NEXT: }
+// CHECK-NEXT: module_end
+// CHECK-NEXT: }

--- a/core/checks/IRRoundtrip/cond-br.tir
+++ b/core/checks/IRRoundtrip/cond-br.tir
@@ -2,11 +2,11 @@
 
 module {
   func @select(%0: !i1) -> !i32 {
-    cond_br %0, ^bb2, ^bb3
-  ^bb2:
+    cond_br %0, ^bb1, ^bb2
+  ^bb1:
     %1 = constant {value = 1} : !i32
     return %1
-  ^bb3:
+  ^bb2:
     %2 = constant {value = 0} : !i32
     return %2
   }
@@ -15,11 +15,11 @@ module {
 
 // CHECK: module {
 // CHECK-NEXT: func @select(%{{[0-9]+}}: !i1) -> !i32 {
-// CHECK-NEXT: cond_br %{{[0-9]+}}, ^bb2, ^bb3
-// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: cond_br %{{[0-9]+}}, ^bb1, ^bb2
+// CHECK-NEXT: ^bb1:
 // CHECK-NEXT: %{{[0-9]+}} = constant {value = 1} : !i32
 // CHECK-NEXT: return %{{[0-9]+}}
-// CHECK-NEXT: ^bb3:
+// CHECK-NEXT: ^bb2:
 // CHECK-NEXT: %{{[0-9]+}} = constant {value = 0} : !i32
 // CHECK-NEXT: return %{{[0-9]+}}
 // CHECK-NEXT: }

--- a/core/checks/IRRoundtrip/cond-br.tir
+++ b/core/checks/IRRoundtrip/cond-br.tir
@@ -1,0 +1,27 @@
+// RUN: tir opt %s | filecheck %s
+
+module {
+  func @select(%0: !i1) -> !i32 {
+    cond_br %0, ^bb2, ^bb3
+  ^bb2:
+    %1 = constant {value = 1} : !i32
+    return %1
+  ^bb3:
+    %2 = constant {value = 0} : !i32
+    return %2
+  }
+  module_end
+}
+
+// CHECK: module {
+// CHECK-NEXT: func @select(%{{[0-9]+}}: !i1) -> !i32 {
+// CHECK-NEXT: cond_br %{{[0-9]+}}, ^bb2, ^bb3
+// CHECK-NEXT: ^bb2:
+// CHECK-NEXT: %{{[0-9]+}} = constant {value = 1} : !i32
+// CHECK-NEXT: return %{{[0-9]+}}
+// CHECK-NEXT: ^bb3:
+// CHECK-NEXT: %{{[0-9]+}} = constant {value = 0} : !i32
+// CHECK-NEXT: return %{{[0-9]+}}
+// CHECK-NEXT: }
+// CHECK-NEXT: module_end
+// CHECK-NEXT: }

--- a/core/src/attributes.rs
+++ b/core/src/attributes.rs
@@ -101,7 +101,9 @@ impl AttributeValue {
                 }
             },
             AttributeValue::Type(ty) => context.print_type(*ty, fmt),
-            AttributeValue::Block(block) => fmt.write(format!("^bb{}", block.number())),
+            AttributeValue::Block(block) => {
+                fmt.write(format!("^bb{}", fmt.region_block_number(*block)))
+            }
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -403,10 +403,31 @@ impl Context {
         block
     }
 
+    pub(crate) fn create_block_at(&self, id: BlockId, arguments: Vec<Value>) -> Arc<Block> {
+        let mut inner = self.0.write();
+
+        let next = inner
+            .last_block_id
+            .load(std::sync::atomic::Ordering::SeqCst)
+            .max(id.number() + 1);
+        inner
+            .last_block_id
+            .store(next, std::sync::atomic::Ordering::SeqCst);
+
+        let block = Arc::new(Block::new(id, arguments));
+        inner.blocks.insert(id, block.clone());
+
+        block
+    }
+
     pub fn get_block(&self, id: BlockId) -> Arc<Block> {
         let inner = self.0.read();
 
         inner.blocks.get(&id).unwrap().clone()
+    }
+
+    pub(crate) fn has_block(&self, id: BlockId) -> bool {
+        self.0.read().blocks.contains_key(&id)
     }
 
     pub fn get_region(&self, id: RegionId) -> Arc<Region> {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -403,31 +403,10 @@ impl Context {
         block
     }
 
-    pub(crate) fn create_block_at(&self, id: BlockId, arguments: Vec<Value>) -> Arc<Block> {
-        let mut inner = self.0.write();
-
-        let next = inner
-            .last_block_id
-            .load(std::sync::atomic::Ordering::SeqCst)
-            .max(id.number() + 1);
-        inner
-            .last_block_id
-            .store(next, std::sync::atomic::Ordering::SeqCst);
-
-        let block = Arc::new(Block::new(id, arguments));
-        inner.blocks.insert(id, block.clone());
-
-        block
-    }
-
     pub fn get_block(&self, id: BlockId) -> Arc<Block> {
         let inner = self.0.read();
 
         inner.blocks.get(&id).unwrap().clone()
-    }
-
-    pub(crate) fn has_block(&self, id: BlockId) -> bool {
-        self.0.read().blocks.contains_key(&id)
     }
 
     pub fn get_region(&self, id: RegionId) -> Arc<Region> {

--- a/core/src/dialects/builtin/control.rs
+++ b/core/src/dialects/builtin/control.rs
@@ -190,7 +190,7 @@ fn print_successor(
     block: BlockId,
     args: &[ValueId],
 ) -> Result<(), std::fmt::Error> {
-    fmt.write(format!("^bb{}", block.number()))?;
+    fmt.write(format!("^bb{}", fmt.region_block_number(block)))?;
     if args.is_empty() {
         return Ok(());
     }
@@ -215,8 +215,13 @@ fn parse_successor(
     parser: &mut tir::parse::text::Parser,
     context: &Context,
 ) -> Result<(BlockId, Vec<ValueId>), (tir::parse::Span, Error)> {
-    let block = parse_block_ref(parser)?;
+    use tir::parse::common::Cursor;
+    let index = parser
+        .parse_block_index()
+        .ok_or_else(|| (parser.span(), Error::ExpectedToken("^bb")))?;
+
     let mut args = vec![];
+    let mut arg_types = vec![];
     if parser.parse_token("(") {
         loop {
             args.push(parse_value_id(parser)?);
@@ -226,10 +231,8 @@ fn parse_successor(
             break;
         }
         expect_token(parser, ":")?;
-        // Argument types are carried by the values themselves; parse and discard
-        // them so the textual form round-trips.
         loop {
-            parse_arg_type(parser, context)?;
+            arg_types.push(parse_arg_type(parser, context)?);
             if parser.parse_token(",") {
                 continue;
             }
@@ -237,6 +240,8 @@ fn parse_successor(
         }
         expect_token(parser, ")")?;
     }
+
+    let block = parser.resolve_region_block_index(context, index, &arg_types)?;
     Ok((block, args))
 }
 
@@ -251,15 +256,6 @@ fn parse_value_id(
         .parse::<u32>()
         .map_err(|_| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))?;
     Ok(ValueId::from_number(id))
-}
-
-fn parse_block_ref(
-    parser: &mut tir::parse::text::Parser,
-) -> Result<BlockId, (tir::parse::Span, Error)> {
-    use tir::parse::common::Cursor;
-    parser
-        .parse_block_ref()
-        .ok_or_else(|| (parser.span(), Error::ExpectedToken("^bb")))
 }
 
 fn parse_arg_type(

--- a/core/src/dialects/builtin/func.rs
+++ b/core/src/dialects/builtin/func.rs
@@ -22,6 +22,29 @@ operation! {
     }
 }
 
+fn print_block_label(
+    fmt: &mut tir::IRFormatter,
+    context: &tir::Context,
+    block: &std::sync::Arc<tir::Block>,
+) -> Result<(), std::fmt::Error> {
+    let args = block.arguments();
+    if args.is_empty() {
+        fmt.writeln(format!("^bb{}:", block.id().number()))?;
+        return Ok(());
+    }
+
+    fmt.write(format!("^bb{}(", block.id().number()))?;
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            fmt.write(", ")?;
+        }
+        fmt.write(format!("%{}: ", arg.id().number()))?;
+        context.print_type(arg.ty(), fmt)?;
+    }
+    fmt.writeln("):")?;
+    Ok(())
+}
+
 impl FuncOpBuilder {
     pub fn sym_name(self, name: &str) -> Self {
         self.attr(
@@ -89,9 +112,17 @@ impl FuncOp {
         // Print body region
         fmt.writeln(" {")?;
         fmt.push();
-        for op in block.iter(context.clone()) {
-            let dyn_op = op.as_dyn_op();
-            dyn_op.print(fmt)?;
+        let region = self.regions().nth(0).unwrap();
+        let mut first = true;
+        for block in region.iter(context.clone()) {
+            if first {
+                first = false;
+            } else {
+                print_block_label(fmt, &context, &block)?;
+            }
+            for op in block.iter(context.clone()) {
+                op.as_dyn_op().print(fmt)?;
+            }
         }
         fmt.pop();
         fmt.writeln("}")?;
@@ -259,6 +290,103 @@ mod tests {
         let mut f = IRFormatter::new(&mut new_buf);
         new_func.print(&mut f).expect("print ok");
 
+        assert_eq!(buf, new_buf);
+    }
+
+    #[test]
+    fn parse_text_labeled_blocks() {
+        let context = Context::with_default_dialects();
+        let src = r#"  func @jump() -> !i32 {
+    br ^bb1
+  ^bb1:
+    %0 = constant {value = 42} : !i32
+    return %0
+  }"#;
+        let func = parse_ir::<FuncOp>(&context, src).expect("parse labeled blocks");
+        let region = func.regions().nth(0).unwrap();
+        assert_eq!(region.iter(context.clone()).len(), 2);
+        assert!(func.verify(&context).is_ok());
+
+        let mut buf = String::new();
+        let mut f = IRFormatter::new(&mut buf);
+        func.print(&mut f).expect("print ok");
+        assert!(buf.contains("^bb1:") || buf.contains("^bb"), "{buf}");
+    }
+
+    #[test]
+    fn multi_block_func_roundtrip() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+
+        let region = context.create_region();
+        let entry = context.create_block(vec![]);
+        let target = context.create_block(vec![]);
+        region.add_block(entry.id());
+        region.add_block(target.id());
+
+        let func = ops::func(&context, "jump", i32_ty, Some(region.id())).build();
+
+        let mut entry_b = IRBuilder::new(entry.clone());
+        entry_b.insert(ops::br(&context, vec![], target.id()).build());
+
+        let mut target_b = IRBuilder::new(target.clone());
+        let c = ops::constant(&context, 42, i32_ty).build();
+        let c_result = c.result();
+        target_b.insert(c);
+        target_b.insert(ops::r#return(&context, c_result).build());
+
+        let mut buf = String::new();
+        let mut f = IRFormatter::new(&mut buf);
+        func.print(&mut f).expect("print ok");
+        assert!(buf.contains("^bb"));
+        assert!(buf.contains("br ^bb"));
+
+        let new_context = Context::with_default_dialects();
+        let new_func = parse_ir::<FuncOp>(&new_context, &buf).expect("parse multi-block func");
+        assert!(new_func.verify(&new_context).is_ok());
+
+        let mut new_buf = String::new();
+        let mut f = IRFormatter::new(&mut new_buf);
+        new_func.print(&mut f).expect("print ok");
+        assert_eq!(buf, new_buf);
+    }
+
+    #[test]
+    fn multi_block_func_with_block_args_roundtrip() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let param = context.create_value(i32_ty, None);
+        let param_id = param.id();
+        let arg = context.create_value(i32_ty, None);
+        let arg_id = arg.id();
+
+        let region = context.create_region();
+        let entry = context.create_block(vec![param]);
+        let target = context.create_block(vec![arg]);
+        region.add_block(entry.id());
+        region.add_block(target.id());
+
+        let func = ops::func(&context, "fwd", i32_ty, Some(region.id())).build();
+
+        let mut entry_b = IRBuilder::new(entry.clone());
+        entry_b.insert(ops::br(&context, vec![param_id], target.id()).build());
+
+        let mut target_b = IRBuilder::new(target.clone());
+        target_b.insert(ops::r#return(&context, arg_id).build());
+
+        let mut buf = String::new();
+        let mut f = IRFormatter::new(&mut buf);
+        func.print(&mut f).expect("print ok");
+        assert!(buf.contains("br ^bb"));
+        assert!(buf.contains("):"));
+
+        let new_context = Context::with_default_dialects();
+        let new_func = parse_ir::<FuncOp>(&new_context, &buf).expect("parse func with block args");
+        assert!(new_func.verify(&new_context).is_ok());
+
+        let mut new_buf = String::new();
+        let mut f = IRFormatter::new(&mut new_buf);
+        new_func.print(&mut f).expect("print ok");
         assert_eq!(buf, new_buf);
     }
 

--- a/core/src/dialects/builtin/func.rs
+++ b/core/src/dialects/builtin/func.rs
@@ -112,7 +112,7 @@ impl FuncOp {
         // Print body region
         fmt.writeln(" {")?;
         fmt.push();
-        let region = self.regions().nth(0).unwrap();
+        let region = self.regions().next().unwrap();
         let mut first = true;
         for block in region.iter(context.clone()) {
             if first {
@@ -303,7 +303,7 @@ mod tests {
     return %0
   }"#;
         let func = parse_ir::<FuncOp>(&context, src).expect("parse labeled blocks");
-        let region = func.regions().nth(0).unwrap();
+        let region = func.regions().next().unwrap();
         assert_eq!(region.iter(context.clone()).len(), 2);
         assert!(func.verify(&context).is_ok());
 

--- a/core/src/dialects/builtin/func.rs
+++ b/core/src/dialects/builtin/func.rs
@@ -22,29 +22,6 @@ operation! {
     }
 }
 
-fn print_block_label(
-    fmt: &mut tir::IRFormatter,
-    context: &tir::Context,
-    block: &std::sync::Arc<tir::Block>,
-) -> Result<(), std::fmt::Error> {
-    let args = block.arguments();
-    if args.is_empty() {
-        fmt.writeln(format!("^bb{}:", block.id().number()))?;
-        return Ok(());
-    }
-
-    fmt.write(format!("^bb{}(", block.id().number()))?;
-    for (i, arg) in args.iter().enumerate() {
-        if i > 0 {
-            fmt.write(", ")?;
-        }
-        fmt.write(format!("%{}: ", arg.id().number()))?;
-        context.print_type(arg.ty(), fmt)?;
-    }
-    fmt.writeln("):")?;
-    Ok(())
-}
-
 impl FuncOpBuilder {
     pub fn sym_name(self, name: &str) -> Self {
         self.attr(
@@ -109,23 +86,7 @@ impl FuncOp {
             context.print_type(ret_type, fmt)?;
         }
 
-        // Print body region
-        fmt.writeln(" {")?;
-        fmt.push();
-        let region = self.regions().next().unwrap();
-        let mut first = true;
-        for block in region.iter(context.clone()) {
-            if first {
-                first = false;
-            } else {
-                print_block_label(fmt, &context, &block)?;
-            }
-            for op in block.iter(context.clone()) {
-                op.as_dyn_op().print(fmt)?;
-            }
-        }
-        fmt.pop();
-        fmt.writeln("}")?;
+        tir::region_format::print_op_region(fmt, &context, self, 0)?;
 
         Ok(())
     }
@@ -187,7 +148,7 @@ impl FuncOp {
         };
 
         // Parse body region { ... }
-        let body_region = parser.parse_single_block_region_with_args(context, block_args)?;
+        let body_region = parser.parse_region_with_entry_args(context, block_args)?;
 
         let builder = FuncOpBuilder::new(context)
             .sym_name(&sym_name)

--- a/core/src/dialects/builtin/module.rs
+++ b/core/src/dialects/builtin/module.rs
@@ -55,7 +55,7 @@ mod tests {
             .unwrap()
             .as_op::<FuncOp>()
             .expect("func op");
-        let region = func.regions().nth(0).unwrap();
+        let region = func.regions().next().unwrap();
         assert_eq!(region.iter(context.clone()).len(), 2);
         assert!(module.verify(&context).is_ok());
     }

--- a/core/src/dialects/builtin/module.rs
+++ b/core/src/dialects/builtin/module.rs
@@ -34,6 +34,33 @@ mod tests {
     };
 
     #[test]
+    fn module_parses_labeled_func_blocks() {
+        use crate::builtin::FuncOp;
+
+        let context = Context::with_default_dialects();
+        let src = r#"module {
+  func @jump() -> !i32 {
+    br ^bb2
+  ^bb2:
+    %0 = constant {value = 42} : !i32
+    return %0
+  }
+  module_end
+}"#;
+        let module = parse_ir::<ModuleOp>(&context, src).expect("parse module");
+        let func = module
+            .body()
+            .iter(context.clone())
+            .next()
+            .unwrap()
+            .as_op::<FuncOp>()
+            .expect("func op");
+        let region = func.regions().nth(0).unwrap();
+        assert_eq!(region.iter(context.clone()).len(), 2);
+        assert!(module.verify(&context).is_ok());
+    }
+
+    #[test]
     fn module_creation() {
         let context = Context::with_default_dialects();
         let m = ops::module(&context, None).build();

--- a/core/src/dialects/builtin/module.rs
+++ b/core/src/dialects/builtin/module.rs
@@ -40,8 +40,8 @@ mod tests {
         let context = Context::with_default_dialects();
         let src = r#"module {
   func @jump() -> !i32 {
-    br ^bb2
-  ^bb2:
+    br ^bb1
+  ^bb1:
     %0 = constant {value = 42} : !i32
     return %0
   }

--- a/core/src/dialects/scf/mod.rs
+++ b/core/src/dialects/scf/mod.rs
@@ -57,7 +57,7 @@ impl ForOp {
             self.operands()[1].number(),
             self.operands()[2].number()
         ))?;
-        print_block_region(fmt, &self.0.context.upgrade(), self.body())
+        tir::region_format::print_op_region(fmt, &self.0.context.upgrade(), self, 0)
     }
 
     fn custom_parse(
@@ -69,7 +69,7 @@ impl ForOp {
         let upper_bound = parse_value_id(parser)?;
         expect_token(parser, ",")?;
         let step = parse_value_id(parser)?;
-        let body = parser.parse_single_block_region(context)?.id();
+        let body = parser.parse_region(context)?.id();
 
         Ok(Box::new(
             ForOpBuilder::new(context)
@@ -113,7 +113,7 @@ impl WhileOp {
 
     fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
         fmt.write(format!("scf.while %{}", self.condition().number()))?;
-        print_block_region(fmt, &self.0.context.upgrade(), self.body())
+        tir::region_format::print_op_region(fmt, &self.0.context.upgrade(), self, 0)
     }
 
     fn custom_parse(
@@ -121,7 +121,7 @@ impl WhileOp {
         context: &Context,
     ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
         let condition = parse_value_id(parser)?;
-        let body = parser.parse_single_block_region(context)?.id();
+        let body = parser.parse_region(context)?.id();
         Ok(Box::new(
             WhileOpBuilder::new(context)
                 .condition(condition)
@@ -166,9 +166,10 @@ impl IfOp {
 
     fn custom_print(&self, fmt: &mut tir::IRFormatter) -> Result<(), std::fmt::Error> {
         fmt.write(format!("scf.if %{}", self.condition().number()))?;
-        print_block_region(fmt, &self.0.context.upgrade(), self.then_body())?;
+        let context = self.0.context.upgrade();
+        tir::region_format::print_op_region(fmt, &context, self, 0)?;
         fmt.write(" else")?;
-        print_block_region(fmt, &self.0.context.upgrade(), self.else_body())
+        tir::region_format::print_op_region(fmt, &context, self, 1)
     }
 
     fn custom_parse(
@@ -176,9 +177,9 @@ impl IfOp {
         context: &Context,
     ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
         let condition = parse_value_id(parser)?;
-        let then_body = parser.parse_single_block_region(context)?.id();
+        let then_body = parser.parse_region(context)?.id();
         expect_token(parser, "else")?;
-        let else_body = parser.parse_single_block_region(context)?.id();
+        let else_body = parser.parse_region(context)?.id();
 
         Ok(Box::new(
             IfOpBuilder::new(context)
@@ -224,20 +225,6 @@ fn expect_token(
     } else {
         Err((parser.span(), Error::ExpectedToken(token)))
     }
-}
-
-fn print_block_region(
-    fmt: &mut tir::IRFormatter,
-    context: &Context,
-    block: Arc<tir::Block>,
-) -> Result<(), std::fmt::Error> {
-    fmt.writeln(" {")?;
-    fmt.push();
-    for op in block.iter(context.clone()) {
-        op.as_dyn_op().print(fmt)?;
-    }
-    fmt.pop();
-    fmt.writeln("}")
 }
 
 fn verify_i1_operand(context: &Context, value: ValueId, label: &str) -> Result<(), Error> {

--- a/core/src/ir_formatter.rs
+++ b/core/src/ir_formatter.rs
@@ -1,9 +1,13 @@
+use std::collections::HashMap;
 use std::fmt::Write;
+
+use crate::BlockId;
 
 pub struct IRFormatter<'a> {
     w: &'a mut dyn Write,
     padding: u8,
     new_line: bool,
+    region_block_numbers: Vec<HashMap<BlockId, u32>>,
 }
 
 impl<'a> IRFormatter<'a> {
@@ -12,7 +16,23 @@ impl<'a> IRFormatter<'a> {
             w,
             padding: 0,
             new_line: true,
+            region_block_numbers: vec![],
         }
+    }
+
+    pub fn push_region_block_numbers(&mut self, numbers: HashMap<BlockId, u32>) {
+        self.region_block_numbers.push(numbers);
+    }
+
+    pub fn pop_region_block_numbers(&mut self) {
+        self.region_block_numbers.pop();
+    }
+
+    pub fn region_block_number(&self, block: BlockId) -> u32 {
+        self.region_block_numbers
+            .last()
+            .and_then(|numbers| numbers.get(&block).copied())
+            .unwrap_or_else(|| block.number())
     }
 
     pub fn push(&mut self) {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,7 @@ mod pass;
 pub mod passes;
 pub mod pbqp;
 mod region;
+pub mod region_format;
 pub mod sem_expr;
 mod ty;
 pub mod utils;

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -2,11 +2,15 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::value::ValueId;
-use crate::{Context, Error, Operation, Region};
+use crate::block::BlockId;
+use crate::value::{Value, ValueId};
+use crate::{Block, Context, Error, Operation, Region};
 
 use super::common::{Cursor, Span};
 use super::text::Parser as TextParser;
+
+type ParseResult<T> = Result<T, (Span, Error)>;
+type BlockLabel = (u32, Vec<Value>);
 
 pub fn parse_ir<T: Operation>(context: &Context, src: &str) -> Result<T, (Span, Error)> {
     let mut parser = TextParser::new(src);
@@ -84,30 +88,147 @@ impl<'src> TextParser<'src> {
     pub fn parse_single_block_region_with_args(
         &mut self,
         context: &Context,
-        block_args: Vec<crate::Value>,
+        block_args: Vec<Value>,
+    ) -> Result<Arc<Region>, (Span, Error)> {
+        self.parse_block_region_with_entry_args(context, block_args)
+    }
+
+    pub fn parse_block_region_with_entry_args(
+        &mut self,
+        context: &Context,
+        entry_args: Vec<Value>,
     ) -> Result<Arc<Region>, (Span, Error)> {
         if !self.parse_token("{") {
             return Err((self.span(), Error::ExpectedToken("{")));
         }
 
-        let mut ops = vec![];
-
-        // FIXME: this is not very error resilient
-        while let Ok(op) = parse_single_op(self, context) {
-            ops.push(op.id());
-        }
-
-        if !self.parse_token("}") {
-            return Err((self.span(), Error::ExpectedToken("}")));
-        }
-
         let region = context.create_region();
-        let block = context.create_block(block_args);
-        region.add_block(block.id());
-        for (idx, id) in ops.iter().enumerate() {
-            block.insert(idx, *id);
+        let entry = context.create_block(entry_args);
+        region.add_block(entry.id());
+
+        let mut current = entry.clone();
+        let mut labeled = HashMap::new();
+
+        loop {
+            self.skip_trivia();
+            if self.parse_token("}") {
+                break;
+            }
+
+            if let Some((block_num, block_args)) = self.try_parse_block_label(context)? {
+                current = self.get_or_create_labeled_block(
+                    context,
+                    &region,
+                    block_num,
+                    block_args,
+                    &mut labeled,
+                )?;
+                continue;
+            }
+
+            let op = parse_single_op(self, context)?;
+            current.insert(current.len(), op.id());
         }
 
         Ok(region)
+    }
+
+    fn try_parse_block_label(
+        &mut self,
+        context: &Context,
+    ) -> ParseResult<Option<BlockLabel>> {
+        let mark = self.pos();
+        let Some(block) = self.parse_block_ref() else {
+            return Ok(None);
+        };
+
+        let block_args = if self.parse_token("(") {
+            self.parse_block_argument_list(context)?
+        } else {
+            vec![]
+        };
+
+        if !self.parse_token(":") {
+            self.set_pos(mark);
+            return Ok(None);
+        }
+
+        Ok(Some((block.number(), block_args)))
+    }
+
+    fn parse_block_argument_list(
+        &mut self,
+        context: &Context,
+    ) -> Result<Vec<Value>, (Span, Error)> {
+        let mut args = vec![];
+
+        loop {
+            if self.parse_token(")") {
+                return Ok(args);
+            }
+
+            let _val_name = self
+                .parse_value_ref()
+                .ok_or_else(|| (self.span(), Error::ExpectedValueRef))?;
+
+            if !self.parse_token(":") {
+                return Err((self.span(), Error::ExpectedToken(":")));
+            }
+
+            let ty = self
+                .parse_type(context)?
+                .ok_or_else(|| (self.span(), Error::ExpectedType))?;
+            args.push(context.create_value(ty, None));
+
+            if self.parse_token(")") {
+                return Ok(args);
+            }
+            if !self.parse_token(",") {
+                return Err((self.span(), Error::ExpectedToken(",")));
+            }
+        }
+    }
+
+    fn get_or_create_labeled_block(
+        &mut self,
+        context: &Context,
+        region: &Arc<Region>,
+        block_num: u32,
+        block_args: Vec<Value>,
+        labeled: &mut HashMap<u32, BlockId>,
+    ) -> Result<Arc<Block>, (Span, Error)> {
+        if let Some(id) = labeled.get(&block_num) {
+            let block = context.get_block(*id);
+            if !block_args.is_empty() && block.arguments().is_empty() {
+                return Err((
+                    self.span(),
+                    Error::VerificationError(format!(
+                        "block ^bb{block_num} was already referenced without arguments"
+                    )),
+                ));
+            }
+            return Ok(block);
+        }
+
+        let id = BlockId::from_number(block_num);
+        let block = if context.has_block(id) {
+            let existing = context.get_block(id);
+            if !block_args.is_empty() && existing.arguments().is_empty() {
+                return Err((
+                    self.span(),
+                    Error::VerificationError(format!(
+                        "block ^bb{block_num} was already created without arguments"
+                    )),
+                ));
+            }
+            existing
+        } else {
+            context.create_block_at(id, block_args)
+        };
+        if !region.iter(context.clone()).any(|b| b.id() == block.id()) {
+            region.add_block(block.id());
+        }
+        labeled.insert(block_num, block.id());
+        Ok(block)
     }
 }

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -78,22 +78,11 @@ impl ValueScope {
 }
 
 impl<'src> TextParser<'src> {
-    pub fn parse_single_block_region(
-        &mut self,
-        context: &Context,
-    ) -> Result<Arc<Region>, (Span, Error)> {
-        self.parse_single_block_region_with_args(context, vec![])
+    pub fn parse_region(&mut self, context: &Context) -> Result<Arc<Region>, (Span, Error)> {
+        self.parse_region_with_entry_args(context, vec![])
     }
 
-    pub fn parse_single_block_region_with_args(
-        &mut self,
-        context: &Context,
-        block_args: Vec<Value>,
-    ) -> Result<Arc<Region>, (Span, Error)> {
-        self.parse_block_region_with_entry_args(context, block_args)
-    }
-
-    pub fn parse_block_region_with_entry_args(
+    pub fn parse_region_with_entry_args(
         &mut self,
         context: &Context,
         entry_args: Vec<Value>,

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -133,10 +133,7 @@ impl<'src> TextParser<'src> {
         Ok(region)
     }
 
-    fn try_parse_block_label(
-        &mut self,
-        context: &Context,
-    ) -> ParseResult<Option<BlockLabel>> {
+    fn try_parse_block_label(&mut self, context: &Context) -> ParseResult<Option<BlockLabel>> {
         let mark = self.pos();
         let Some(block) = self.parse_block_ref() else {
             return Ok(None);

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -96,35 +96,83 @@ impl<'src> TextParser<'src> {
         region.add_block(entry.id());
 
         let mut current = entry.clone();
-        let mut labeled = HashMap::new();
+        self.region_parse = Some(super::text::RegionParseState {
+            region: region.clone(),
+            indices: HashMap::from([(0, entry.id())]),
+        });
 
+        let result = self.parse_region_body(context, &region, &mut current);
+        self.region_parse = None;
+        result?;
+        Ok(region)
+    }
+
+    fn parse_region_body(
+        &mut self,
+        context: &Context,
+        region: &Arc<Region>,
+        current: &mut Arc<Block>,
+    ) -> ParseResult<()> {
         loop {
             self.skip_trivia();
             if self.parse_token("}") {
-                break;
+                return Ok(());
             }
 
-            if let Some((block_num, block_args)) = self.try_parse_block_label(context)? {
-                current = self.get_or_create_labeled_block(
-                    context,
-                    &region,
-                    block_num,
-                    block_args,
-                    &mut labeled,
-                )?;
+            if let Some((block_index, block_args)) = self.try_parse_block_label(context)? {
+                *current = self.block_at_region_index(context, region, block_index, block_args)?;
                 continue;
             }
 
             let op = parse_single_op(self, context)?;
             current.insert(current.len(), op.id());
         }
+    }
 
-        Ok(region)
+    pub(crate) fn resolve_region_block_index(
+        &mut self,
+        context: &Context,
+        index: u32,
+        block_arg_types: &[crate::TypeId],
+    ) -> Result<BlockId, (Span, Error)> {
+        let Some(state) = &mut self.region_parse else {
+            return Ok(BlockId::from_number(index));
+        };
+
+        if let Some(id) = state.indices.get(&index) {
+            let block = context.get_block(*id);
+            if !block_arg_types.is_empty() && block.arguments().is_empty() {
+                return Err((
+                    self.span(),
+                    Error::VerificationError(format!(
+                        "block ^bb{index} was already referenced without arguments"
+                    )),
+                ));
+            }
+            return Ok(*id);
+        }
+
+        let len = state.region.iter(context.clone()).len();
+        if index as usize != len {
+            return Err((
+                self.span(),
+                Error::VerificationError(format!("block ^bb{index} is not defined in this region")),
+            ));
+        }
+
+        let block_args = block_arg_types
+            .iter()
+            .map(|ty| context.create_value(*ty, None))
+            .collect();
+        let block = context.create_block(block_args);
+        state.region.add_block(block.id());
+        state.indices.insert(index, block.id());
+        Ok(block.id())
     }
 
     fn try_parse_block_label(&mut self, context: &Context) -> ParseResult<Option<BlockLabel>> {
         let mark = self.pos();
-        let Some(block) = self.parse_block_ref() else {
+        let Some(block_index) = self.parse_block_index() else {
             return Ok(None);
         };
 
@@ -139,7 +187,7 @@ impl<'src> TextParser<'src> {
             return Ok(None);
         }
 
-        Ok(Some((block.number(), block_args)))
+        Ok(Some((block_index, block_args)))
     }
 
     fn parse_block_argument_list(
@@ -175,46 +223,42 @@ impl<'src> TextParser<'src> {
         }
     }
 
-    fn get_or_create_labeled_block(
+    fn block_at_region_index(
         &mut self,
         context: &Context,
         region: &Arc<Region>,
-        block_num: u32,
+        index: u32,
         block_args: Vec<Value>,
-        labeled: &mut HashMap<u32, BlockId>,
     ) -> Result<Arc<Block>, (Span, Error)> {
-        if let Some(id) = labeled.get(&block_num) {
+        let state = self
+            .region_parse
+            .as_mut()
+            .expect("block labels require an active region parse scope");
+
+        if let Some(id) = state.indices.get(&index) {
             let block = context.get_block(*id);
             if !block_args.is_empty() && block.arguments().is_empty() {
                 return Err((
                     self.span(),
                     Error::VerificationError(format!(
-                        "block ^bb{block_num} was already referenced without arguments"
+                        "block ^bb{index} was already referenced without arguments"
                     )),
                 ));
             }
             return Ok(block);
         }
 
-        let id = BlockId::from_number(block_num);
-        let block = if context.has_block(id) {
-            let existing = context.get_block(id);
-            if !block_args.is_empty() && existing.arguments().is_empty() {
-                return Err((
-                    self.span(),
-                    Error::VerificationError(format!(
-                        "block ^bb{block_num} was already created without arguments"
-                    )),
-                ));
-            }
-            existing
-        } else {
-            context.create_block_at(id, block_args)
-        };
-        if !region.iter(context.clone()).any(|b| b.id() == block.id()) {
-            region.add_block(block.id());
+        let len = region.iter(context.clone()).len();
+        if index as usize != len {
+            return Err((
+                self.span(),
+                Error::VerificationError(format!("block ^bb{index} is not defined in this region")),
+            ));
         }
-        labeled.insert(block_num, block.id());
+
+        let block = context.create_block(block_args);
+        region.add_block(block.id());
+        state.indices.insert(index, block.id());
         Ok(block)
     }
 }

--- a/core/src/parse/text.rs
+++ b/core/src/parse/text.rs
@@ -1,13 +1,28 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::Region;
+use crate::block::BlockId;
 use crate::parse::common::{Cursor, Span};
+
+pub(crate) struct RegionParseState {
+    pub region: Arc<Region>,
+    pub indices: HashMap<u32, BlockId>,
+}
 
 pub struct Parser<'src> {
     src: &'src str,
     position: u32,
+    pub(crate) region_parse: Option<RegionParseState>,
 }
 
 impl<'src> Parser<'src> {
     pub fn new(src: &'src str) -> Self {
-        Self { src, position: 0 }
+        Self {
+            src,
+            position: 0,
+            region_parse: None,
+        }
     }
 
     pub fn peek_char(&self) -> Option<char> {
@@ -162,20 +177,25 @@ impl<'src> Parser<'src> {
         }
     }
 
-    /// Parse a basic block reference of the form `^bb<number>` (e.g. `^bb2`),
-    /// returning the referenced [`BlockId`](crate::BlockId).
-    pub fn parse_block_ref(&mut self) -> Option<crate::BlockId> {
+    /// Parse the region-local index in a `^bb<number>` reference.
+    pub fn parse_block_index(&mut self) -> Option<u32> {
         let mark = self.position;
         if !self.parse_token("^bb") {
             return None;
         }
         match self.parse_number() {
-            Some(n) if n >= 0 => Some(crate::BlockId::from_number(n as u32)),
+            Some(n) if n >= 0 => Some(n as u32),
             _ => {
                 self.position = mark;
                 None
             }
         }
+    }
+
+    /// Parse a `^bb<number>` reference, returning a [`BlockId`](crate::BlockId)
+    /// without applying any active region parse scope.
+    pub fn parse_block_ref(&mut self) -> Option<BlockId> {
+        self.parse_block_index().map(BlockId::from_number)
     }
 
     pub fn parse_symbol_name(&mut self) -> Option<&'src str> {

--- a/core/src/passes/mem2reg.rs
+++ b/core/src/passes/mem2reg.rs
@@ -277,8 +277,7 @@ mod tests {
     }
 
     /// A store in the entry block dominates a load in a successor block, so the
-    /// value is forwarded across the branch. The `FuncOp` printer only shows the
-    /// entry block, so these multi-block cases inspect the IR directly.
+    /// value is forwarded across the branch.
     #[test]
     fn promotes_across_unstructured_branch() {
         let context = Context::with_default_dialects();

--- a/core/src/region_format.rs
+++ b/core/src/region_format.rs
@@ -1,19 +1,32 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{Block, Context, IRFormatter, Operation, Region};
+
+pub fn region_block_numbers(
+    region: &Arc<Region>,
+    context: &Context,
+) -> HashMap<crate::BlockId, u32> {
+    region
+        .iter(context.clone())
+        .enumerate()
+        .map(|(index, block)| (block.id(), index as u32))
+        .collect()
+}
 
 pub fn print_block_label(
     fmt: &mut IRFormatter,
     context: &Context,
     block: &Arc<Block>,
+    index: u32,
 ) -> Result<(), std::fmt::Error> {
     let args = block.arguments();
     if args.is_empty() {
-        fmt.writeln(format!("^bb{}:", block.id().number()))?;
+        fmt.writeln(format!("^bb{index}:"))?;
         return Ok(());
     }
 
-    fmt.write(format!("^bb{}(", block.id().number()))?;
+    fmt.write(format!("^bb{index}("))?;
     for (i, arg) in args.iter().enumerate() {
         if i > 0 {
             fmt.write(", ")?;
@@ -30,14 +43,13 @@ pub fn print_region(
     context: &Context,
     region: &Arc<Region>,
 ) -> Result<(), std::fmt::Error> {
+    let numbers = region_block_numbers(region, context);
+    fmt.push_region_block_numbers(numbers);
     fmt.writeln(" {")?;
     fmt.push();
-    let mut first = true;
-    for block in region.iter(context.clone()) {
-        if first {
-            first = false;
-        } else {
-            print_block_label(fmt, context, &block)?;
+    for (index, block) in region.iter(context.clone()).enumerate() {
+        if index > 0 {
+            print_block_label(fmt, context, &block, index as u32)?;
         }
         for op in block.iter(context.clone()) {
             op.as_dyn_op().print(fmt)?;
@@ -45,6 +57,7 @@ pub fn print_region(
     }
     fmt.pop();
     fmt.writeln("}")?;
+    fmt.pop_region_block_numbers();
     Ok(())
 }
 

--- a/core/src/region_format.rs
+++ b/core/src/region_format.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use crate::{Block, Context, IRFormatter, Operation, Region};
+
+pub fn print_block_label(
+    fmt: &mut IRFormatter,
+    context: &Context,
+    block: &Arc<Block>,
+) -> Result<(), std::fmt::Error> {
+    let args = block.arguments();
+    if args.is_empty() {
+        fmt.writeln(format!("^bb{}:", block.id().number()))?;
+        return Ok(());
+    }
+
+    fmt.write(format!("^bb{}(", block.id().number()))?;
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            fmt.write(", ")?;
+        }
+        fmt.write(format!("%{}: ", arg.id().number()))?;
+        context.print_type(arg.ty(), fmt)?;
+    }
+    fmt.writeln("):")?;
+    Ok(())
+}
+
+pub fn print_region(
+    fmt: &mut IRFormatter,
+    context: &Context,
+    region: &Arc<Region>,
+) -> Result<(), std::fmt::Error> {
+    fmt.writeln(" {")?;
+    fmt.push();
+    let mut first = true;
+    for block in region.iter(context.clone()) {
+        if first {
+            first = false;
+        } else {
+            print_block_label(fmt, context, &block)?;
+        }
+        for op in block.iter(context.clone()) {
+            op.as_dyn_op().print(fmt)?;
+        }
+    }
+    fmt.pop();
+    fmt.writeln("}")?;
+    Ok(())
+}
+
+pub fn print_op_region(
+    fmt: &mut IRFormatter,
+    context: &Context,
+    op: &impl Operation,
+    index: usize,
+) -> Result<(), std::fmt::Error> {
+    let region = op.regions().nth(index).unwrap();
+    print_region(fmt, context, &region)
+}

--- a/tmdl/src/sema.rs
+++ b/tmdl/src/sema.rs
@@ -503,7 +503,7 @@ fn check_template_parents(
                         current.span,
                         format!(
                             "Unknown parent template '{}' for template '{}'",
-                            parent_name, &current.name
+                            parent_name, current.name
                         ),
                     ),
                 ));

--- a/tools/src/opt/mod.rs
+++ b/tools/src/opt/mod.rs
@@ -27,15 +27,17 @@ pub fn run(args: ToolArgs) -> Result<(), Box<dyn Error>> {
     let module = tir::parse::ir::parse_ir::<ModuleOp>(&context, &input)
         .map_err(|(span, err)| format!("failed to parse input at byte {}: {err:?}", span.0))?;
 
-    let pipeline = args.passes.join(",");
-    let mut pm = tir::parse_pipeline(&pipeline).map_err(|e| {
-        format!(
-            "{e} (available passes: {})",
-            tir::registered_passes().join(", ")
-        )
-    })?;
-    pm.run(&context, context.get_op(module.id()))
-        .map_err(|e| format!("pass pipeline failed: {e}"))?;
+    if !args.passes.is_empty() {
+        let pipeline = args.passes.join(",");
+        let mut pm = tir::parse_pipeline(&pipeline).map_err(|e| {
+            format!(
+                "{e} (available passes: {})",
+                tir::registered_passes().join(", ")
+            )
+        })?;
+        pm.run(&context, context.get_op(module.id()))
+            .map_err(|e| format!("pass pipeline failed: {e}"))?;
+    }
 
     let mut rendered = String::new();
     let mut fmt = IRFormatter::new(&mut rendered);

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1557,7 +1557,7 @@ fn make_generic_printer(
     };
 
     let regions = if regions.len() == 1 && regions[0].single_block {
-        make_single_block_region_printer(&regions[0])
+        make_single_block_region_printer(&regions[0], 0)
     } else {
         quote! {}
     };
@@ -1596,18 +1596,13 @@ fn make_generic_printer(
     }
 }
 
-fn make_single_block_region_printer(region: &Region) -> proc_macro2::TokenStream {
-    let name = format_ident!("{}", region.name);
+fn make_single_block_region_printer(region: &Region, index: usize) -> proc_macro2::TokenStream {
+    let _ = region;
     quote! {
-        fmt.writeln(" {")?;
-        let context = self.0.context.upgrade();
-        fmt.push();
-        for op in self.#name().iter(context.clone()) {
-            let dyn_op = op.as_dyn_op();
-            dyn_op.print(fmt)?;
+        {
+            let context = self.0.context.upgrade();
+            tir::region_format::print_op_region(fmt, &context, self, #index)?;
         }
-        fmt.pop();
-        fmt.writeln("}")?;
     }
 }
 
@@ -1621,7 +1616,7 @@ fn make_parser(
         let region_name = format_ident!("{}", regions[0].name);
         (
             quote! {
-               let #region_name = parser.parse_single_block_region(context)?.id();
+               let #region_name = parser.parse_region(context)?.id();
             },
             quote! {
                 .#region_name(#region_name)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add shared `region_format` helpers for multi-block region print/parse
- Block labels and branch successors use **region-local indices** (`^bb0` = entry, `^bb1` = first successor, etc.)
- `IRFormatter` pushes a per-region block numbering scope while printing
- Parser resolves `^bbN` against the region currently being parsed; forward branch refs with argument types pre-create the target block

## Changes

- **`region_format`**: `print_region`, `print_op_region`, region-local label printing
- **`parse_region`**: region parse scope maps local indices to `BlockId`s
- **LIT tests** updated to use `^bb1`/`^bb2` within function bodies (no longer offset by parent module blocks)
- Removed unused `create_block_at` / `has_block` context helpers

## Tests

- Unit tests for multi-block func roundtrip
- LIT roundtrip tests in `core/checks/IRRoundtrip/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0a7269b-976a-4454-96bf-35f9f9c440fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0a7269b-976a-4454-96bf-35f9f9c440fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

