### PR TITLE
feat(isasim): Konata pipeline log via --konata

### DIFF
--- a/simulator/isasim/checks/riscv/exec/konata.S
+++ b/simulator/isasim/checks/riscv/exec/konata.S
@@ -1,0 +1,24 @@
+# RUN: isasim --march=riscv64 --entry=_start --until-pc=done --timing --machine=rv64-ooo --konata - %s | filecheck %s
+
+# The Konata pipeline log labels every traced instruction with its PC and
+# disassembly (L command) and walks it through dispatch (D), execute (X), and
+# retire (R) in a single forward-moving cycle domain.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  addi x1, x0, 5
+  addi x2, x0, 7
+  add  x3, x1, x2
+
+# CHECK: Kanata{{\t}}0004
+# CHECK-NEXT: C={{\t}}0
+# CHECK-NEXT: I{{\t}}0{{\t}}0{{\t}}0
+# CHECK-NEXT: L{{\t}}0{{\t}}0{{\t}}0x80000000: addi x1, x0, 5
+# CHECK-NEXT: S{{\t}}0{{\t}}0{{\t}}D
+# CHECK-NEXT: S{{\t}}0{{\t}}0{{\t}}X
+# CHECK: L{{\t}}1{{\t}}0{{\t}}0x80000004: addi x2, x0, 7
+# CHECK: L{{\t}}2{{\t}}0{{\t}}0x80000008: add x3, x1, x2
+# CHECK: R{{\t}}2{{\t}}2{{\t}}0
+# CHECK: timing[OutOfOrderCore / btfn]: 3 instructions

