### PR TITLE
feat(tmdl): configure targets from ISA/extension feature sets

### DIFF
--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -3,49 +3,107 @@ use tir::{Any, Operation};
 
 include!(concat!(env!("OUT_DIR"), "/arm64.rs"));
 
-/// Parsed AArch64 target selection from `--march`/`--mcpu`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct TargetConfig;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CpuModel {
-    Generic,
-    InOrder,
-    OutOfOrder,
+/// Parsed AArch64 target selection from `--march`/`--mcpu`/`--mattr`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TargetConfig {
+    features: Vec<Feature>,
+    /// Machine model implied by `--mcpu`, when it names one.
+    machine: Option<String>,
 }
 
 impl TargetConfig {
-    /// Parse an AArch64 `--march`/`--mcpu` pair.
-    pub fn parse(march: &str, mcpu: Option<&str>) -> Option<Self> {
+    /// Parse an AArch64 `--march`/`--mcpu`/`--mattr` triple.
+    pub fn parse(march: &str, mcpu: Option<&str>, mattr: Option<&str>) -> Result<Self, String> {
         parse_march(march)?;
-        if let Some(mcpu) = mcpu {
-            parse_mcpu(mcpu)?;
+        let mut config = TargetConfig {
+            features: vec![Feature::ARMv8A64],
+            machine: None,
+        };
+        if let Some(mattr) = mattr {
+            apply_mattr(&mut config.features, mattr)?;
         }
-        Some(TargetConfig)
+        validate_features(&config.features)?;
+        if !config.features.contains(&Feature::ARMv8A64) {
+            return Err("--mattr must not disable the base ISA 'ARMv8A64'".to_string());
+        }
+        if let Some(mcpu) = mcpu {
+            config.machine = parse_mcpu(mcpu, &config)?;
+        }
+        Ok(config)
     }
 
     /// Canonical architecture name for diagnostics and target-specific behavior.
     pub fn canonical_name(&self) -> &'static str {
         "arm64"
     }
-}
 
-fn parse_march(march: &str) -> Option<()> {
-    match normalize(march).as_str() {
-        "arm64" | "aarch64" | "armv8" | "armv8a" | "armv8-a" => Some(()),
-        _ => None,
+    /// The enabled ISA/extension set.
+    pub fn features(&self) -> &[Feature] {
+        &self.features
     }
 }
 
-fn parse_mcpu(mcpu: &str) -> Option<CpuModel> {
-    match normalize(mcpu).as_str() {
-        "generic" | "generic-arm64" | "generic-aarch64" => Some(CpuModel::Generic),
-        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => Some(CpuModel::InOrder),
+fn parse_march(march: &str) -> Result<(), String> {
+    match normalize(march).as_str() {
+        "arm64" | "aarch64" | "armv8" | "armv8a" | "armv8-a" => Ok(()),
+        other => Err(format!("unknown AArch64 architecture '{other}'")),
+    }
+}
+
+/// Resolve `--mcpu` to an optional default machine model. Generic CPU names map
+/// onto the generic cores; any other name must be a TMDL machine (by name or
+/// alias) compatible with the enabled features.
+fn parse_mcpu(mcpu: &str, config: &TargetConfig) -> Result<Option<String>, String> {
+    let name = normalize(mcpu);
+    let generic = match name.as_str() {
+        "generic" | "generic-arm64" | "generic-aarch64" => Some(None),
+        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => {
+            Some(Some("arm64-in-order".to_string()))
+        }
         "generic-ooo" | "generic-out-of-order" | "ooo" | "out-of-order" => {
-            Some(CpuModel::OutOfOrder)
+            Some(Some("arm64-ooo".to_string()))
         }
         _ => None,
+    };
+    if let Some(machine) = generic {
+        return Ok(machine);
     }
+
+    if machine_model(&name, &config.features).is_some() {
+        return Ok(Some(name));
+    }
+    if machine_model(&name, Feature::ALL).is_some() {
+        return Err(format!(
+            "cpu '{name}' is incompatible with the selected architecture"
+        ));
+    }
+    Err(format!(
+        "unknown AArch64 cpu '{name}' (expected 'generic', 'generic-in-order', 'generic-ooo' or one of: {})",
+        machines(Feature::ALL).join(", ")
+    ))
+}
+
+/// Apply an LLVM-style `--mattr` list (`+feat`/`-feat`, comma-separated).
+fn apply_mattr(features: &mut Vec<Feature>, mattr: &str) -> Result<(), String> {
+    for item in mattr.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let (add, name) = if let Some(name) = item.strip_prefix('+') {
+            (true, name)
+        } else if let Some(name) = item.strip_prefix('-') {
+            (false, name)
+        } else {
+            return Err(format!(
+                "invalid --mattr entry '{item}' (expected '+feature' or '-feature')"
+            ));
+        };
+        let feature = Feature::from_name(&normalize(name))
+            .ok_or_else(|| format!("unknown AArch64 feature '{name}' in --mattr"))?;
+        if add && !features.contains(&feature) {
+            features.push(feature);
+        } else if !add {
+            features.retain(|f| *f != feature);
+        }
+    }
+    Ok(())
 }
 
 fn normalize(s: &str) -> String {
@@ -232,7 +290,7 @@ fn lower_func_and_return_to_asm_symbol(
 
 impl Arm64Dialect {
     pub fn get_asm_parser(&self) -> tir_be_common::AsmParser {
-        tir_be_common::AsmParser::new(get_instruction_parsers())
+        tir_be_common::AsmParser::new(get_instruction_parsers(Feature::ALL).0)
     }
 
     pub fn get_asm_printer(&self) -> tir_be_common::AsmPrinter {
@@ -275,7 +333,14 @@ fn lower_branches(
 }
 
 pub fn create_isel_pass(context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
-    tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context))
+    create_isel_pass_for(context, Feature::ALL)
+}
+
+fn create_isel_pass_for(
+    context: &tir::Context,
+    features: &[Feature],
+) -> tir_be_common::isel::InstructionSelectPass {
+    tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context, features))
         .with_op_lowering(lower_func_and_return_to_asm_symbol)
         .with_op_lowering(lower_branches)
 }
@@ -386,7 +451,7 @@ impl tir_be_common::TargetMachine for Arm64Target {
     }
 
     fn isel_pass(&self, context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
-        create_isel_pass(context)
+        create_isel_pass_for(context, &self.config.features)
     }
 
     fn regalloc_pass(&self) -> tir_be_common::regalloc::RegisterAllocationPass {
@@ -398,11 +463,9 @@ impl tir_be_common::TargetMachine for Arm64Target {
         Arm64RegAlloc.register_info()
     }
 
-    fn asm_parser(&self, context: &tir::Context) -> tir_be_common::AsmParser {
-        context
-            .find_dialect::<Arm64Dialect>()
-            .expect("arm64 dialect must be registered before building an asm parser")
-            .get_asm_parser()
+    fn asm_parser(&self, _context: &tir::Context) -> tir_be_common::AsmParser {
+        let (parsers, disabled) = get_instruction_parsers(&self.config.features);
+        tir_be_common::AsmParser::new(parsers).with_disabled_mnemonics(disabled)
     }
 
     fn asm_printer(&self, context: &tir::Context) -> tir_be_common::AsmPrinter {
@@ -413,11 +476,15 @@ impl tir_be_common::TargetMachine for Arm64Target {
     }
 
     fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
-        crate::machine_model(name)
+        crate::machine_model(name, &self.config.features)
     }
 
-    fn machines(&self) -> &'static [&'static str] {
-        crate::MACHINES
+    fn machines(&self) -> Vec<&'static str> {
+        crate::machines(&self.config.features)
+    }
+
+    fn default_machine(&self) -> Option<&str> {
+        self.config.machine.as_deref()
     }
 
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String> {
@@ -425,9 +492,19 @@ impl tir_be_common::TargetMachine for Arm64Target {
     }
 }
 
-fn select_arm64(march: &str, mcpu: Option<&str>) -> Option<Box<dyn tir_be_common::TargetMachine>> {
-    let config = TargetConfig::parse(march, mcpu)?;
-    Some(Box::new(Arm64Target { config }))
+fn select_arm64(
+    march: &str,
+    mcpu: Option<&str>,
+    mattr: Option<&str>,
+) -> Result<Option<Box<dyn tir_be_common::TargetMachine>>, String> {
+    let owned = ["arm", "aarch64"]
+        .iter()
+        .any(|prefix| normalize(march).starts_with(prefix));
+    if !owned {
+        return Ok(None);
+    }
+    let config = TargetConfig::parse(march, mcpu, mattr)?;
+    Ok(Some(Box::new(Arm64Target { config })))
 }
 
 tir_be_common::register_target!(select_arm64, ["arm64"]);
@@ -863,20 +940,36 @@ mod tests {
 
 #[cfg(test)]
 mod target_parser_tests {
-    use super::TargetConfig;
+    use super::{Feature, TargetConfig};
 
     #[test]
     fn accepts_arm64_aliases_and_generic_cpus() {
         assert_eq!(
-            TargetConfig::parse("aarch64", Some("generic-in-order")).map(|c| c.canonical_name()),
-            Some("arm64")
+            TargetConfig::parse("aarch64", Some("generic-in-order"), None)
+                .map(|c| c.canonical_name()),
+            Ok("arm64")
         );
-        assert!(TargetConfig::parse("armv8-a", Some("generic-aarch64")).is_some());
+        assert!(TargetConfig::parse("armv8-a", Some("generic-aarch64"), None).is_ok());
+    }
+
+    #[test]
+    fn generic_cpu_names_resolve_machine_models() {
+        let config = TargetConfig::parse("arm64", Some("generic-ooo"), None).unwrap();
+        assert_eq!(config.machine.as_deref(), Some("arm64-ooo"));
+        let config = TargetConfig::parse("arm64", Some("arm64-in-order"), None).unwrap();
+        assert_eq!(config.machine.as_deref(), Some("arm64-in-order"));
+    }
+
+    #[test]
+    fn march_enables_the_base_isa() {
+        let config = TargetConfig::parse("arm64", None, None).unwrap();
+        assert_eq!(config.features(), &[Feature::ARMv8A64]);
+        assert!(TargetConfig::parse("arm64", None, Some("-armv8a64")).is_err());
     }
 
     #[test]
     fn rejects_unknown_march_or_cpu() {
-        assert!(TargetConfig::parse("rv64im", None).is_none());
-        assert!(TargetConfig::parse("arm64", Some("cortex-a710")).is_none());
+        assert!(TargetConfig::parse("rv64im", None, None).is_err());
+        assert!(TargetConfig::parse("arm64", Some("cortex-a710"), None).is_err());
     }
 }

--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -487,6 +487,14 @@ impl tir_be_common::TargetMachine for Arm64Target {
         self.config.machine.as_deref()
     }
 
+    fn isa_params(&self) -> Vec<(&'static str, i64)> {
+        crate::isa_params(&self.config.features)
+    }
+
+    fn register_widths(&self) -> Vec<(&'static str, u32)> {
+        crate::register_widths(&self.config.features)
+    }
+
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String> {
         crate::register_name(class, index, prefer_abi)
     }

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -63,6 +63,13 @@ pub trait MachineContext {
     fn write_memory(&mut self, address: u64, size: usize, value: u64) -> Result<(), SimTrap>;
     fn read_pc(&self) -> u64;
     fn write_pc(&mut self, value: u64);
+    /// The value of a TMDL ISA parameter (e.g. RISC-V `XLEN`) under the selected
+    /// target configuration, or `None` when unconfigured (behaviors then fall
+    /// back to the widest TMDL value).
+    fn isa_param(&self, name: &str) -> Option<i64> {
+        let _ = name;
+        None
+    }
 }
 
 /// How an instruction affects control flow, derived at TMDL-compile time from

--- a/backends/common/src/parser.rs
+++ b/backends/common/src/parser.rs
@@ -16,13 +16,26 @@ pub struct AsmParser {
     /// can name several instruction forms (register vs. immediate), so each key
     /// maps to a list tried in turn with backtracking.
     instruction_parsers: HashMap<String, Vec<AsmInstructionParser>>,
+    /// Mnemonics the target defines but the selected ISA/extension set disables.
+    /// These are parse errors, unlike genuinely unknown identifiers which are
+    /// still skipped.
+    disabled_mnemonics: std::collections::HashSet<String>,
 }
 
 impl AsmParser {
     pub fn new(instruction_parsers: HashMap<String, Vec<AsmInstructionParser>>) -> Self {
         AsmParser {
             instruction_parsers,
+            disabled_mnemonics: Default::default(),
         }
+    }
+
+    pub fn with_disabled_mnemonics(
+        mut self,
+        disabled_mnemonics: std::collections::HashSet<String>,
+    ) -> Self {
+        self.disabled_mnemonics = disabled_mnemonics;
+        self
     }
 
     #[allow(clippy::result_unit_err)]
@@ -93,6 +106,10 @@ impl AsmParser {
                         if !parsed {
                             return Err(());
                         }
+                    } else if self.disabled_mnemonics.contains(&key) {
+                        // The instruction exists but the selected ISA/extension
+                        // set does not include it.
+                        return Err(());
                     } else {
                         // Unknown ident in text section; skip it for now
                         let _ = parser.bump();

--- a/backends/common/src/target.rs
+++ b/backends/common/src/target.rs
@@ -50,11 +50,19 @@ pub trait TargetMachine {
     fn asm_printer(&self, context: &Context) -> AsmPrinter;
 
     /// A cycle-approximate machine model by name, or `None` if this target has no
-    /// model under that name. Names are globally unique (e.g. `rv64-ooo`).
+    /// model under that name compatible with the selected features. Names are
+    /// globally unique (e.g. `rv64-ooo`).
     fn machine_model(&self, name: &str) -> Option<MachineModel>;
 
-    /// The selectable machine names of this target (for help text / diagnostics).
-    fn machines(&self) -> &'static [&'static str];
+    /// The selectable machine names compatible with the selected features (for
+    /// help text / diagnostics).
+    fn machines(&self) -> Vec<&'static str>;
+
+    /// The machine implied by `--mcpu`, used as the default model when a tool
+    /// needs one and no explicit machine was selected.
+    fn default_machine(&self) -> Option<&str> {
+        None
+    }
 
     /// The ISA (or ABI, when `prefer_abi`) name of a register given its class and
     /// encoding index — the inverse of the asm parser, for printing `x1`/`ra`
@@ -70,20 +78,40 @@ pub trait TargetMachine {
 pub struct TargetInfo {
     /// Canonical names this backend answers to, for help text and diagnostics.
     pub canonical_names: &'static [&'static str],
-    /// Parse a `--march`/`--mcpu` pair, returning a target if this backend owns it.
+    /// Parse a `--march`/`--mcpu`/`--mattr` triple, returning a target if this
+    /// backend owns it.
     pub select: SelectFn,
 }
 
-/// Parses a `--march`/`--mcpu` pair into a target, if the backend owns it.
-pub type SelectFn = fn(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>>;
+/// Parses a `--march`/`--mcpu`/`--mattr` triple into a target. `Ok(None)` means
+/// the march string belongs to another backend; `Err` means this backend owns
+/// the march but the combination is invalid (unknown extension, incompatible
+/// CPU, ...).
+pub type SelectFn = fn(
+    march: &str,
+    mcpu: Option<&str>,
+    mattr: Option<&str>,
+) -> Result<Option<Box<dyn TargetMachine>>, String>;
 
 /// Link-time registry of every target reachable in the final binary.
 #[distributed_slice]
 pub static TARGETS: [TargetInfo];
 
-/// Resolve a `--march`/`--mcpu` pair to a target, or `None` if no backend accepts it.
-pub fn select_target(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>> {
-    TARGETS.iter().find_map(|t| (t.select)(march, mcpu))
+/// Resolve a `--march`/`--mcpu`/`--mattr` triple to a target.
+pub fn select_target(
+    march: &str,
+    mcpu: Option<&str>,
+    mattr: Option<&str>,
+) -> Result<Box<dyn TargetMachine>, String> {
+    for t in TARGETS.iter() {
+        if let Some(target) = (t.select)(march, mcpu, mattr)? {
+            return Ok(target);
+        }
+    }
+    Err(format!(
+        "unknown target '{march}' (supported: {})",
+        supported_targets().join(", ")
+    ))
 }
 
 /// Canonical names accepted by [`select_target`], sorted and de-duplicated.
@@ -99,8 +127,8 @@ pub fn supported_targets() -> Vec<&'static str> {
 
 /// Register a target backend so the tools can select it.
 ///
-/// `select` is a `fn(&str, Option<&str>) -> Option<Box<dyn TargetMachine>>`;
-/// `names` lists the canonical spellings shown in help and error text.
+/// `select` is a [`SelectFn`]; `names` lists the canonical spellings shown in
+/// help and error text.
 #[macro_export]
 macro_rules! register_target {
     ($select:path, [$($name:expr),+ $(,)?]) => {

--- a/backends/common/src/target.rs
+++ b/backends/common/src/target.rs
@@ -64,6 +64,15 @@ pub trait TargetMachine {
         None
     }
 
+    /// TMDL ISA parameter values (e.g. RISC-V `XLEN`) resolved from the selected
+    /// features. Simulators install these so instruction behaviors referencing
+    /// `self.PARAM` execute with the selected ISA's value.
+    fn isa_params(&self) -> Vec<(&'static str, i64)>;
+
+    /// Architectural width in bits of each register class under the selected
+    /// features (e.g. RISC-V `GPR` is 32 bits wide on rv32, 64 on rv64).
+    fn register_widths(&self) -> Vec<(&'static str, u32)>;
+
     /// The ISA (or ABI, when `prefer_abi`) name of a register given its class and
     /// encoding index — the inverse of the asm parser, for printing `x1`/`ra`
     /// instead of the raw `(class, index)`. `None` if the class/index is unknown.

--- a/backends/riscv/build.rs
+++ b/backends/riscv/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let compiler = Compiler::builder()
         .add_input("./defs/main.tmdl")
         .add_input("./defs/base.tmdl")
+        .add_input("./defs/multiplication.tmdl")
         .add_input("./defs/perf.tmdl")
         .add_input("./defs/syntacore_scr1.tmdl")
         .output(OutputKind::File(format!(

--- a/backends/riscv/checks/asm/extension-gating.S
+++ b/backends/riscv/checks/asm/extension-gating.S
@@ -1,0 +1,11 @@
+# RUN: tir mc --march=rv64im %s | filecheck %s
+# RUN: tir mc --march=rv64i --mattr=+m %s | filecheck %s
+# RUN: tir mc --march=rv32i_zmmul %s | filecheck %s
+# RUN: not tir mc --march=rv64i %s
+# RUN: not tir mc --march=rv64im --mattr=-m,-zmmul %s
+
+.global f
+f:
+    mul x10, x11, x12
+
+# CHECK: mul x10, x11, x12

--- a/backends/riscv/checks/asm/xlen-gating.S
+++ b/backends/riscv/checks/asm/xlen-gating.S
@@ -1,0 +1,12 @@
+# RV64-only instructions must not be available on rv32 targets.
+# RUN: tir mc --march=rv64i %s | filecheck %s
+# RUN: not tir mc --march=rv32i %s
+# RUN: not tir mc --march=rv32im %s
+
+.global f
+f:
+    addw x10, x11, x12
+    ld x11, 0(x2)
+
+# CHECK: addw x10, x11, x12
+# CHECK: ld x11, 0(x2)

--- a/backends/riscv/checks/isel/arith.tir
+++ b/backends/riscv/checks/isel/arith.tir
@@ -1,5 +1,5 @@
-// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s
-// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s
+// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV64
+// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV32
 
 module {
   func @chain(%0: !i32, %1: !i32) -> !i32 {
@@ -13,8 +13,10 @@ module {
 }
 
 // CHECK: asm.symbol {name = "chain", arg_regs = [%virt0:GPR, %virt1:GPR]}
-// CHECK: riscv.addw {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}
-// CHECK: riscv.subw {rd = %virt3:GPR, rs1 = %virt2:GPR, rs2 = %virt1:GPR}
+// RV64: riscv.addw {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}
+// RV64: riscv.subw {rd = %virt3:GPR, rs1 = %virt2:GPR, rs2 = %virt1:GPR}
+// RV32: riscv.add {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}
+// RV32: riscv.sub {rd = %virt3:GPR, rs1 = %virt2:GPR, rs2 = %virt1:GPR}
 // CHECK: riscv.and {rd = %virt4:GPR, rs1 = %virt0:GPR, rs2 = %virt3:GPR}
 // CHECK: riscv.or {rd = %virt5:GPR, rs1 = %virt1:GPR, rs2 = %virt4:GPR}
 // CHECK: riscv.vret

--- a/backends/riscv/checks/isel/single-add.tir
+++ b/backends/riscv/checks/isel/single-add.tir
@@ -1,5 +1,5 @@
-// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s
-// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s
+// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV64
+// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV32
 
 module {
   func @add(%0: !i32, %1: !i32) -> !i32 {
@@ -9,4 +9,7 @@ module {
   module_end
 }
 
-// CHECK: riscv.addw {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}
+// On RV64 an i32 add selects the word op; on RV32 the word ops do not exist
+// and plain add is the 32-bit add.
+// RV64: riscv.addw {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}
+// RV32: riscv.add {rd = %virt2:GPR, rs1 = %virt0:GPR, rs2 = %virt1:GPR}

--- a/backends/riscv/checks/isel/two-functions.tir
+++ b/backends/riscv/checks/isel/two-functions.tir
@@ -1,5 +1,5 @@
-// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s
-// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s
+// RUN: tir mc --march=rv64i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV64
+// RUN: tir mc --march=rv32i --stage=isel %s | filecheck %s --check-prefixes=CHECK,RV32
 
 module {
   func @a(%0: !i32, %1: !i32) -> !i32 {
@@ -14,6 +14,8 @@ module {
 }
 
 // CHECK: asm.symbol {name = "a"
-// CHECK: riscv.addw
+// RV64: riscv.addw
+// RV32: riscv.add
 // CHECK: asm.symbol {name = "b"
-// CHECK: riscv.subw
+// RV64: riscv.subw
+// RV32: riscv.sub

--- a/backends/riscv/checks/regalloc/arith.tir
+++ b/backends/riscv/checks/regalloc/arith.tir
@@ -1,5 +1,5 @@
-// RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
-// RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
+// RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s --check-prefixes=CHECK,RV64
+// RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s --check-prefixes=CHECK,RV32
 
 module {
   func @chain(%0: !i32, %1: !i32) -> !i32 {
@@ -12,8 +12,10 @@ module {
   module_end
 }
 
-// CHECK: riscv.addw {rd = {{x[0-9]+}}, rs1 = x10, rs2 = x11}
-// CHECK: riscv.subw
+// RV64: riscv.addw {rd = {{x[0-9]+}}, rs1 = x10, rs2 = x11}
+// RV64: riscv.subw
+// RV32: riscv.add {rd = {{x[0-9]+}}, rs1 = x10, rs2 = x11}
+// RV32: riscv.sub
 // CHECK: riscv.and
 // CHECK: riscv.or {rd = x10,
 // CHECK: riscv.vret

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -3,27 +3,34 @@ use tir::{Any, Operation};
 
 include!(concat!(env!("OUT_DIR"), "/riscv.rs"));
 
-/// Parsed RISC-V target selection from `--march`/`--mcpu`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Parsed RISC-V target selection from `--march`/`--mcpu`/`--mattr`.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TargetConfig {
     xlen: u32,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CpuModel {
-    Generic,
-    InOrder,
-    OutOfOrder,
+    features: Vec<Feature>,
+    /// Machine model implied by `--mcpu`, when it names one.
+    machine: Option<String>,
 }
 
 impl TargetConfig {
-    /// Parse a RISC-V `--march`/`--mcpu` pair.
-    pub fn parse(march: &str, mcpu: Option<&str>) -> Option<Self> {
-        let config = parse_march(march)?;
-        if let Some(mcpu) = mcpu {
-            parse_mcpu(mcpu, config)?;
+    /// Parse a RISC-V `--march`/`--mcpu`/`--mattr` triple.
+    pub fn parse(march: &str, mcpu: Option<&str>, mattr: Option<&str>) -> Result<Self, String> {
+        let mut config = parse_march(march)?;
+        if let Some(mattr) = mattr {
+            apply_mattr(&mut config.features, mattr)?;
         }
-        Some(config)
+        validate_features(&config.features)?;
+        let base = config.base_feature();
+        if !config.features.contains(&base) {
+            return Err(format!(
+                "--mattr must not disable the base ISA '{}'",
+                base.name()
+            ));
+        }
+        if let Some(mcpu) = mcpu {
+            config.machine = parse_mcpu(mcpu, &config)?;
+        }
+        Ok(config)
     }
 
     /// Canonical architecture name for diagnostics and target-specific behavior.
@@ -33,37 +40,133 @@ impl TargetConfig {
             _ => "riscv64",
         }
     }
+
+    /// The enabled ISA/extension set.
+    pub fn features(&self) -> &[Feature] {
+        &self.features
+    }
+
+    fn base_feature(&self) -> Feature {
+        match self.xlen {
+            32 => Feature::RV32I,
+            _ => Feature::RV64I,
+        }
+    }
+
+    /// The generic profile for an XLEN: every extension modeled in TMDL.
+    fn generic(xlen: u32) -> Self {
+        let mut config = TargetConfig {
+            xlen,
+            features: vec![],
+            machine: None,
+        };
+        config.features = Feature::ALL
+            .iter()
+            .copied()
+            .filter(|f| match f {
+                Feature::RV32I => xlen == 32,
+                Feature::RV64I => xlen == 64,
+                _ => true,
+            })
+            .collect();
+        config
+    }
 }
 
-fn parse_march(march: &str) -> Option<TargetConfig> {
+fn parse_march(march: &str) -> Result<TargetConfig, String> {
     let march = normalize(march);
     match march.as_str() {
-        "riscv" => Some(TargetConfig { xlen: 64 }),
-        "riscv32" => Some(TargetConfig { xlen: 32 }),
-        "riscv64" => Some(TargetConfig { xlen: 64 }),
+        // Bare architecture names select the generic profile with every
+        // modeled extension, mirroring how toolchains treat a bare triple.
+        "riscv" | "riscv64" => Ok(TargetConfig::generic(64)),
+        "riscv32" => Ok(TargetConfig::generic(32)),
         _ => parse_riscv_isa_string(&march),
     }
 }
 
-fn parse_mcpu(mcpu: &str, march_config: TargetConfig) -> Option<CpuModel> {
+/// Resolve `--mcpu` to an optional default machine model. Generic CPU names
+/// map onto the generic cores when one exists for the configured XLEN; any
+/// other name must be a TMDL machine (by name or alias) compatible with the
+/// enabled features.
+fn parse_mcpu(mcpu: &str, config: &TargetConfig) -> Result<Option<String>, String> {
     let mcpu = normalize(mcpu);
-    for (prefix, xlen) in [("riscv32-", 32), ("riscv64-", 64)] {
-        if let Some(model) = mcpu.strip_prefix(prefix).and_then(parse_cpu_model) {
-            return (march_config.xlen == xlen).then_some(model);
+    let name = match (
+        mcpu.strip_prefix("riscv32-"),
+        mcpu.strip_prefix("riscv64-"),
+        config.xlen,
+    ) {
+        (Some(name), _, 32) | (_, Some(name), 64) => name,
+        (Some(_), _, _) | (_, Some(_), _) => {
+            return Err(format!(
+                "cpu '{mcpu}' does not match the '{}' architecture",
+                config.canonical_name()
+            ));
         }
-    }
+        _ => mcpu.as_str(),
+    };
 
-    parse_cpu_model(&mcpu)
-}
-
-fn parse_cpu_model(name: &str) -> Option<CpuModel> {
-    match name {
-        "generic" => Some(CpuModel::Generic),
-        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => Some(CpuModel::InOrder),
+    let generic = match name {
+        "generic" => Some(None),
+        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => {
+            Some((config.xlen == 64).then(|| "rv64-in-order".to_string()))
+        }
         "generic-ooo" | "generic-out-of-order" | "ooo" | "out-of-order" => {
-            Some(CpuModel::OutOfOrder)
+            Some((config.xlen == 64).then(|| "rv64-ooo".to_string()))
         }
         _ => None,
+    };
+    if let Some(machine) = generic {
+        return Ok(machine);
+    }
+
+    if machine_model(name, &config.features).is_some() {
+        return Ok(Some(name.to_string()));
+    }
+    if machine_model(name, Feature::ALL).is_some() {
+        return Err(format!(
+            "cpu '{name}' is incompatible with the selected architecture"
+        ));
+    }
+    Err(format!(
+        "unknown RISC-V cpu '{name}' (expected 'generic', 'generic-in-order', 'generic-ooo' or one of: {})",
+        machines(Feature::ALL).join(", ")
+    ))
+}
+
+/// Apply an LLVM-style `--mattr` list (`+feat`/`-feat`, comma-separated) on top
+/// of the march-derived feature set.
+fn apply_mattr(features: &mut Vec<Feature>, mattr: &str) -> Result<(), String> {
+    for item in mattr.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let (add, name) = if let Some(name) = item.strip_prefix('+') {
+            (true, name)
+        } else if let Some(name) = item.strip_prefix('-') {
+            (false, name)
+        } else {
+            return Err(format!(
+                "invalid --mattr entry '{item}' (expected '+feature' or '-feature')"
+            ));
+        };
+        let toggled = attr_features(name)
+            .ok_or_else(|| format!("unknown RISC-V feature '{name}' in --mattr"))?;
+        for feature in toggled {
+            if add && !features.contains(&feature) {
+                features.push(feature);
+            } else if !add {
+                features.retain(|f| *f != feature);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Features named by a `--mattr` entry: the march extension letter spellings
+/// plus the TMDL feature names.
+fn attr_features(name: &str) -> Option<Vec<Feature>> {
+    let name = normalize(name);
+    match name.as_str() {
+        // The M extension implies Zmmul.
+        "m" => Some(vec![Feature::RVM, Feature::Zmmul]),
+        _ => Feature::from_name(&name).map(|f| vec![f]),
     }
 }
 
@@ -71,66 +174,109 @@ fn normalize(s: &str) -> String {
     s.trim().to_ascii_lowercase().replace('_', "-")
 }
 
-fn parse_riscv_isa_string(march: &str) -> Option<TargetConfig> {
-    let rest = march.strip_prefix("rv")?;
+fn parse_riscv_isa_string(march: &str) -> Result<TargetConfig, String> {
+    let err = || format!("invalid RISC-V ISA string '{march}'");
+    let rest = march.strip_prefix("rv").ok_or_else(err)?;
     let (xlen, rest) = if let Some(rest) = rest.strip_prefix("32") {
         (32, rest)
     } else {
-        (64, rest.strip_prefix("64")?)
+        (64, rest.strip_prefix("64").ok_or_else(err)?)
+    };
+
+    let base_feature = if xlen == 32 {
+        Feature::RV32I
+    } else {
+        Feature::RV64I
+    };
+    let mut features = vec![];
+    let mut enable = |feature: Feature| {
+        if !features.contains(&feature) {
+            features.push(feature);
+        }
     };
 
     let mut chars = rest.chars().peekable();
-    let base = chars.next()?;
+    let base = chars.next().ok_or_else(err)?;
     match base {
-        'i' | 'e' | 'g' => skip_extension_version(&mut chars),
-        _ => return None,
+        'i' => {
+            enable(base_feature);
+            skip_extension_version(&mut chars);
+        }
+        // G abbreviates IMAFD_Zicsr_Zifencei; the parts TMDL does not model
+        // yet contribute nothing.
+        'g' => {
+            enable(base_feature);
+            enable(Feature::RVM);
+            enable(Feature::Zmmul);
+            skip_extension_version(&mut chars);
+        }
+        'e' => return Err(format!("unsupported RISC-V base ISA 'e' in '{march}'")),
+        _ => return Err(err()),
     }
 
     while chars.peek().is_some() {
         if chars.peek() == Some(&'-') {
             chars.next();
-            chars.peek()?;
+            chars.peek().ok_or_else(err)?;
             continue;
         }
 
-        let ext = chars.next()?;
+        let ext = chars.next().ok_or_else(err)?;
         if ext.is_ascii_digit() {
-            return None;
+            return Err(err());
         }
 
         match ext {
-            'm' | 'a' | 'f' | 'd' | 'q' | 'l' | 'c' | 'b' | 'j' | 't' | 'p' | 'v' | 'h' => {
+            'm' => {
+                enable(Feature::RVM);
+                enable(Feature::Zmmul);
+                skip_extension_version(&mut chars);
+            }
+            // Standard single-letter extensions TMDL does not model yet are
+            // accepted so common GNU march strings (e.g. rv64gc) keep working;
+            // they contribute no instructions.
+            'a' | 'f' | 'd' | 'q' | 'l' | 'c' | 'b' | 'j' | 't' | 'p' | 'v' | 'h' => {
                 skip_extension_version(&mut chars);
             }
             'z' | 's' | 'x' => {
-                if !consume_multi_letter_extension(&mut chars) {
-                    return None;
+                let name = consume_multi_letter_extension(ext, &mut chars).ok_or_else(err)?;
+                // Same policy for multi-letter extensions: enable the modeled
+                // ones, accept and ignore the rest.
+                if let Some(feature) = Feature::from_name(&name) {
+                    enable(feature);
                 }
             }
-            _ => return None,
+            _ => return Err(err()),
         }
     }
 
-    Some(TargetConfig { xlen })
+    Ok(TargetConfig {
+        xlen,
+        features,
+        machine: None,
+    })
 }
 
-fn consume_multi_letter_extension<I>(chars: &mut std::iter::Peekable<I>) -> bool
+fn consume_multi_letter_extension<I>(
+    first: char,
+    chars: &mut std::iter::Peekable<I>,
+) -> Option<String>
 where
     I: Iterator<Item = char>,
 {
-    let mut consumed_name_char = false;
+    let mut name = String::from(first);
     while let Some(&c) = chars.peek() {
         if c == '-' {
             break;
         }
         if c.is_ascii_lowercase() || c.is_ascii_digit() {
-            consumed_name_char = true;
+            name.push(c);
             chars.next();
         } else {
-            return false;
+            return None;
         }
     }
-    consumed_name_char
+    (name.len() > 1).then_some(name)
 }
 
 fn skip_extension_version<I>(chars: &mut std::iter::Peekable<I>)
@@ -255,6 +401,9 @@ dialect! {
             ShiftLeftLogicalImmWordOp,
             ShiftRightLogicalImmWordOp,
             ShiftRightArithmeticImmWordOp,
+            // M extension (Zmmul subset)
+            MulOp,
+            MulHOp,
             // Loads / stores
             LoadByteOp,
             LoadByteUnsignedOp,
@@ -289,7 +438,7 @@ pub mod ops {
 
 impl RiscvDialect {
     pub fn get_asm_parser(&self) -> tir_be_common::AsmParser {
-        tir_be_common::AsmParser::new(get_instruction_parsers())
+        tir_be_common::AsmParser::new(get_instruction_parsers(Feature::ALL).0)
     }
 
     pub fn get_asm_printer(&self) -> tir_be_common::AsmPrinter {
@@ -398,7 +547,14 @@ fn lower_branches(
 }
 
 pub fn create_isel_pass(context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
-    tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context))
+    create_isel_pass_for(context, Feature::ALL)
+}
+
+fn create_isel_pass_for(
+    context: &tir::Context,
+    features: &[Feature],
+) -> tir_be_common::isel::InstructionSelectPass {
+    tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context, features))
         .with_op_lowering(lower_func_and_return_to_asm_symbol)
         .with_op_lowering(lower_branches)
 }
@@ -508,7 +664,7 @@ impl tir_be_common::TargetMachine for RiscvTarget {
     }
 
     fn isel_pass(&self, context: &tir::Context) -> tir_be_common::isel::InstructionSelectPass {
-        create_isel_pass(context)
+        create_isel_pass_for(context, &self.config.features)
     }
 
     fn regalloc_pass(&self) -> tir_be_common::regalloc::RegisterAllocationPass {
@@ -520,11 +676,9 @@ impl tir_be_common::TargetMachine for RiscvTarget {
         RiscvRegAlloc.register_info()
     }
 
-    fn asm_parser(&self, context: &tir::Context) -> tir_be_common::AsmParser {
-        context
-            .find_dialect::<RiscvDialect>()
-            .expect("riscv dialect must be registered before building an asm parser")
-            .get_asm_parser()
+    fn asm_parser(&self, _context: &tir::Context) -> tir_be_common::AsmParser {
+        let (parsers, disabled) = get_instruction_parsers(&self.config.features);
+        tir_be_common::AsmParser::new(parsers).with_disabled_mnemonics(disabled)
     }
 
     fn asm_printer(&self, context: &tir::Context) -> tir_be_common::AsmPrinter {
@@ -535,11 +689,15 @@ impl tir_be_common::TargetMachine for RiscvTarget {
     }
 
     fn machine_model(&self, name: &str) -> Option<tir_be_common::sched::MachineModel> {
-        crate::machine_model(name)
+        crate::machine_model(name, &self.config.features)
     }
 
-    fn machines(&self) -> &'static [&'static str] {
-        crate::MACHINES
+    fn machines(&self) -> Vec<&'static str> {
+        crate::machines(&self.config.features)
+    }
+
+    fn default_machine(&self) -> Option<&str> {
+        self.config.machine.as_deref()
     }
 
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String> {
@@ -547,9 +705,19 @@ impl tir_be_common::TargetMachine for RiscvTarget {
     }
 }
 
-fn select_riscv(march: &str, mcpu: Option<&str>) -> Option<Box<dyn tir_be_common::TargetMachine>> {
-    let config = TargetConfig::parse(march, mcpu)?;
-    Some(Box::new(RiscvTarget { config }))
+fn select_riscv(
+    march: &str,
+    mcpu: Option<&str>,
+    mattr: Option<&str>,
+) -> Result<Option<Box<dyn tir_be_common::TargetMachine>>, String> {
+    let owned = ["riscv", "rv32", "rv64"]
+        .iter()
+        .any(|prefix| normalize(march).starts_with(prefix));
+    if !owned {
+        return Ok(None);
+    }
+    let config = TargetConfig::parse(march, mcpu, mattr)?;
+    Ok(Some(Box::new(RiscvTarget { config })))
 }
 
 tir_be_common::register_target!(select_riscv, ["riscv32", "riscv64"]);
@@ -760,6 +928,92 @@ mod tests {
         assert_eq!(ooo.issue_width, 4);
         assert_eq!(ooo.buffer("rob"), Some(128));
         assert_eq!(ooo.resource("ALU").map(|r| r.units), Some(4));
+    }
+
+    fn target_for(march: &str) -> crate::RiscvTarget {
+        crate::RiscvTarget {
+            config: crate::TargetConfig::parse(march, None, None).expect("march should parse"),
+        }
+    }
+
+    #[test]
+    fn asm_parser_gates_extensions() {
+        use tir_be_common::TargetMachine;
+
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        // M-extension instructions need RVM (or Zmmul) enabled.
+        let mul = ".global f\nf:\n    mul a0, a1, a2\n";
+        assert!(
+            target_for("rv64i")
+                .asm_parser(&context)
+                .parse_asm(&context, mul)
+                .is_err()
+        );
+        for march in ["rv64im", "rv64i_zmmul", "riscv64"] {
+            assert!(
+                target_for(march)
+                    .asm_parser(&context)
+                    .parse_asm(&context, mul)
+                    .is_ok(),
+                "mul should parse with --march={march}"
+            );
+        }
+
+        // RV64-only instructions are rejected on rv32.
+        let word_ops = ".global f\nf:\n    addw a0, a1, a2\n    ld a1, 0(sp)\n";
+        assert!(
+            target_for("rv32im")
+                .asm_parser(&context)
+                .parse_asm(&context, word_ops)
+                .is_err()
+        );
+        assert!(
+            target_for("rv64i")
+                .asm_parser(&context)
+                .parse_asm(&context, word_ops)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn machines_filter_by_feature_set() {
+        use tir_be_common::TargetMachine;
+
+        let rv64 = target_for("rv64im");
+        assert_eq!(rv64.machines(), vec!["rv64-in-order", "rv64-ooo"]);
+        assert!(rv64.machine_model("rv64-ooo").is_some());
+        assert!(rv64.machine_model("scr1-3stage").is_none());
+
+        let rv32 = target_for("rv32i");
+        assert_eq!(rv32.machines(), vec!["scr1-3stage"]);
+        assert!(rv32.machine_model("scr1-3stage").is_some());
+        assert!(rv32.machine_model("rv64-ooo").is_none());
+    }
+
+    #[test]
+    fn isel_rules_filter_by_feature_set() {
+        let context = Context::with_default_dialects();
+        let rule_names = |features: &[crate::Feature]| -> Vec<&'static str> {
+            crate::get_isel_rules(&context, features)
+                .iter()
+                .map(|r| r.name)
+                .collect()
+        };
+
+        let rv64i = rule_names(&[crate::Feature::RV64I]);
+        assert!(rv64i.contains(&"addword"));
+        assert!(!rv64i.contains(&"mul"));
+
+        let rv64im = rule_names(&[crate::Feature::RV64I, crate::Feature::RVM]);
+        assert!(rv64im.contains(&"mul"));
+
+        let rv32i = rule_names(&[crate::Feature::RV32I]);
+        assert!(rv32i.contains(&"add"));
+        assert!(!rv32i.contains(&"addword"));
+        assert!(!rv32i.contains(&"loaddoubleword"));
     }
 
     #[test]
@@ -1408,36 +1662,92 @@ mod tests {
 
 #[cfg(test)]
 mod target_parser_tests {
-    use super::TargetConfig;
+    use super::{Feature, TargetConfig};
+
+    fn features(march: &str, mattr: Option<&str>) -> Vec<Feature> {
+        TargetConfig::parse(march, None, mattr)
+            .expect("march should parse")
+            .features
+    }
 
     #[test]
     fn march_accepts_gcc_style_isa_strings() {
         assert_eq!(
-            TargetConfig::parse("rv64im", None).map(|c| c.canonical_name()),
-            Some("riscv64")
+            TargetConfig::parse("rv64im", None, None).map(|c| c.canonical_name()),
+            Ok("riscv64")
         );
         assert_eq!(
-            TargetConfig::parse("rv32imac", None).map(|c| c.canonical_name()),
-            Some("riscv32")
+            TargetConfig::parse("rv32imac", None, None).map(|c| c.canonical_name()),
+            Ok("riscv32")
         );
         assert_eq!(
-            TargetConfig::parse("rv64gc_zba_zbb", None).map(|c| c.canonical_name()),
-            Some("riscv64")
+            TargetConfig::parse("rv64gc_zba_zbb", None, None).map(|c| c.canonical_name()),
+            Ok("riscv64")
         );
+    }
+
+    #[test]
+    fn march_selects_extension_features() {
+        assert_eq!(features("rv64i", None), vec![Feature::RV64I]);
+        assert_eq!(
+            features("rv64im", None),
+            vec![Feature::RV64I, Feature::RVM, Feature::Zmmul]
+        );
+        assert_eq!(
+            features("rv32imac", None),
+            vec![Feature::RV32I, Feature::RVM, Feature::Zmmul]
+        );
+        assert_eq!(
+            features("rv32i_zmmul", None),
+            vec![Feature::RV32I, Feature::Zmmul]
+        );
+        // G abbreviates IMAFD...; M is the modeled part.
+        assert!(features("rv64gc_zba_zbb", None).contains(&Feature::RVM));
+        // Bare architecture names select the generic, everything-on profile.
+        assert_eq!(
+            features("riscv64", None),
+            vec![Feature::RV64I, Feature::Zmmul, Feature::RVM]
+        );
+        assert!(!features("riscv32", None).contains(&Feature::RV64I));
+    }
+
+    #[test]
+    fn mattr_toggles_features() {
+        assert_eq!(
+            features("rv64i", Some("+m")),
+            vec![Feature::RV64I, Feature::RVM, Feature::Zmmul]
+        );
+        assert_eq!(
+            features("rv64im", Some("-m,+zmmul")),
+            vec![Feature::RV64I, Feature::Zmmul]
+        );
+        assert!(TargetConfig::parse("rv64i", None, Some("+vector")).is_err());
+        assert!(TargetConfig::parse("rv64i", None, Some("m")).is_err());
+        assert!(TargetConfig::parse("rv64i", None, Some("-rv64i")).is_err());
     }
 
     #[test]
     fn mcpu_accepts_target_prefixed_generic_names() {
-        assert!(TargetConfig::parse("rv32im", Some("riscv32-generic-in-order")).is_some());
-        assert!(TargetConfig::parse("rv64im", Some("riscv32-generic-in-order")).is_none());
-        assert!(TargetConfig::parse("rv64im", Some("generic-in-order")).is_some());
+        assert!(TargetConfig::parse("rv32im", Some("riscv32-generic-in-order"), None).is_ok());
+        assert!(TargetConfig::parse("rv64im", Some("riscv32-generic-in-order"), None).is_err());
+        assert!(TargetConfig::parse("rv64im", Some("generic-in-order"), None).is_ok());
+    }
+
+    #[test]
+    fn mcpu_resolves_machine_models() {
+        let config = TargetConfig::parse("rv64im", Some("generic-ooo"), None).unwrap();
+        assert_eq!(config.machine.as_deref(), Some("rv64-ooo"));
+        let config = TargetConfig::parse("rv32i", Some("scr1-3stage"), None).unwrap();
+        assert_eq!(config.machine.as_deref(), Some("scr1-3stage"));
+        // The SCR1 model is declared `for [RV32I]`; rv64 must reject it.
+        assert!(TargetConfig::parse("rv64i", Some("scr1-3stage"), None).is_err());
     }
 
     #[test]
     fn unknown_or_malformed_march_is_rejected() {
-        assert!(TargetConfig::parse("rv64", None).is_none());
-        assert!(TargetConfig::parse("rv64zm", None).is_none());
-        assert!(TargetConfig::parse("mips", None).is_none());
-        assert!(TargetConfig::parse("rv64im", Some("riscv64-unknown-cpu")).is_none());
+        assert!(TargetConfig::parse("rv64", None, None).is_err());
+        assert!(TargetConfig::parse("rv64zm", None, None).is_err());
+        assert!(TargetConfig::parse("mips", None, None).is_err());
+        assert!(TargetConfig::parse("rv64im", Some("riscv64-unknown-cpu"), None).is_err());
     }
 }

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -27,6 +27,10 @@ impl TargetConfig {
                 base.name()
             ));
         }
+        // Exactly one base ISA: parameters like XLEN resolve from it.
+        if config.features.contains(&Feature::RV32I) && config.features.contains(&Feature::RV64I) {
+            return Err("RV32I and RV64I are mutually exclusive".to_string());
+        }
         if let Some(mcpu) = mcpu {
             config.machine = parse_mcpu(mcpu, &config)?;
         }
@@ -698,6 +702,14 @@ impl tir_be_common::TargetMachine for RiscvTarget {
 
     fn default_machine(&self) -> Option<&str> {
         self.config.machine.as_deref()
+    }
+
+    fn isa_params(&self) -> Vec<(&'static str, i64)> {
+        crate::isa_params(&self.config.features)
+    }
+
+    fn register_widths(&self) -> Vec<(&'static str, u32)> {
+        crate::register_widths(&self.config.features)
     }
 
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String> {
@@ -1741,6 +1753,30 @@ mod target_parser_tests {
         assert_eq!(config.machine.as_deref(), Some("scr1-3stage"));
         // The SCR1 model is declared `for [RV32I]`; rv64 must reject it.
         assert!(TargetConfig::parse("rv64i", Some("scr1-3stage"), None).is_err());
+    }
+
+    #[test]
+    fn isa_params_resolve_from_the_selected_base() {
+        assert_eq!(crate::isa_params(&[Feature::RV32I]), vec![("XLEN", 32)]);
+        assert_eq!(
+            crate::isa_params(&[Feature::RV64I, Feature::RVM]),
+            vec![("XLEN", 64)]
+        );
+        assert_eq!(
+            crate::register_widths(&[Feature::RV32I]),
+            vec![("PC", 32), ("GPR", 32)]
+        );
+        assert_eq!(
+            crate::register_widths(&[Feature::RV64I]),
+            vec![("PC", 64), ("GPR", 64)]
+        );
+        // Extensions alone resolve nothing; the base supplies XLEN.
+        assert_eq!(crate::isa_params(&[Feature::RVM]), vec![]);
+    }
+
+    #[test]
+    fn base_isas_are_mutually_exclusive() {
+        assert!(TargetConfig::parse("rv32i", None, Some("+rv64i")).is_err());
     }
 
     #[test]

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -347,7 +347,22 @@ fn eval_node<M: Memory>(
             let value = as_int!(c(0), "extract");
             let high = as_int!(c(1), "extract").to_u64() as u32;
             let low = as_int!(c(2), "extract").to_u64() as u32;
-            Value::Int(value.extract_bits(high, low))
+            // `extract(a * b, 2N-1, N)` is the TMDL idiom for the high half of a
+            // full multiply (e.g. RISC-V `mulh`). The `Mul` node itself only
+            // keeps the low N bits, so when the slice lies entirely past the
+            // product's width, recompute it from the multiply's operands as a
+            // signed full-width product.
+            let mul = graph.children(node).next().expect("extract has children");
+            if low >= value.width() && matches!(graph.get_kind(mul), ExprKind::Mul) {
+                let (a, b) = coerce_ints(
+                    as_int!(child_val(graph, mul, 0, cache), "extract"),
+                    as_int!(child_val(graph, mul, 1, cache), "extract"),
+                );
+                let product_high = a.with_signed(true).mulh(&b.with_signed(true));
+                Value::Int(product_high.extract_bits(high - a.width(), low - a.width()))
+            } else {
+                Value::Int(value.extract_bits(high, low))
+            }
         }
         ExprKind::ZExt => {
             let value = as_int!(c(0), "zext");
@@ -538,6 +553,33 @@ mod tests {
         let b = sym(&mut g, 1);
         inner(&mut g, ExprKind::Mul, &[a, b]);
         assert_eq!(as_i64(execute(&g, &[iv(6), iv(7)])), 42);
+    }
+
+    #[test]
+    fn extract_above_mul_yields_signed_high_product() {
+        // The RISC-V `mulh` semantics expressed the TMDL way:
+        // extract(rs1 * rs2, 127, 64) on 64-bit operands.
+        let mut g = ExprPostGraph::new();
+        let a = sym(&mut g, 0);
+        let b = sym(&mut g, 1);
+        let mul = inner(&mut g, ExprKind::Mul, &[a, b]);
+        let hi = int_con(&mut g, 127);
+        let lo = int_con(&mut g, 64);
+        inner(&mut g, ExprKind::Extract, &[mul, hi, lo]);
+
+        // -3 * 7 = -21: the high half of the signed 128-bit product is -1.
+        let inputs = [
+            Value::Int(APInt::new(64, (-3i64) as u64)),
+            Value::Int(APInt::new(64, 7)),
+        ];
+        assert_eq!(as_i64(execute(&g, &inputs)), -1);
+
+        // 2^62 * 4 = 2^64: high half is 1.
+        let inputs = [
+            Value::Int(APInt::new(64, 1u64 << 62)),
+            Value::Int(APInt::new(64, 4)),
+        ];
+        assert_eq!(as_i64(execute(&g, &inputs)), 1);
     }
 
     #[test]

--- a/docs/design/simulator.md
+++ b/docs/design/simulator.md
@@ -52,7 +52,7 @@ simulator/isasim    (tir-isasim) the dynamic CLI
 └── dump.rs         --dump-state JSON snapshots (differential ISA testing)
 
 tools/src/sched     `tir sched`: static analysis front-end + report views
-backends/targets    --march/--mcpu registry (TargetMachine per backend)
+backends/targets    --march/--mcpu/--mattr registry (TargetMachine per backend)
 ```
 
 ## Execution model: functional-first, timing-directed

--- a/simulator/isasim/checks/riscv/exec/multiply.S
+++ b/simulator/isasim/checks/riscv/exec/multiply.S
@@ -1,0 +1,20 @@
+# RUN: isasim --march=rv64im --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s
+# RUN: isasim --march=riscv64 --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s
+# RUN: not isasim --march=rv64i --entry=_start --until-pc=done %s
+
+# M extension: 6 * 7 = 42 (0x2a); mulh of -3 * 7 is the high half of the
+# signed 128-bit product, i.e. -1.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  addi x1, x0, 6
+  addi x2, x0, 7
+  mul  x3, x1, x2
+  addi x4, x0, -3
+  mulh x5, x4, x2
+
+# CHECK: final registers:
+# CHECK-DAG: GPR[3] = 0x2a
+# CHECK-DAG: GPR[5] = 0xffffffffffffffff

--- a/simulator/isasim/checks/riscv/exec/rv32-widths.S
+++ b/simulator/isasim/checks/riscv/exec/rv32-widths.S
@@ -1,0 +1,30 @@
+# RUN: isasim --march=rv32im --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s --check-prefixes=CHECK,RV32
+# RUN: isasim --march=rv64im --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s --check-prefixes=CHECK,RV64
+
+# XLEN comes from the selected ISA: on rv32 registers are 32 bits wide, so
+# lui produces a plain 0x80000000, doubling it wraps to zero, -1 is the
+# 32-bit all-ones, and a logical right shift only has 32 bits to move.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  lui  x1, 524288
+  add  x3, x1, x1
+  addi x4, x0, -1
+  srli x9, x4, 28
+  mul  x5, x4, x4
+  mulh x6, x4, x4
+
+# CHECK: final registers:
+# RV32-DAG: GPR[1] = 0x80000000 (width=32)
+# RV32-DAG: GPR[3] = 0x0 (width=32)
+# RV32-DAG: GPR[4] = 0xffffffff (width=32)
+# RV32-DAG: GPR[9] = 0xf (width=32)
+# RV64-DAG: GPR[1] = 0xffffffff80000000 (width=64)
+# RV64-DAG: GPR[3] = 0xffffffff00000000 (width=64)
+# RV64-DAG: GPR[4] = 0xffffffffffffffff (width=64)
+# RV64-DAG: GPR[9] = 0xfffffffff (width=64)
+# (-1)^2 = 1 with a zero high half on both widths.
+# CHECK-DAG: GPR[5] = 0x1
+# CHECK-DAG: GPR[6] = 0x0

--- a/simulator/isasim/src/main.rs
+++ b/simulator/isasim/src/main.rs
@@ -95,6 +95,21 @@ fn main() {
     // can stop at a label without hand-computing its address.
     let until_pc = resolve_pc(&args.until_pc, &program.symbols);
     let mut executor = Executor::new_at(args.mem_size, args.mem_start_address);
+    // Teach the executor which register classes share a physical file so, e.g.,
+    // a value written via AArch64 `GPRsp` reads back through `GPR`.
+    let register_info = target.register_info();
+    let register_files = register_info
+        .classes
+        .iter()
+        .map(|c| (c.name.to_string(), c.file.to_string()))
+        .collect();
+    executor.set_register_files(register_files);
+
+    // Install the selected ISA's parameters and register widths so behaviors
+    // execute with the configured XLEN (e.g. rv32 arithmetic wraps at 32 bits).
+    executor.set_isa_params(target.isa_params());
+    executor.set_register_widths(target.register_widths());
+
     if let Some(path) = &args.memory_config {
         memory::load_memory_config(&mut executor, path);
     } else if !args.no_default_memory {
@@ -105,16 +120,6 @@ fn main() {
             args.mem_size,
         );
     }
-
-    // Teach the executor which register classes share a physical file so, e.g.,
-    // a value written via AArch64 `GPRsp` reads back through `GPR`.
-    let register_info = target.register_info();
-    let register_files = register_info
-        .classes
-        .iter()
-        .map(|c| (c.name.to_string(), c.file.to_string()))
-        .collect();
-    executor.set_register_files(register_files);
 
     // Pick the timing model up front so a bad `--machine` fails before running.
     let model = if args.timing {

--- a/simulator/isasim/src/main.rs
+++ b/simulator/isasim/src/main.rs
@@ -13,12 +13,16 @@ mod memory;
 
 #[derive(Parser)]
 struct Cli {
-    /// Target architecture (e.g. `riscv64`, `arm64`).
+    /// Target architecture (e.g. `riscv64`, `rv64im`, `arm64`).
     #[arg(long)]
     march: String,
-    /// Target CPU. Accepted for forward compatibility; currently unused.
+    /// Target CPU. A TMDL machine name (e.g. `scr1-3stage`) provides the default
+    /// for `--machine`.
     #[arg(long)]
     mcpu: Option<String>,
+    /// Target feature toggles (e.g. `+m,-zmmul`), applied on top of `--march`.
+    #[arg(long)]
+    mattr: Option<String>,
     #[arg(long, default_value_t = 65536)]
     mem_size: usize,
     #[arg(long, default_value_t = 0x80000000_u64)]
@@ -66,14 +70,11 @@ fn main() {
     let args = Cli::parse();
     let src = std::fs::read_to_string(&args.program).expect("failed to read program path");
 
-    let target = tir_targets::select(&args.march, args.mcpu.as_deref()).unwrap_or_else(|| {
-        eprintln!(
-            "unknown target '{}' (supported: {})",
-            args.march,
-            tir_targets::supported_targets().join(", ")
-        );
-        std::process::exit(2);
-    });
+    let target = tir_targets::select(&args.march, args.mcpu.as_deref(), args.mattr.as_deref())
+        .unwrap_or_else(|error| {
+            eprintln!("{error}");
+            std::process::exit(2);
+        });
 
     let context = tir::Context::with_default_dialects();
     target.register_dialects(&context);
@@ -117,13 +118,17 @@ fn main() {
 
     // Pick the timing model up front so a bad `--machine` fails before running.
     let model = if args.timing {
-        let name = args.machine.as_deref().unwrap_or_else(|| {
-            eprintln!(
-                "--timing requires --machine (one of: {})",
-                target.machines().join(", "),
-            );
-            std::process::exit(2);
-        });
+        let name = args
+            .machine
+            .as_deref()
+            .or_else(|| target.default_machine())
+            .unwrap_or_else(|| {
+                eprintln!(
+                    "--timing requires --machine or --mcpu (one of: {})",
+                    target.machines().join(", "),
+                );
+                std::process::exit(2);
+            });
         let m = target.machine_model(name).unwrap_or_else(|| {
             eprintln!(
                 "unknown machine '{}' for target '{}' (one of: {})",

--- a/simulator/simcore/src/executor.rs
+++ b/simulator/simcore/src/executor.rs
@@ -31,6 +31,15 @@ pub struct Executor {
     /// register storage is keyed by file rather than by class. Classes absent
     /// from the map are their own file.
     register_files: HashMap<String, String>,
+    /// Architectural width in bits per register class (e.g. RISC-V `GPR` is 32
+    /// on rv32). Values are normalized to this width on write and produced at
+    /// it on read, so e.g. rv32 arithmetic wraps at 32 bits. Classes absent
+    /// from the map keep whatever width the behavior produced.
+    register_widths: HashMap<String, u32>,
+    /// TMDL ISA parameter values (e.g. `XLEN`) under the selected target
+    /// configuration, consulted by instruction behaviors via
+    /// [`MachineContext::isa_param`].
+    isa_params: HashMap<String, i64>,
     memory: Vec<u8>,
     memory_base: u64,
     pc: u64,
@@ -80,6 +89,33 @@ impl Executor {
     /// `GPR`/`GPRsp`). Without it, each class is its own independent file.
     pub fn set_register_files(&mut self, register_files: HashMap<String, String>) {
         self.register_files = register_files;
+    }
+
+    /// Configure architectural register widths per class (from
+    /// `TargetMachine::register_widths`).
+    pub fn set_register_widths(&mut self, widths: impl IntoIterator<Item = (&'static str, u32)>) {
+        self.register_widths = widths
+            .into_iter()
+            .map(|(class, width)| (class.to_string(), width))
+            .collect();
+    }
+
+    /// Configure TMDL ISA parameter values (from `TargetMachine::isa_params`).
+    pub fn set_isa_params(&mut self, params: impl IntoIterator<Item = (&'static str, i64)>) {
+        self.isa_params = params
+            .into_iter()
+            .map(|(name, value)| (name.to_string(), value))
+            .collect();
+    }
+
+    /// Resize `value` to a class's architectural width: truncate wider values,
+    /// zero-extend narrower ones. Identity for unconfigured classes.
+    fn resize_to_class_width(&self, class: &str, value: tir::utils::APInt) -> tir::utils::APInt {
+        match self.register_widths.get(class) {
+            Some(&width) if value.width() > width => value.truncate(width),
+            Some(&width) if value.width() < width => value.zero_extend(width),
+            _ => value,
+        }
     }
 
     /// Canonicalize a register class to the physical file it draws from.
@@ -267,13 +303,13 @@ impl MachineContext for Executor {
         // The program counter is held specially (it drives instruction fetch), but
         // semantics reference it as the `PC` register class (e.g. `PC::pc`).
         if class == "PC" {
-            return Ok(tir::utils::APInt::new(64, self.pc));
+            return Ok(self.resize_to_class_width(class, tir::utils::APInt::new(64, self.pc)));
         }
         let key = (self.register_file(class).to_string(), index);
         if let Some(value) = self.registers.get(&key) {
-            return Ok(value.clone());
+            return Ok(self.resize_to_class_width(class, value.clone()));
         }
-        Ok(tir::utils::APInt::new(64, 0))
+        Ok(self.resize_to_class_width(class, tir::utils::APInt::new(64, 0)))
     }
 
     fn write_register(
@@ -282,6 +318,7 @@ impl MachineContext for Executor {
         index: u16,
         value: tir::utils::APInt,
     ) -> Result<(), SimTrap> {
+        let value = self.resize_to_class_width(class, value);
         if class == "PC" {
             self.write_pc(value.to_u64());
             return Ok(());
@@ -289,6 +326,10 @@ impl MachineContext for Executor {
         let file = self.register_file(class).to_string();
         self.registers.insert((file, index), value);
         Ok(())
+    }
+
+    fn isa_param(&self, name: &str) -> Option<i64> {
+        self.isa_params.get(name).copied()
     }
 
     fn read_memory(&self, address: u64, size: usize) -> Result<u64, SimTrap> {
@@ -376,6 +417,45 @@ mod tests {
         assert_eq!(x1.to_u64(), 3);
         assert_eq!(x2.to_u64(), 0);
         assert_eq!(tir_be_common::MachineContext::read_pc(&executor), until_pc);
+    }
+
+    #[test]
+    fn rv32_configuration_wraps_arithmetic_at_32_bits() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let dialect = context.find_dialect::<RiscvDialect>().unwrap();
+        // Symbols are laid out in reverse declaration order: `first` executes at
+        // 0x8000_0000 and falls through to `last` at 0x8000_000c.
+        let asm = "
+            .global last
+            last:
+              add x0, x0, x0
+            .global first
+            first:
+              lui  x1, 524288
+              add  x3, x1, x1
+              addi x4, x0, -1
+        ";
+        let module = dialect.get_asm_parser().parse_asm(&context, asm).unwrap();
+        let program =
+            ProgramImage::from_module(&context, module, 0x8000_0000, Some("first")).unwrap();
+
+        let rv32 = [tir_riscv::Feature::RV32I];
+        let mut executor = Executor::new_at(4096, 0x8000_0000);
+        executor.set_isa_params(tir_riscv::isa_params(&rv32));
+        executor.set_register_widths(tir_riscv::register_widths(&rv32));
+        executor.load(program).unwrap();
+        executor.run(0x8000_000c, 10).unwrap();
+
+        let reg =
+            |idx| tir_be_common::MachineContext::read_register(&executor, "GPR", idx).unwrap();
+        // lui keeps 32-bit values (no sign extension into a 64-bit register),
+        // the doubled value wraps to zero, and -1 is the 32-bit all-ones.
+        assert_eq!((reg(1).to_u64(), reg(1).width()), (0x8000_0000, 32));
+        assert_eq!(reg(3).to_u64(), 0);
+        assert_eq!(reg(4).to_u64(), 0xFFFF_FFFF);
     }
 
     #[test]

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -53,6 +53,18 @@ pub fn generate_rust<'a>(
 // Top-level emitters
 // ---------------------------------------------------------------------------
 
+/// `(isa name, value)` for every ISA defining `param` with a literal integer
+/// default, in declaration order.
+fn isa_param_definers(files: &[ast::File], param: &str) -> Vec<(String, i64)> {
+    let mut definers = vec![];
+    for isa in files.iter().flat_map(|f| f.isas()) {
+        if let Some((_ty, Some(ast::Expr::Lit(ast::Lit::Int(li))))) = isa.parameters.get(param) {
+            definers.push((isa.name.clone(), parse_literal_value(li) as i64));
+        }
+    }
+    definers
+}
+
 fn emit_features(files: &[ast::File]) -> Result<proc_macro2::TokenStream, TMDLError> {
     let mut enum_variants = vec![];
     let mut all_variants = vec![];
@@ -89,6 +101,41 @@ fn emit_features(files: &[ast::File]) -> Result<proc_macro2::TokenStream, TMDLEr
             quote! { &[#(#members),*] }
         });
         requires_arms.push(quote! { Self::#ident => &[#(#group_ts),*] });
+    }
+
+    // One resolver block per distinct ISA parameter: the value comes from the
+    // enabled ISA that defines it (widest wins if several are enabled).
+    let mut param_blocks = vec![];
+    let mut seen_params: HashSet<&str> = HashSet::new();
+    for isa in files.iter().flat_map(|f| f.isas()) {
+        for name in isa.parameters.keys() {
+            if !seen_params.insert(name) {
+                continue;
+            }
+            let definers = isa_param_definers(files, name);
+            if definers.is_empty() {
+                continue;
+            }
+            let name_lit = proc_macro2::Literal::string(name);
+            let definer_arms = definers.iter().map(|(isa_name, value)| {
+                let feature_ident = format_ident!("{}", isa_name);
+                let value_lit = proc_macro2::Literal::i64_unsuffixed(*value);
+                quote! {
+                    if features.contains(&Feature::#feature_ident) {
+                        value = Some(value.map_or(#value_lit, |v: i64| v.max(#value_lit)));
+                    }
+                }
+            });
+            param_blocks.push(quote! {
+                {
+                    let mut value: Option<i64> = None;
+                    #(#definer_arms)*
+                    if let Some(value) = value {
+                        out.push((#name_lit, value));
+                    }
+                }
+            });
+        }
     }
 
     Ok(quote! {
@@ -148,6 +195,16 @@ fn emit_features(files: &[ast::File]) -> Result<proc_macro2::TokenStream, TMDLEr
         /// An empty requirement list means the item is unconditionally available.
         fn features_enabled(enabled: &[Feature], required: &[Feature]) -> bool {
             required.is_empty() || required.iter().any(|f| enabled.contains(f))
+        }
+
+        /// TMDL ISA parameter values (e.g. RISC-V `XLEN`) resolved from the
+        /// enabled feature set. Tools install these into the simulator so
+        /// instruction behaviors referencing `self.PARAM` execute with the
+        /// selected ISA's value.
+        pub fn isa_params(features: &[Feature]) -> Vec<(&'static str, i64)> {
+            let mut out: Vec<(&'static str, i64)> = Vec::new();
+            #(#param_blocks)*
+            out
         }
     })
 }
@@ -1106,11 +1163,53 @@ fn emit_register_info(files: &[ast::File]) -> Result<proc_macro2::TokenStream, T
         });
     }
 
+    // Architectural register widths: a class's `WIDTH` param is either a literal
+    // or an ISA parameter reference (`self.XLEN`), resolved at runtime from the
+    // enabled feature set so e.g. rv32 registers are 32 bits wide.
+    let mut width_entries = Vec::new();
+    for rc in files.iter().flat_map(|f| f.register_classes()) {
+        let name_lit = proc_macro2::Literal::string(&rc.name);
+        let width_ts = match rc.parameters.get("WIDTH") {
+            Some((_ty, Some(ast::Expr::Lit(ast::Lit::Int(li))))) => {
+                let lit =
+                    proc_macro2::Literal::u32_unsuffixed(parse_literal_value(li).min(64) as u32);
+                quote! { #lit }
+            }
+            Some((_ty, Some(ast::Expr::Field(field)))) if matches!(&*field.base, ast::Expr::Ident(id) if id.name == "self") =>
+            {
+                let param = field.member.as_str();
+                let fallback = isa_param_definers(files, param)
+                    .iter()
+                    .map(|(_, v)| *v)
+                    .max()
+                    .unwrap_or(64);
+                let param_lit = proc_macro2::Literal::string(param);
+                let fallback_lit = proc_macro2::Literal::i64_unsuffixed(fallback);
+                quote! {
+                    params
+                        .iter()
+                        .find(|(name, _)| *name == #param_lit)
+                        .map(|(_, value)| *value)
+                        .unwrap_or(#fallback_lit) as u32
+                }
+            }
+            _ => continue,
+        };
+        width_entries.push(quote! { (#name_lit, #width_ts) });
+    }
+
     Ok(quote! {
         pub fn register_info() -> tir_be_common::regalloc::RegisterInfo {
             tir_be_common::regalloc::RegisterInfo {
                 classes: &[#(#class_entries),*],
             }
+        }
+
+        /// Architectural width in bits of each register class under `features`.
+        pub fn register_widths(features: &[Feature]) -> Vec<(&'static str, u32)> {
+            let params = isa_params(features);
+            let _ = &params;
+            vec![#(#width_entries),*]
         }
     })
 }
@@ -2207,11 +2306,13 @@ fn emit_sym_inits(
                 _ => {}
             }
         } else if let Some(&value) = isa_param_values.get(name) {
-            // An ISA parameter (e.g. `XLEN`): bind it to its constant value.
+            // An ISA parameter (e.g. `XLEN`): resolve it from the machine's
+            // selected feature set, falling back to the widest TMDL value for
+            // contexts that don't configure ISA params.
             let value_lit = proc_macro2::Literal::i64_unsuffixed(value);
             steps.push(quote! {
                 __syms[#sym_lit] = Some(tir::sem_expr::Value::Int(
-                    tir::utils::APInt::new_signed(64, #value_lit),
+                    tir::utils::APInt::new_signed(64, machine.isa_param(#name_lit).unwrap_or(#value_lit)),
                 ));
             });
         }

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -55,30 +55,110 @@ pub fn generate_rust<'a>(
 
 fn emit_features(files: &[ast::File]) -> Result<proc_macro2::TokenStream, TMDLError> {
     let mut enum_variants = vec![];
+    let mut all_variants = vec![];
     let mut name_arms = vec![];
+    let mut from_name_arms = vec![];
+    let mut requires_arms = vec![];
 
     for isa in files.iter().flat_map(|f| f.isas()) {
         let ident = format_ident!("{}", &isa.name);
         let name = isa.name.clone();
+        let lower_name = isa.name.to_ascii_lowercase();
         enum_variants.push(quote! { #ident });
+        all_variants.push(quote! { Feature::#ident });
         name_arms.push(quote! { Self::#ident => #name });
+        from_name_arms.push(quote! { #lower_name => Some(Self::#ident) });
+
+        // `requires` as conjunction of any-of groups: every inner slice must
+        // intersect the enabled set for the feature to be valid.
+        let groups: Vec<Vec<&str>> = match &isa.requires {
+            None => vec![],
+            Some(ast::IsaRequirement::Single(parent)) => vec![vec![parent.as_str()]],
+            Some(ast::IsaRequirement::Any(parents)) => {
+                vec![parents.iter().map(String::as_str).collect()]
+            }
+            Some(ast::IsaRequirement::All(parents)) => {
+                parents.iter().map(|p| vec![p.as_str()]).collect()
+            }
+        };
+        let group_ts = groups.iter().map(|group| {
+            let members = group.iter().map(|name| {
+                let ident = format_ident!("{}", name);
+                quote! { Feature::#ident }
+            });
+            quote! { &[#(#members),*] }
+        });
+        requires_arms.push(quote! { Self::#ident => &[#(#group_ts),*] });
     }
 
     Ok(quote! {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub enum Feature {
             #(#enum_variants,)*
             Custom,
         }
 
         impl Feature {
+            /// Every ISA/extension defined in TMDL.
+            pub const ALL: &'static [Feature] = &[#(#all_variants),*];
+
             pub fn name(&self) -> &'static str {
                 match self {
                     #(#name_arms,)*
                     Feature::Custom => "custom",
                 }
             }
+
+            /// Look a feature up by its TMDL name, case-insensitively.
+            pub fn from_name(name: &str) -> Option<Self> {
+                match name.to_ascii_lowercase().as_str() {
+                    #(#from_name_arms,)*
+                    _ => None,
+                }
+            }
+
+            /// The TMDL `requires` clause: each inner slice is an any-of group
+            /// that must intersect the enabled feature set.
+            pub fn requires(&self) -> &'static [&'static [Feature]] {
+                match self {
+                    #(#requires_arms,)*
+                    Feature::Custom => &[],
+                }
+            }
+        }
+
+        /// Check every enabled feature's `requires` clause against the set itself.
+        pub fn validate_features(features: &[Feature]) -> Result<(), String> {
+            for feature in features {
+                for group in feature.requires() {
+                    if !group.iter().any(|needed| features.contains(needed)) {
+                        let names: Vec<&str> = group.iter().map(|f| f.name()).collect();
+                        return Err(format!(
+                            "feature '{}' requires one of: {}",
+                            feature.name(),
+                            names.join(", ")
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        /// An item scoped `for [A, B]` is available when any of its features is enabled.
+        /// An empty requirement list means the item is unconditionally available.
+        fn features_enabled(enabled: &[Feature], required: &[Feature]) -> bool {
+            required.is_empty() || required.iter().any(|f| enabled.contains(f))
         }
     })
+}
+
+/// `&[Feature::A, Feature::B]` for an item's `for [A, B]` clause.
+fn feature_slice(for_isas: &[String]) -> proc_macro2::TokenStream {
+    let idents = for_isas.iter().map(|name| {
+        let ident = format_ident!("{}", name);
+        quote! { Feature::#ident }
+    });
+    quote! { &[#(#idents),*] }
 }
 
 fn emit_instructions<'a>(
@@ -276,20 +356,36 @@ fn emit_instructions<'a>(
 
         // ISA parameters referenced via `self.PARAM` (e.g. `XLEN`). They are not
         // instruction/template params, so they survive lowering as unbound symbols;
-        // `execute()` binds them from here. An instruction may span ISAs that define
-        // the same parameter with different values (RV32I/RV64I `XLEN`); pick the
-        // widest so 64-bit execution is correct.
+        // `execute()` binds them from here. Extension ISAs (e.g. `RVM`) inherit
+        // parameters from the base ISAs in their `requires` closure. An
+        // instruction may span ISAs that define the same parameter with different
+        // values (RV32I/RV64I `XLEN`); pick the widest so 64-bit execution is
+        // correct.
         let isa_param_values: HashMap<String, i64> = {
             let mut acc: HashMap<String, i64> = HashMap::new();
-            for isa_name in &inst.for_isas {
-                if let Some(ast::Item::Isa(isa)) = item_cache.get(isa_name.as_str()) {
-                    for (name, (_ty, value)) in isa.parameters.iter() {
-                        if let Some(ast::Expr::Lit(ast::Lit::Int(li))) = value {
-                            let v = parse_literal_value(li) as i64;
-                            acc.entry(name.clone())
-                                .and_modify(|e| *e = (*e).max(v))
-                                .or_insert(v);
-                        }
+            let mut pending: Vec<&str> = inst.for_isas.iter().map(String::as_str).collect();
+            let mut visited: HashSet<&str> = HashSet::new();
+            while let Some(isa_name) = pending.pop() {
+                if !visited.insert(isa_name) {
+                    continue;
+                }
+                let Some(ast::Item::Isa(isa)) = item_cache.get(isa_name) else {
+                    continue;
+                };
+                for (name, (_ty, value)) in isa.parameters.iter() {
+                    if let Some(ast::Expr::Lit(ast::Lit::Int(li))) = value {
+                        let v = parse_literal_value(li) as i64;
+                        acc.entry(name.clone())
+                            .and_modify(|e| *e = (*e).max(v))
+                            .or_insert(v);
+                    }
+                }
+                match &isa.requires {
+                    None => {}
+                    Some(ast::IsaRequirement::Single(parent)) => pending.push(parent),
+                    Some(ast::IsaRequirement::Any(parents))
+                    | Some(ast::IsaRequirement::All(parents)) => {
+                        pending.extend(parents.iter().map(String::as_str));
                     }
                 }
             }
@@ -452,17 +548,22 @@ fn emit_instructions<'a>(
                 }
             });
 
+            let inst_features = feature_slice(&inst.for_isas);
             isel_rule_inits.push(quote! {
-                tir_be_common::isel::Rule::new(
-                    #rule_name_lit,
-                    #pattern_fn_ident(context),
-                    // base_cost is the larger of the canonical pattern size and the
-                    // TMDL-modeled instruction cost, so a genuinely expensive
-                    // instruction (high `unit` latency) outweighs the structural proxy.
-                    (#base_cost_lit).max(instruction_cost(#mnemonic_cost_lit)),
-                    #emit_fn_ident,
-                )
-                .with_operand_constraints(vec![#(#operand_constraint_entries),*])
+                if features_enabled(features, #inst_features) {
+                    rules.push(
+                        tir_be_common::isel::Rule::new(
+                            #rule_name_lit,
+                            #pattern_fn_ident(context),
+                            // base_cost is the larger of the canonical pattern size and the
+                            // TMDL-modeled instruction cost, so a genuinely expensive
+                            // instruction (high `unit` latency) outweighs the structural proxy.
+                            (#base_cost_lit).max(instruction_cost(#mnemonic_cost_lit)),
+                            #emit_fn_ident,
+                        )
+                        .with_operand_constraints(vec![#(#operand_constraint_entries),*]),
+                    );
+                }
             });
         }
 
@@ -777,19 +878,18 @@ fn emit_instructions<'a>(
 
             if let Some(mn) = mnemonic.as_deref().or(Some(op_name)) {
                 let mn_lit = proc_macro2::Literal::string(mn);
+                let inst_features = feature_slice(&inst.for_isas);
                 instruction_parser_map_inits.push(quote! {
-                    let f: tir_be_common::AsmInstructionParser = #parse_fn_ident;
-                    map.entry(#mn_lit.to_string()).or_default().push(f);
+                    if features_enabled(features, #inst_features) {
+                        let f: tir_be_common::AsmInstructionParser = #parse_fn_ident;
+                        map.entry(#mn_lit.to_string()).or_default().push(f);
+                    } else {
+                        disabled.insert(#mn_lit.to_string());
+                    }
                 });
             }
         }
     }
-
-    let isel_rules_body = if isel_rule_inits.is_empty() {
-        quote! { Vec::new() }
-    } else {
-        quote! { vec![#(#isel_rule_inits),*] }
-    };
 
     Ok(quote! {
         #(#instruction_defs)*
@@ -797,12 +897,23 @@ fn emit_instructions<'a>(
         #(#machine_instruction_impls)*
         #(#as_sem_expr_impls)*
 
-        fn get_instruction_parsers() -> std::collections::HashMap<String, Vec<tir_be_common::AsmInstructionParser>> {
+        /// Mnemonic-keyed parsers for the instructions available under `features`,
+        /// plus the mnemonics that exist in TMDL but are disabled by the feature
+        /// set (so the assembler can reject them instead of skipping them).
+        fn get_instruction_parsers(
+            features: &[Feature],
+        ) -> (
+            std::collections::HashMap<String, Vec<tir_be_common::AsmInstructionParser>>,
+            std::collections::HashSet<String>,
+        ) {
             let mut map: std::collections::HashMap<String, Vec<tir_be_common::AsmInstructionParser>> = std::collections::HashMap::new();
+            let mut disabled: std::collections::HashSet<String> = std::collections::HashSet::new();
             #(#instruction_parsers_impls)*
             #(#instruction_parser_map_inits)*
 
-            map
+            // A mnemonic with any enabled form stays available.
+            disabled.retain(|mnemonic| !map.contains_key(mnemonic));
+            (map, disabled)
         }
 
         fn get_instruction_printers() -> std::collections::HashMap<String, tir_be_common::AsmInstructionPrinter> {
@@ -815,9 +926,12 @@ fn emit_instructions<'a>(
 
         #(#isel_rule_emitters)*
 
-        pub fn get_isel_rules(context: &tir::Context) -> Vec<tir_be_common::isel::Rule> {
-            let _ = &context;
-            #isel_rules_body
+        /// Instruction-selection rules for the instructions available under `features`.
+        pub fn get_isel_rules(context: &tir::Context, features: &[Feature]) -> Vec<tir_be_common::isel::Rule> {
+            let _ = (&context, &features);
+            let mut rules = Vec::new();
+            #(#isel_rule_inits)*
+            rules
         }
     })
 }
@@ -1127,24 +1241,37 @@ fn emit_machine_models<'a>(
         if let Some(alias) = &machine.alias {
             keys.push(alias.clone());
         }
+        let machine_features = feature_slice(&machine.for_isas);
         let key_lits = keys.iter().map(|k| proc_macro2::Literal::string(k));
-        machine_names.push(proc_macro2::Literal::string(keys.last().unwrap()));
-        lookup_arms.push(quote! { #(#key_lits)|* => Some(#fn_ident()) });
+        let tool_name = proc_macro2::Literal::string(keys.last().unwrap());
+        machine_names.push(quote! {
+            if features_enabled(features, #machine_features) {
+                names.push(#tool_name);
+            }
+        });
+        lookup_arms.push(quote! {
+            #(#key_lits)|* => features_enabled(features, #machine_features).then(#fn_ident)
+        });
     }
 
     Ok(quote! {
         #(#model_fns)*
 
-        /// Resolve a machine by its TMDL name or alias, or `None` if unknown.
-        pub fn machine_model(name: &str) -> Option<tir_be_common::sched::MachineModel> {
+        /// Resolve a machine by its TMDL name or alias. `None` when the name is
+        /// unknown or the machine's `for [...]` clause is disjoint from `features`.
+        pub fn machine_model(name: &str, features: &[Feature]) -> Option<tir_be_common::sched::MachineModel> {
             match name {
                 #(#lookup_arms,)*
                 _ => None,
             }
         }
 
-        /// Tool-facing names of every machine defined in TMDL (alias preferred).
-        pub const MACHINES: &[&str] = &[#(#machine_names),*];
+        /// Tool-facing names (alias preferred) of the machines compatible with `features`.
+        pub fn machines(features: &[Feature]) -> Vec<&'static str> {
+            let mut names = Vec::new();
+            #(#machine_names)*
+            names
+        }
     })
 }
 

--- a/tools/src/mc/mod.rs
+++ b/tools/src/mc/mod.rs
@@ -16,6 +16,9 @@ pub struct ToolArgs {
     /// Target architecture
     #[arg(long)]
     march: String,
+    /// Target feature toggles (e.g. `+m,-zmmul`), applied on top of `--march`.
+    #[arg(long)]
+    mattr: Option<String>,
     /// Optional stage after which pipeline is stopped
     #[arg(value_enum, long)]
     stage: Option<Stage>,
@@ -35,13 +38,7 @@ pub enum Stage {
 }
 
 pub fn run(args: ToolArgs) -> Result<(), Box<dyn Error>> {
-    let target = tir_targets::select(&args.march, args.mcpu.as_deref()).ok_or_else(|| {
-        format!(
-            "unknown target '{}' (supported: {})",
-            args.march,
-            tir_targets::supported_targets().join(", ")
-        )
-    })?;
+    let target = tir_targets::select(&args.march, args.mcpu.as_deref(), args.mattr.as_deref())?;
 
     let context = Context::with_default_dialects();
     target.register_dialects(&context);

--- a/tools/src/sched/mod.rs
+++ b/tools/src/sched/mod.rs
@@ -43,9 +43,12 @@ pub struct ToolArgs {
     /// Target architecture
     #[arg(long)]
     march: String,
+    /// Target feature toggles (e.g. `+m,-zmmul`), applied on top of `--march`.
+    #[arg(long)]
+    mattr: Option<String>,
     /// Performance model / machine to analyze against (e.g. `ooo`, `in-order`).
-    /// Omitted: a generic single-issue core that costs every instruction one
-    /// cycle (the scheduling fallback when no machine is selected).
+    /// Omitted: the machine implied by `--mcpu` when it names one, otherwise a
+    /// generic single-issue core that costs every instruction one cycle.
     #[arg(long)]
     model: Option<String>,
     /// Number of times the region is repeated through the pipeline.
@@ -59,18 +62,12 @@ pub struct ToolArgs {
 }
 
 pub fn run(args: ToolArgs) -> Result<(), Box<dyn Error>> {
-    let target = tir_targets::select(&args.march, args.mcpu.as_deref()).ok_or_else(|| {
-        format!(
-            "unknown target '{}' (supported: {})",
-            args.march,
-            tir_targets::supported_targets().join(", ")
-        )
-    })?;
+    let target = tir_targets::select(&args.march, args.mcpu.as_deref(), args.mattr.as_deref())?;
 
     let context = Context::with_default_dialects();
     target.register_dialects(&context);
 
-    let model = match &args.model {
+    let model = match args.model.as_deref().or_else(|| target.default_machine()) {
         Some(name) => target.machine_model(name).ok_or_else(|| {
             format!(
                 "unknown machine '{}' for target '{}' (one of: {})",


### PR DESCRIPTION
TMDL declares ISAs, extensions and their requirements, but nothing
consumed them: every instruction, isel rule and machine model was always
available regardless of --march, and the RVM definitions were not even
compiled. Hook the feature system up end-to-end:

- rustgen: derive Eq/Hash on Feature and emit Feature::ALL, from_name,
  requires (from TMDL `requires` clauses) and validate_features.
  Generated get_instruction_parsers/get_isel_rules/machine_model/machines
  now take the enabled feature set and filter items by their `for [...]`
  clause. Extension ISAs inherit parameters (e.g. XLEN) through their
  requires closure, fixing parameter binding for RVM behaviors.
- riscv: compile multiplication.tmdl (mul/mulh existed in TMDL but were
  never built). March strings resolve to feature sets: rv64i enables only
  RV64I, rv64im pulls in RVM/Zmmul, rv32im excludes the RV64-only word
  ops. Unmodeled standard extensions parse and contribute nothing so
  common GNU strings (rv64gc_zba_zbb) keep working. Bare riscv32/riscv64
  select the generic everything-on profile.
- targets: SelectFn takes --mattr and returns errors instead of a bare
  Option, so invalid extension/cpu combinations are diagnosed. LLVM-style
  --mattr (+feat/-feat) added to tir mc, tir sched and isasim. --mcpu
  resolves TMDL machine names/aliases, validates them against the feature
  set and provides the default machine model.
- asm parser: mnemonics that exist but are disabled by the feature set
  are parse errors instead of silently skipped identifiers.
- sem_expr: extract above a multiply's width evaluates the signed
  full-product high half (the TMDL mulh idiom), instead of panicking.
- machine models are gated by their `for [...]` clause: scr1-3stage is
  only selectable on rv32 targets.

https://claude.ai/code/session_01FxaqLU7BweRE5AYT9UKhty