### PR TITLE
feat(asm): support constant literal directives in parser and IR

### DIFF
--- a/backends/common/src/lexer.rs
+++ b/backends/common/src/lexer.rs
@@ -24,6 +24,14 @@ pub enum Token<'src> {
     #[token(".global")]
     Global,
 
+    // Catch-all for directives without a dedicated token (`.dword`, `.string`,
+    // `.rodata`, ...). Specific tokens above win on priority.
+    #[regex("\\.[a-zA-Z_][a-zA-Z0-9_\\.]*", |d| d.slice())]
+    Directive(&'src str),
+
+    #[regex("\"[^\"]*\"", |s| { let s = s.slice(); &s[1..s.len() - 1] })]
+    StringLit(&'src str),
+
     #[regex("[a-zA-Z_][a-zA-Z0-9_\\.]*:", |n| { let n = n.slice(); &n[0..n.len() - 1] })]
     Label(&'src str),
 
@@ -81,6 +89,26 @@ mod tests {
     #[test]
     fn asm_accepts_single_character_identifiers_and_labels() {
         assert_eq!(lex("a b:"), Ok(vec![Token::Ident("a"), Token::Label("b")]));
+    }
+
+    #[test]
+    fn asm_lexes_directives_and_string_literals() {
+        assert_eq!(
+            lex(".dword 0x100000000"),
+            Ok(vec![
+                Token::Directive(".dword"),
+                Token::HexNumber("0x100000000")
+            ])
+        );
+        assert_eq!(
+            lex(".string \"Hello, RISC-V!\""),
+            Ok(vec![
+                Token::Directive(".string"),
+                Token::StringLit("Hello, RISC-V!")
+            ])
+        );
+        // Dedicated tokens still win over the directive catch-all.
+        assert_eq!(lex(".text .data"), Ok(vec![Token::Text, Token::Data]));
     }
 
     #[test]

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -159,6 +159,6 @@ pub mod ops {
 dialect! {
     AsmDialect {
         name: "asm",
-        operations: [SectionOp, SectionEndOp, SymbolOp, SymbolEndOp, BlockEndOp],
+        operations: [SectionOp, SectionEndOp, SymbolOp, SymbolEndOp, LiteralOp, BlockEndOp],
     }
 }

--- a/backends/common/src/operations.rs
+++ b/backends/common/src/operations.rs
@@ -41,6 +41,18 @@ operation! {
 
 impl Terminator for SymbolEndOp {}
 
+// A data definition directive (`.dword 42`, `.string "hi"`, `.space 16`).
+// `kind` names the directive, `value` holds the literal (Int or Str).
+operation! {
+    LiteralOp {
+        name: "literal",
+        dialect: "asm",
+        attributes: A {
+            kind: "Str",
+        }
+    }
+}
+
 operation! {
     BlockEndOp {
         name: "block_end",

--- a/backends/common/src/parser.rs
+++ b/backends/common/src/parser.rs
@@ -6,7 +6,9 @@ use tir::{
     parse::tokens::Parser,
 };
 
-use crate::{SectionOpBuilder, SymbolEndOpBuilder, SymbolOpBuilder, lex, lexer::Token};
+use crate::{
+    LiteralOpBuilder, SectionOpBuilder, SymbolEndOpBuilder, SymbolOpBuilder, lex, lexer::Token,
+};
 
 pub type AsmInstructionParser =
     for<'src> fn(&tir::Context, &mut IRBuilder, &mut Parser<'src, Token<'src>>) -> Result<(), ()>;
@@ -83,6 +85,49 @@ impl AsmParser {
                     // FIXME set insertion point to end of text section
                     let _ = parser.bump();
                 }
+                Token::Directive(directive) => {
+                    let directive = *directive;
+                    let _ = parser.bump();
+                    let kind = &directive[1..];
+                    match kind {
+                        "byte" | "half" | "word" | "dword" | "space" => {
+                            let value = match parser.bump() {
+                                Some(Token::DecNumber(n)) => n.parse::<i64>().map_err(|_| ())?,
+                                Some(Token::HexNumber(n)) => parse_hex(n)?,
+                                _ => return Err(()),
+                            };
+                            builder.insert(
+                                LiteralOpBuilder::new(context)
+                                    .attr(
+                                        "kind",
+                                        tir::attributes::AttributeValue::Str(kind.to_string()),
+                                    )
+                                    .attr("value", tir::attributes::AttributeValue::Int(value))
+                                    .build(),
+                            );
+                        }
+                        "string" | "ascii" | "asciz" => {
+                            let Some(Token::StringLit(value)) = parser.bump() else {
+                                return Err(());
+                            };
+                            builder.insert(
+                                LiteralOpBuilder::new(context)
+                                    .attr(
+                                        "kind",
+                                        tir::attributes::AttributeValue::Str(kind.to_string()),
+                                    )
+                                    .attr(
+                                        "value",
+                                        tir::attributes::AttributeValue::Str((*value).to_string()),
+                                    )
+                                    .build(),
+                            );
+                        }
+                        // Layout/section directives (`.rodata`, `.align`, ...)
+                        // carry no data; skip them like unknown idents.
+                        _ => {}
+                    }
+                }
                 Token::Ident(ident) => {
                     // Try to dispatch to an instruction parser by mnemonic.
                     let key = ident.to_string();
@@ -123,4 +168,15 @@ impl AsmParser {
 
         Ok(module)
     }
+}
+
+fn parse_hex(text: &str) -> Result<i64, ()> {
+    let (neg, text) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text),
+    };
+    let digits = text.trim_start_matches("0x").trim_start_matches("0X");
+    let value = i128::from_str_radix(digits, 16).map_err(|_| ())?;
+    let value = if neg { -value } else { value };
+    i64::try_from(value).map_err(|_| ())
 }

--- a/backends/riscv/checks/asm/arithmetic-rv64.S
+++ b/backends/riscv/checks/asm/arithmetic-rv64.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
 
     .section .data
 bigval: .dword 0x100000000
@@ -10,3 +10,9 @@ _start64:
     ld   x6, 0(x5)
     addi x7, x6, 42
     sd   x7, 0(x5)
+
+# CHECK:      asm.symbol {name = "_start64"}
+# CHECK-NEXT: riscv.ld {rd = x6, imm = 0, rs1 = x5}
+# CHECK-NEXT: riscv.addi {rd = x7, rs1 = x6, imm = 42}
+# CHECK-NEXT: riscv.sd {rs2 = x7, imm = 0, rs1 = x5}
+# CHECK:      asm.literal {kind = "dword", value = 4294967296}

--- a/backends/riscv/checks/asm/memory_strings-rv32.S
+++ b/backends/riscv/checks/asm/memory_strings-rv32.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
 
     .section .rodata
 msg: .string "Hello, RISC-V!"
@@ -15,3 +15,9 @@ _memtest:
     lw   x3, 0(x1)
     sw   x3, 0(x2)
     nop
+
+# CHECK:      asm.symbol {name = "_memtest"}
+# CHECK-NEXT: riscv.lw {rd = x3, imm = 0, rs1 = x1}
+# CHECK-NEXT: riscv.sw {rs2 = x3, imm = 0, rs1 = x2}
+# CHECK:      asm.literal {kind = "string", value = "Hello, RISC-V!"}
+# CHECK-NEXT: asm.literal {kind = "space", value = 16}

--- a/backends/riscv/checks/asm/shifts-rv64.S
+++ b/backends/riscv/checks/asm/shifts-rv64.S
@@ -1,4 +1,4 @@
-# RUNx: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
+# RUN: tir mc --march=rv64i --stage=regalloc %s | filecheck %s
 
     .section .text
 shift_test:


### PR DESCRIPTION
Lex data directives (.dword, .string, .space, ...) and string literals,
represent them as asm.literal ops with kind/value attributes, and
re-enable the arithmetic-rv64, memory_strings-rv32 and shifts-rv64
checks.

https://claude.ai/code/session_01WvchPBspkm7TAgzsZJJpw9