--- a/simulator/isasim/src/konata.rs
+++ b/simulator/isasim/src/konata.rs
@@ -1,0 +1,124 @@
+//! Pipeline log in the Kanata format (version 0004) consumed by the Konata
+//! viewer (<https://github.com/shioyadan/Konata>). The handler buffers the
+//! per-instruction dispatch/issue/retire cycles emitted by the scoreboard and
+//! renders them as cycle-ordered commands: each instruction is introduced
+//! (`I`) and labeled (`L`, with its PC and disassembly) when dispatched,
+//! occupies a `D` (dispatched, waiting to issue) and then `X` (executing)
+//! stage, and retires (`R`) in program order.
+
+use std::fmt::Write;
+
+use tir_sim::scoreboard::{EventHandler, SimContext};
+
+pub struct KonataView {
+    /// Per-instruction `L` text: PC and disassembly, in trace order.
+    labels: Vec<String>,
+    dispatch: Vec<u64>,
+    issue: Vec<u64>,
+    retire: Vec<u64>,
+}
+
+impl KonataView {
+    pub fn new(labels: Vec<String>) -> Self {
+        let n = labels.len();
+        KonataView {
+            labels,
+            dispatch: vec![0; n],
+            issue: vec![0; n],
+            retire: vec![0; n],
+        }
+    }
+}
+
+impl EventHandler for KonataView {
+    fn start(&mut self, ctx: &SimContext) {
+        assert_eq!(
+            ctx.base.len() * ctx.iterations,
+            self.labels.len(),
+            "one label per trace instruction"
+        );
+    }
+
+    fn dispatched(&mut self, cycle: u64, i: usize) {
+        self.dispatch[i] = cycle;
+    }
+
+    fn issued(&mut self, cycle: u64, i: usize) {
+        self.issue[i] = cycle;
+    }
+
+    fn retired(&mut self, cycle: u64, i: usize) {
+        self.retire[i] = cycle;
+    }
+
+    fn render(&self) -> String {
+        // Gather each instruction's commands keyed by cycle, then a stable sort
+        // groups them into Konata's single forward-moving time domain while
+        // keeping same-cycle commands in program order.
+        let mut events: Vec<(u64, String)> = Vec::new();
+        for (i, label) in self.labels.iter().enumerate() {
+            let (d, s, r) = (self.dispatch[i], self.issue[i], self.retire[i]);
+            events.push((d, format!("I\t{i}\t{i}\t0")));
+            events.push((d, format!("L\t{i}\t0\t{label}")));
+            events.push((d, format!("S\t{i}\t0\tD")));
+            events.push((s, format!("S\t{i}\t0\tX")));
+            // Retirement is in-order, so the retire id equals the index.
+            events.push((r, format!("R\t{i}\t{i}\t0")));
+        }
+        events.sort_by_key(|(cycle, _)| *cycle);
+
+        let mut out = String::from("Kanata\t0004\n");
+        let mut cur = events.first().map(|(cycle, _)| *cycle).unwrap_or(0);
+        let _ = writeln!(out, "C=\t{cur}");
+        for (cycle, line) in events {
+            if cycle > cur {
+                let _ = writeln!(out, "C\t{}", cycle - cur);
+                cur = cycle;
+            }
+            out.push_str(&line);
+            out.push('\n');
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two instructions: the first dispatches/issues at cycle 0 and retires at
+    /// 2; the second dispatches at 0, waits a cycle for its operand, and
+    /// retires at 4.
+    #[test]
+    fn renders_cycle_ordered_kanata_log() {
+        let mut view = KonataView::new(vec![
+            "0x80000000: add a0, a1, a2".to_string(),
+            "0x80000004: add a3, a0, a0".to_string(),
+        ]);
+        view.dispatched(0, 0);
+        view.issued(0, 0);
+        view.dispatched(0, 1);
+        view.issued(1, 1);
+        view.retired(2, 0);
+        view.retired(4, 1);
+
+        let expected = "\
+Kanata\t0004
+C=\t0
+I\t0\t0\t0
+L\t0\t0\t0x80000000: add a0, a1, a2
+S\t0\t0\tD
+S\t0\t0\tX
+I\t1\t1\t0
+L\t1\t0\t0x80000004: add a3, a0, a0
+S\t1\t0\tD
+C\t1
+S\t1\t0\tX
+C\t1
+R\t0\t0\t0
+C\t2
+R\t1\t1\t0
+";
+        assert_eq!(view.render(), expected);
+    }
+}

--- a/simulator/isasim/src/main.rs
+++ b/simulator/isasim/src/main.rs
@@ -4,11 +4,12 @@
 //! report. See `docs/design/simulator.md`.
 
 use clap::Parser;
-use tir_sim::scoreboard::Prf;
+use tir_sim::scoreboard::{EventHandler, Prf};
 use tir_sim::timing::{self, TimingConfig};
 use tir_sim::{Executor, ProgramImage, TraceOptions};
 
 mod dump;
+mod konata;
 mod memory;
 
 #[derive(Parser)]
@@ -50,6 +51,10 @@ struct Cli {
     /// Branch predictor for `--timing`: `not-taken` or `btfn`.
     #[arg(long, default_value = "btfn")]
     predictor: String,
+    /// Write a Konata/Kanata pipeline log of the `--timing` run to this path
+    /// (`-` for stdout). View it with <https://github.com/shioyadan/Konata>.
+    #[arg(long, requires = "timing")]
+    konata: Option<String>,
     /// Write a structured JSON snapshot of architectural state (PC, GPRs, and any
     /// requested memory windows) to this path after the run. Used by the
     /// differential ISA test suite to compare against a golden oracle.
@@ -160,6 +165,22 @@ fn main() {
         });
         let config = TimingConfig::for_model(&model);
         let prf = Prf::for_target(&register_info, &model);
+        let mut konata_view = args.konata.as_ref().map(|_| {
+            let printer = target.asm_printer(&context);
+            let labels = executor
+                .trace()
+                .iter()
+                .map(|(id, pc)| {
+                    let op = context.get_op(*id);
+                    let text = printer
+                        .print_instruction(&op)
+                        .expect("failed to print instruction")
+                        .unwrap_or_else(|| op.name().to_string());
+                    format!("{pc:#x}: {text}")
+                })
+                .collect();
+            konata::KonataView::new(labels)
+        });
         let result = timing::simulate(
             &model,
             &context,
@@ -167,7 +188,16 @@ fn main() {
             &config,
             predictor.as_mut(),
             Some(&prf),
+            konata_view.as_mut().map(|v| v as &mut dyn EventHandler),
         );
+        if let (Some(path), Some(view)) = (&args.konata, &konata_view) {
+            let log = view.render();
+            if path == "-" {
+                print!("{log}");
+            } else {
+                std::fs::write(path, log).expect("failed to write konata log");
+            }
+        }
         println!(
             "timing[{} / {}]: {} instructions, {} cycles, IPC {:.3}, {} mispredicts",
             model.name,

--- a/simulator/simcore/src/timing.rs
+++ b/simulator/simcore/src/timing.rs
@@ -13,14 +13,15 @@ use tir_be_common::sched::{InstrSchedClass, MachineModel};
 use tir_be_common::{ControlFlow, MachineInstruction};
 
 use crate::predictor::BranchPredictor;
-use crate::scoreboard::{self, BranchOutcome, Prf, ScoreboardInstr, phys_regs};
+use crate::scoreboard::{self, BranchOutcome, EventHandler, Prf, ScoreboardInstr, phys_regs};
 
 pub use crate::scoreboard::{TimingConfig, TimingResult};
 
 /// Replay `trace` (a `(op, pc)` stream) against `model` and return the cycle
 /// count. `predictor` supplies branch-direction guesses; mispredictions stall
 /// the front end by `config.mispredict_penalty` cycles. `prf` enables
-/// register-file pressure on a renaming core.
+/// register-file pressure on a renaming core. `handler` receives the pipeline
+/// events for report rendering.
 ///
 /// Only [`ControlFlow::Conditional`] instructions are predictor-scored: an
 /// unconditional transfer's target is known at decode, so it flows through the
@@ -32,6 +33,7 @@ pub fn simulate(
     config: &TimingConfig,
     predictor: &mut dyn BranchPredictor,
     prf: Option<&Prf>,
+    handler: Option<&mut dyn EventHandler>,
 ) -> TimingResult {
     // Pre-resolve each trace entry to its scheduling class, registers, and
     // (for conditional branches) PC and width — branch outcomes need the next
@@ -91,7 +93,7 @@ pub fn simulate(
         slots[i].branch = Some(BranchOutcome { pc, target, taken });
     }
 
-    scoreboard::run(model, &slots, 1, config, Some(predictor), prf, None)
+    scoreboard::run(model, &slots, 1, config, Some(predictor), prf, handler)
 }
 
 #[cfg(test)]
@@ -207,6 +209,7 @@ mod tests {
             config,
             &mut AlwaysNotTaken,
             None,
+            None,
         )
     }
 
@@ -288,8 +291,24 @@ mod tests {
         let model = tir_riscv::out_of_order_core_model();
         let config = TimingConfig::for_model(&model);
 
-        let ant = simulate(&model, &context, &trace, &config, &mut AlwaysNotTaken, None);
-        let btfn = simulate(&model, &context, &trace, &config, &mut BackwardTaken, None);
+        let ant = simulate(
+            &model,
+            &context,
+            &trace,
+            &config,
+            &mut AlwaysNotTaken,
+            None,
+            None,
+        );
+        let btfn = simulate(
+            &model,
+            &context,
+            &trace,
+            &config,
+            &mut BackwardTaken,
+            None,
+            None,
+        );
 
         assert_eq!(
             ant.mispredicts, 1,
@@ -363,8 +382,24 @@ mod tests {
 
         let model = tir_riscv::out_of_order_core_model();
         let config = TimingConfig::for_model(&model);
-        let ant = simulate(&model, &context, &trace, &config, &mut AlwaysNotTaken, None);
-        let btfn = simulate(&model, &context, &trace, &config, &mut BackwardTaken, None);
+        let ant = simulate(
+            &model,
+            &context,
+            &trace,
+            &config,
+            &mut AlwaysNotTaken,
+            None,
+            None,
+        );
+        let btfn = simulate(
+            &model,
+            &context,
+            &trace,
+            &config,
+            &mut BackwardTaken,
+            None,
+            None,
+        );
 
         assert_eq!(
             ant.mispredicts, 2,


### PR DESCRIPTION
Add a Kanata 0004 EventHandler that renders the timing run's
dispatch/D, execute/X, and retire events, labeling each instruction
with its PC and disassembly (L command). timing::simulate gains a
handler passthrough to the scoreboard. `--konata <path>` (requires
--timing) writes the log to a file, or stdout with `-`.

https://claude.ai/code/session_01YLMn6Q8cufCV4VRTtfFxmY