### PR TITLE
feat: add RISC-V Zicsr extension with perf counters and ecall/ebreak

### DIFF
--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -54,6 +54,13 @@ pub enum SimTrap {
         max_cycles: u64,
         until_pc: u64,
     },
+    /// A synchronous exception raised by instruction semantics (TMDL `trap`,
+    /// e.g. ecall/ebreak) that no installed handler absorbed. `cause` uses the
+    /// target's cause encoding (RISC-V mcause for the riscv backend).
+    Exception {
+        cause: u64,
+        pc: u64,
+    },
 }
 
 pub trait MachineContext {
@@ -70,6 +77,24 @@ pub trait MachineContext {
         let _ = name;
         None
     }
+    /// Raise a synchronous exception from instruction semantics (TMDL `trap`).
+    /// Implementations may absorb it (e.g. emulate an environment call) and
+    /// return `Ok`; the default surfaces it as a [`SimTrap::Exception`].
+    fn raise_exception(&mut self, cause: u64) -> Result<(), SimTrap> {
+        Err(SimTrap::Exception {
+            cause,
+            pc: self.read_pc(),
+        })
+    }
+}
+
+/// A hardware performance counter a target maps onto one of its registers
+/// (e.g. the RISC-V `cycle`/`time`/`instret` CSRs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerfCounter {
+    Cycles,
+    Time,
+    InstructionsRetired,
 }
 
 /// How an instruction affects control flow, derived at TMDL-compile time from

--- a/backends/common/src/lib.rs
+++ b/backends/common/src/lib.rs
@@ -89,12 +89,17 @@ pub trait MachineContext {
 }
 
 /// A hardware performance counter a target maps onto one of its registers
-/// (e.g. the RISC-V `cycle`/`time`/`instret` CSRs).
+/// (e.g. the RISC-V `cycle`/`time`/`instret` CSRs). The `High` variants
+/// deliver the upper 32 bits of the 64-bit counter, for targets that split
+/// counters across two registers (RV32 `cycleh`/`timeh`/`instreth`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PerfCounter {
     Cycles,
     Time,
     InstructionsRetired,
+    CyclesHigh,
+    TimeHigh,
+    InstructionsRetiredHigh,
 }
 
 /// How an instruction affects control flow, derived at TMDL-compile time from

--- a/backends/common/src/target.rs
+++ b/backends/common/src/target.rs
@@ -77,6 +77,13 @@ pub trait TargetMachine {
     /// encoding index — the inverse of the asm parser, for printing `x1`/`ra`
     /// instead of the raw `(class, index)`. `None` if the class/index is unknown.
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String>;
+
+    /// Registers backed by hardware performance counters under the selected
+    /// features, as `(class, index, counter)`. Simulators route reads of these
+    /// registers to their counters instead of the register file.
+    fn counter_registers(&self) -> Vec<(&'static str, u16, crate::PerfCounter)> {
+        vec![]
+    }
 }
 
 /// A target made selectable by `--march`/`--mcpu`.

--- a/backends/riscv/build.rs
+++ b/backends/riscv/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add_input("./defs/main.tmdl")
         .add_input("./defs/base.tmdl")
         .add_input("./defs/multiplication.tmdl")
+        .add_input("./defs/zicsr.tmdl")
         .add_input("./defs/perf.tmdl")
         .add_input("./defs/syntacore_scr1.tmdl")
         .output(OutputKind::File(format!(

--- a/backends/riscv/checks/asm/syscall-rv32.S
+++ b/backends/riscv/checks/asm/syscall-rv32.S
@@ -1,5 +1,4 @@
 # RUN: tir mc --march=rv32i --stage=regalloc %s | filecheck %s
-# XFAIL: *
 
     .section .text
     .global _exit

--- a/backends/riscv/checks/asm/zicsr-rv32.S
+++ b/backends/riscv/checks/asm/zicsr-rv32.S
@@ -1,0 +1,18 @@
+# RUN: tir mc --march=rv32i_zicsr --stage=regalloc %s | filecheck %s
+# RUN: not tir mc --march=rv32i %s
+
+.global f
+f:
+    csrrw  x5, mscratch, x6
+    csrrs  x7, cycle, x0
+    csrrc  x8, instret, x9
+    csrrwi x10, time, 1
+    csrrsi x11, mscratch, 2
+    csrrci x12, mscratch, 31
+
+# CHECK:      riscv.csrrw {rd = x5, csr = mscratch, rs1 = x6}
+# CHECK-NEXT: riscv.csrrs {rd = x7, csr = cycle, rs1 = x0}
+# CHECK-NEXT: riscv.csrrc {rd = x8, csr = instret, rs1 = x9}
+# CHECK-NEXT: riscv.csrrwi {rd = x10, csr = time, zimm = 1}
+# CHECK-NEXT: riscv.csrrsi {rd = x11, csr = mscratch, zimm = 2}
+# CHECK-NEXT: riscv.csrrci {rd = x12, csr = mscratch, zimm = 31}

--- a/backends/riscv/checks/asm/zicsr-rv32.S
+++ b/backends/riscv/checks/asm/zicsr-rv32.S
@@ -9,6 +9,8 @@ f:
     csrrwi x10, time, 1
     csrrsi x11, mscratch, 2
     csrrci x12, mscratch, 31
+    csrrs  x13, cycleh, x0
+    csrrs  x14, instreth, x0
 
 # CHECK:      riscv.csrrw {rd = x5, csr = mscratch, rs1 = x6}
 # CHECK-NEXT: riscv.csrrs {rd = x7, csr = cycle, rs1 = x0}
@@ -16,3 +18,5 @@ f:
 # CHECK-NEXT: riscv.csrrwi {rd = x10, csr = time, zimm = 1}
 # CHECK-NEXT: riscv.csrrsi {rd = x11, csr = mscratch, zimm = 2}
 # CHECK-NEXT: riscv.csrrci {rd = x12, csr = mscratch, zimm = 31}
+# CHECK-NEXT: riscv.csrrs {rd = x13, csr = cycleh, rs1 = x0}
+# CHECK-NEXT: riscv.csrrs {rd = x14, csr = instreth, rs1 = x0}

--- a/backends/riscv/defs/base.tmdl
+++ b/backends/riscv/defs/base.tmdl
@@ -528,6 +528,43 @@ instruction ShiftRightArithmeticImmWord for [RV64I] : ShiftImmWord64 {
     }
 }
 
+// SYSTEM instructions without operands; the whole encoding is fixed.
+template SystemNoOperand for [RV32I, RV64I] {
+    param MNEMONIC: String;
+    param IMM12: bits<12>;
+    param OPCODE: bits<7> = 0b1110011;
+
+    encoding {
+        0..6 => OPCODE,
+        7..19 => 0,
+        20..31 => IMM12,
+    }
+
+    asm {
+        "{self.MNEMONIC}"
+    }
+}
+
+instruction EnvCall for [RV32I, RV64I] : SystemNoOperand {
+    param MNEMONIC: String = "ecall";
+    param IMM12: bits<12> = 0b000000000000;
+
+    behavior {
+        // mcause 11: environment call from M-mode (the simulator's only mode).
+        trap(11);
+    }
+}
+
+instruction EnvBreak for [RV32I, RV64I] : SystemNoOperand {
+    param MNEMONIC: String = "ebreak";
+    param IMM12: bits<12> = 0b000000000001;
+
+    behavior {
+        // mcause 3: breakpoint.
+        trap(3);
+    }
+}
+
 instruction AddWord for [RV64I] : ALUOpWord {
     param MNEMONIC: String = "addw";
     param FUNCT3: bits<3> = 0b000;

--- a/backends/riscv/defs/zicsr.tmdl
+++ b/backends/riscv/defs/zicsr.tmdl
@@ -1,0 +1,131 @@
+// Zicsr extension: control and status register instructions, plus the
+// user-level counter CSRs backing basic performance monitoring.
+
+isa Zicsr requires [RV32I | RV64I] {}
+
+// CSRs are a register file addressed by the 12-bit csr field; each register's
+// explicit index is its architectural CSR address. Only the CSRs the simulator
+// models are listed; counters are read-only and provided by the simulator,
+// mscratch is an ordinary read-write register.
+register_class CSR for [Zicsr] {
+    param ENCODING_LEN: Integer = 12;
+    param WIDTH: Integer = self.XLEN;
+
+    registers {
+        cycle => { index = 0xC00 },
+        time => { index = 0xC01 },
+        instret => { index = 0xC02 },
+        mscratch => { index = 0x340 },
+    }
+}
+
+template CSRType for [Zicsr] {
+    param MNEMONIC: String;
+    param FUNCT3: bits<3>;
+    param OPCODE: bits<7> = 0b1110011;
+
+    operands {
+        rd: GPR,
+        csr: CSR,
+        rs1: GPR,
+    }
+
+    encoding {
+        0..6 => OPCODE,
+        7..11 => rd,
+        12..14 => FUNCT3,
+        15..19 => rs1,
+        20..31 => csr,
+    }
+
+    asm {
+        "{self.MNEMONIC} {rd}, {csr}, {rs1}"
+    }
+}
+
+template CSRImmType for [Zicsr] {
+    param MNEMONIC: String;
+    param FUNCT3: bits<3>;
+    param OPCODE: bits<7> = 0b1110011;
+
+    operands {
+        rd: GPR,
+        csr: CSR,
+        zimm: bits<5>,
+    }
+
+    encoding {
+        0..6 => OPCODE,
+        7..11 => rd,
+        12..14 => FUNCT3,
+        15..19 => zimm,
+        20..31 => csr,
+    }
+
+    asm {
+        "{self.MNEMONIC} {rd}, {csr}, {zimm}"
+    }
+}
+
+// Behaviors assign rd first so it observes the pre-write CSR value, matching
+// the spec's read-then-modify ordering.
+
+instruction CSRReadWrite for [Zicsr] : CSRType {
+    param MNEMONIC: String = "csrrw";
+    param FUNCT3: bits<3> = 0b001;
+
+    behavior {
+        rd = csr;
+        csr = rs1;
+    }
+}
+
+instruction CSRReadSet for [Zicsr] : CSRType {
+    param MNEMONIC: String = "csrrs";
+    param FUNCT3: bits<3> = 0b010;
+
+    behavior {
+        rd = csr;
+        csr = csr | rs1;
+    }
+}
+
+instruction CSRReadClear for [Zicsr] : CSRType {
+    param MNEMONIC: String = "csrrc";
+    param FUNCT3: bits<3> = 0b011;
+
+    behavior {
+        rd = csr;
+        csr = csr & (rs1 ^ sext(0b1, self.XLEN));
+    }
+}
+
+instruction CSRReadWriteImm for [Zicsr] : CSRImmType {
+    param MNEMONIC: String = "csrrwi";
+    param FUNCT3: bits<3> = 0b101;
+
+    behavior {
+        rd = csr;
+        csr = zext(zimm, self.XLEN);
+    }
+}
+
+instruction CSRReadSetImm for [Zicsr] : CSRImmType {
+    param MNEMONIC: String = "csrrsi";
+    param FUNCT3: bits<3> = 0b110;
+
+    behavior {
+        rd = csr;
+        csr = csr | zext(zimm, self.XLEN);
+    }
+}
+
+instruction CSRReadClearImm for [Zicsr] : CSRImmType {
+    param MNEMONIC: String = "csrrci";
+    param FUNCT3: bits<3> = 0b111;
+
+    behavior {
+        rd = csr;
+        csr = csr & (zext(zimm, self.XLEN) ^ sext(0b1, self.XLEN));
+    }
+}

--- a/backends/riscv/defs/zicsr.tmdl
+++ b/backends/riscv/defs/zicsr.tmdl
@@ -15,6 +15,11 @@ register_class CSR for [Zicsr] {
         cycle => { index = 0xC00 },
         time => { index = 0xC01 },
         instret => { index = 0xC02 },
+        // Upper halves of the 64-bit counters. Architecturally RV32-only;
+        // the simulator backs them with counters only on RV32.
+        cycleh => { index = 0xC80 },
+        timeh => { index = 0xC81 },
+        instreth => { index = 0xC82 },
         mscratch => { index = 0x340 },
     }
 }

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -734,11 +734,21 @@ impl tir_be_common::TargetMachine for RiscvTarget {
         }
         // The user-level counter CSRs at their architectural addresses (the
         // indices declared in zicsr.tmdl).
-        vec![
+        let mut counters = vec![
             ("CSR", 0xC00, PerfCounter::Cycles),
             ("CSR", 0xC01, PerfCounter::Time),
             ("CSR", 0xC02, PerfCounter::InstructionsRetired),
-        ]
+        ];
+        // RV32 reads counters as XLEN-wide halves: cycleh/timeh/instreth
+        // deliver the upper 32 bits. RV64 reads the full counter directly.
+        if self.config.features.contains(&Feature::RV32I) {
+            counters.extend([
+                ("CSR", 0xC80, PerfCounter::CyclesHigh),
+                ("CSR", 0xC81, PerfCounter::TimeHigh),
+                ("CSR", 0xC82, PerfCounter::InstructionsRetiredHigh),
+            ]);
+        }
+        counters
     }
 }
 
@@ -1797,6 +1807,22 @@ mod target_parser_tests {
         );
         // Extensions alone resolve nothing; the base supplies XLEN.
         assert_eq!(crate::isa_params(&[Feature::RVM]), vec![]);
+    }
+
+    #[test]
+    fn counter_registers_follow_the_feature_set() {
+        use tir_be_common::{PerfCounter, TargetMachine};
+
+        let target = |march| crate::RiscvTarget {
+            config: TargetConfig::parse(march, None, None).expect("march should parse"),
+        };
+        assert!(target("rv64i").counter_registers().is_empty());
+        // RV64 reads the full 64-bit counters; RV32 adds the high-half CSRs.
+        assert_eq!(target("rv64i_zicsr").counter_registers().len(), 3);
+        let rv32 = target("rv32i_zicsr").counter_registers();
+        assert_eq!(rv32.len(), 6);
+        assert!(rv32.contains(&("CSR", 0xC80, PerfCounter::CyclesHigh)));
+        assert!(rv32.contains(&("CSR", 0xC82, PerfCounter::InstructionsRetiredHigh)));
     }
 
     #[test]

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -212,6 +212,7 @@ fn parse_riscv_isa_string(march: &str) -> Result<TargetConfig, String> {
             enable(base_feature);
             enable(Feature::RVM);
             enable(Feature::Zmmul);
+            enable(Feature::Zicsr);
             skip_extension_version(&mut chars);
         }
         'e' => return Err(format!("unsupported RISC-V base ISA 'e' in '{march}'")),
@@ -408,6 +409,16 @@ dialect! {
             // M extension (Zmmul subset)
             MulOp,
             MulHOp,
+            // Zicsr
+            CSRReadWriteOp,
+            CSRReadSetOp,
+            CSRReadClearOp,
+            CSRReadWriteImmOp,
+            CSRReadSetImmOp,
+            CSRReadClearImmOp,
+            // System
+            EnvCallOp,
+            EnvBreakOp,
             // Loads / stores
             LoadByteOp,
             LoadByteUnsignedOp,
@@ -714,6 +725,20 @@ impl tir_be_common::TargetMachine for RiscvTarget {
 
     fn register_name(&self, class: &str, index: u16, prefer_abi: bool) -> Option<String> {
         crate::register_name(class, index, prefer_abi)
+    }
+
+    fn counter_registers(&self) -> Vec<(&'static str, u16, tir_be_common::PerfCounter)> {
+        use tir_be_common::PerfCounter;
+        if !self.config.features.contains(&Feature::Zicsr) {
+            return vec![];
+        }
+        // The user-level counter CSRs at their architectural addresses (the
+        // indices declared in zicsr.tmdl).
+        vec![
+            ("CSR", 0xC00, PerfCounter::Cycles),
+            ("CSR", 0xC01, PerfCounter::Time),
+            ("CSR", 0xC02, PerfCounter::InstructionsRetired),
+        ]
     }
 }
 
@@ -1718,7 +1743,7 @@ mod target_parser_tests {
         // Bare architecture names select the generic, everything-on profile.
         assert_eq!(
             features("riscv64", None),
-            vec![Feature::RV64I, Feature::Zmmul, Feature::RVM]
+            vec![Feature::RV64I, Feature::Zmmul, Feature::RVM, Feature::Zicsr]
         );
         assert!(!features("riscv32", None).contains(&Feature::RV64I));
     }
@@ -1764,11 +1789,11 @@ mod target_parser_tests {
         );
         assert_eq!(
             crate::register_widths(&[Feature::RV32I]),
-            vec![("PC", 32), ("GPR", 32)]
+            vec![("PC", 32), ("GPR", 32), ("CSR", 32)]
         );
         assert_eq!(
             crate::register_widths(&[Feature::RV64I]),
-            vec![("PC", 64), ("GPR", 64)]
+            vec![("PC", 64), ("GPR", 64), ("CSR", 64)]
         );
         // Extensions alone resolve nothing; the base supplies XLEN.
         assert_eq!(crate::isa_params(&[Feature::RVM]), vec![]);

--- a/docs/tmdl/syntax.md
+++ b/docs/tmdl/syntax.md
@@ -93,6 +93,11 @@ register_class GPR for [RV32I, RV64I] {
 - `for [...]` — attach the class to multiple ISAs.
 - Single register: `name("alias") => { traits = [..] }`
 - Range: `start..end("alias{}") => { traits = [..] }` uses `{}` placeholder to number aliases sequentially.
+- Explicit encoding index: `name => { index = 0xC00 }` for registers whose
+  architectural number is not derivable from the name (e.g. RISC-V CSRs).
+  Without it, the index is the trailing number in the name (`x5` -> 5), or the
+  declaration position for index-less registers. Both `index` and `traits` are
+  optional inside the braces.
 - Known traits currently recognized by tools: `hardwired_zero`, `return_address`, `caller_saved`, `callee_saved`, `stack_pointer`. Other identifiers parse but may be ignored by current tooling.
 
 #### Inheritance
@@ -176,6 +181,10 @@ instruction Add for [RV32I, RV64I] : RType {
 
 - Same structure as `template` with optional inheritance and `for [...]`.
 - `behavior` — required; describes semantics using the expression language. Basic assignments and arithmetic/bitwise ops are supported.
+- Builtin functions usable in behaviors: `sext`/`zext` (width extension),
+  `extract`, `clamp`, `log2Ceil`, `load`/`store` (memory), and `trap(cause)` —
+  raise a synchronous exception with a constant cause code (e.g. RISC-V
+  `ecall`/`ebreak`); the simulator routes it to its exception callback.
 - Optional `asm`/`encoding` sections can be provided or inherited.
 
 ## Encoding Section Details

--- a/simulator/isasim/checks/riscv/exec/trap-ecall.S
+++ b/simulator/isasim/checks/riscv/exec/trap-ecall.S
@@ -1,0 +1,17 @@
+# RUN: isasim --march=riscv64 --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s
+
+# ecall traps to the embedder; isasim reports it and halts the run, so the
+# instruction after the ecall never executes.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  addi x17, x0, 93
+  ecall
+  addi x1, x0, 1
+
+# CHECK: trap: cause=11 pc=0x80000004
+# CHECK: final registers:
+# CHECK-NOT: GPR[1]
+# CHECK: GPR[17] = 0x5d

--- a/simulator/isasim/checks/riscv/exec/zicsr-counters-rv32.S
+++ b/simulator/isasim/checks/riscv/exec/zicsr-counters-rv32.S
@@ -1,0 +1,18 @@
+# RUN: isasim --march=rv32i_zicsr --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s
+
+# RV32 reads the 64-bit counters as two 32-bit halves: the low half counts
+# retired instructions, the high half is zero for short runs.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  addi  x4, x0, 1
+  csrrs x1, instret, x0
+  csrrs x2, instreth, x0
+  csrrs x3, cycleh, x0
+
+# CHECK: final registers:
+# CHECK-DAG: GPR[1] = 0x1
+# CHECK-DAG: GPR[2] = 0x0
+# CHECK-DAG: GPR[3] = 0x0

--- a/simulator/isasim/checks/riscv/exec/zicsr-counters.S
+++ b/simulator/isasim/checks/riscv/exec/zicsr-counters.S
@@ -1,0 +1,20 @@
+# RUN: isasim --march=riscv64 --entry=_start --until-pc=done --trace-registers-end %s | filecheck %s
+
+# Counter CSRs report instructions retired before the reading instruction;
+# mscratch behaves as an ordinary read-write CSR.
+.global done
+done:
+  add x0, x0, x0
+.global _start
+_start:
+  addi  x1, x0, 5
+  csrrw x0, mscratch, x1
+  csrrs x2, mscratch, x0
+  csrrs x3, instret, x0
+  csrrs x4, cycle, x0
+
+# CHECK: final registers:
+# CHECK-DAG: CSR[832] = 0x5
+# CHECK-DAG: GPR[2] = 0x5
+# CHECK-DAG: GPR[3] = 0x3
+# CHECK-DAG: GPR[4] = 0x4

--- a/simulator/isasim/src/main.rs
+++ b/simulator/isasim/src/main.rs
@@ -114,6 +114,15 @@ fn main() {
     // execute with the configured XLEN (e.g. rv32 arithmetic wraps at 32 bits).
     executor.set_isa_params(target.isa_params());
     executor.set_register_widths(target.register_widths());
+    // Route reads of counter-backed registers (e.g. the RISC-V cycle/instret
+    // CSRs) to the executor's performance counters.
+    executor.set_counter_registers(target.counter_registers());
+    // Bare-metal snippets have no exception environment: report ecall/ebreak
+    // and stop the run cleanly instead of failing it.
+    executor.set_exception_handler(Box::new(|_executor, cause, pc| {
+        println!("trap: cause={cause} pc={pc:#x}");
+        tir_sim::ExceptionAction::Halt
+    }));
 
     if let Some(path) = &args.memory_config {
         memory::load_memory_config(&mut executor, path);

--- a/simulator/simcore/src/executor.rs
+++ b/simulator/simcore/src/executor.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::rc::Rc;
 
 use tir::Context;
-use tir_be_common::{MachineContext, MachineInstruction, SimTrap};
+use tir_be_common::{MachineContext, MachineInstruction, PerfCounter, SimTrap};
 
 use crate::error::Error;
 use crate::program::{MachineBlock, ProgramImage};
@@ -20,7 +20,24 @@ enum BlockExit {
     Until,
     /// PC moved to the next block (control transfer or fallthrough).
     Next,
+    /// An exception handler requested a halt; `pc` points at the trapping
+    /// instruction.
+    Halted,
 }
+
+/// What the simulation should do after an exception handler ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExceptionAction {
+    /// Resume at the next instruction.
+    Continue,
+    /// Stop the run cleanly; [`Executor::halted`] reports `true`.
+    Halt,
+}
+
+/// Callback invoked when instruction semantics raise an exception (TMDL
+/// `trap`, e.g. ecall/ebreak). Receives the executor (so it can inspect or
+/// update architectural state), the cause code and the trapping PC.
+pub type ExceptionHandler = Box<dyn FnMut(&mut Executor, u64, u64) -> ExceptionAction>;
 
 #[derive(Default)]
 pub struct Executor {
@@ -46,6 +63,15 @@ pub struct Executor {
     pc_explicitly_written: bool,
     record_trace: bool,
     trace: Vec<(tir::OpId, u64)>,
+    /// Registers backed by performance counters (e.g. the RISC-V `cycle` CSR):
+    /// reads return the counter value, writes are ignored.
+    counter_registers: HashMap<(String, u16), PerfCounter>,
+    /// Instructions retired so far. Drives every performance counter: the
+    /// functional model retires one instruction per cycle, and time ticks with
+    /// the cycle counter.
+    retired_instructions: u64,
+    exception_handler: Option<ExceptionHandler>,
+    halted: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -106,6 +132,43 @@ impl Executor {
             .into_iter()
             .map(|(name, value)| (name.to_string(), value))
             .collect();
+    }
+
+    /// Configure which registers are backed by performance counters (from
+    /// `TargetMachine::counter_registers`).
+    pub fn set_counter_registers(
+        &mut self,
+        counters: impl IntoIterator<Item = (&'static str, u16, PerfCounter)>,
+    ) {
+        self.counter_registers = counters
+            .into_iter()
+            .map(|(class, index, counter)| ((class.to_string(), index), counter))
+            .collect();
+    }
+
+    /// Install the callback invoked when instruction semantics raise an
+    /// exception (ecall/ebreak). Without one, exceptions surface as
+    /// [`SimTrap::Exception`] errors from [`Executor::run`].
+    pub fn set_exception_handler(&mut self, handler: ExceptionHandler) {
+        self.exception_handler = Some(handler);
+    }
+
+    /// Instructions retired by this executor so far.
+    pub fn retired_instructions(&self) -> u64 {
+        self.retired_instructions
+    }
+
+    /// Whether an exception handler stopped the run.
+    pub fn halted(&self) -> bool {
+        self.halted
+    }
+
+    fn counter_value(&self, counter: PerfCounter) -> u64 {
+        match counter {
+            PerfCounter::Cycles | PerfCounter::Time | PerfCounter::InstructionsRetired => {
+                self.retired_instructions
+            }
+        }
     }
 
     /// Resize `value` to a class's architectural width: truncate wider values,
@@ -170,7 +233,7 @@ impl Executor {
                 .block_at(self.pc)
                 .ok_or(SimTrap::PcNotMapped { pc: self.pc })?;
             match self.exec_block(&program.context, block, until_pc, trace, out)? {
-                BlockExit::Until => return Ok(()),
+                BlockExit::Until | BlockExit::Halted => return Ok(()),
                 BlockExit::Next => {}
             }
         }
@@ -221,8 +284,12 @@ impl Executor {
             self.pc = inst_pc;
             self.pc_explicitly_written = false;
             machine_inst.execute(self)?;
+            self.retired_instructions += 1;
             if trace.registers_after_each_instruction {
                 self.emit_register_dump(out, "registers");
+            }
+            if self.halted {
+                return Ok(BlockExit::Halted);
             }
             if self.pc_explicitly_written {
                 // A control transfer wrote PC: `self.pc` holds the target, and
@@ -305,6 +372,10 @@ impl MachineContext for Executor {
         if class == "PC" {
             return Ok(self.resize_to_class_width(class, tir::utils::APInt::new(64, self.pc)));
         }
+        if let Some(&counter) = self.counter_registers.get(&(class.to_string(), index)) {
+            let value = self.counter_value(counter);
+            return Ok(self.resize_to_class_width(class, tir::utils::APInt::new(64, value)));
+        }
         let key = (self.register_file(class).to_string(), index);
         if let Some(value) = self.registers.get(&key) {
             return Ok(self.resize_to_class_width(class, value.clone()));
@@ -321,6 +392,14 @@ impl MachineContext for Executor {
         let value = self.resize_to_class_width(class, value);
         if class == "PC" {
             self.write_pc(value.to_u64());
+            return Ok(());
+        }
+        // Counter-backed registers are read-only; writes (e.g. the write-back a
+        // csrrs with rs1=x0 performs) are ignored.
+        if self
+            .counter_registers
+            .contains_key(&(class.to_string(), index))
+        {
             return Ok(());
         }
         let file = self.register_file(class).to_string();
@@ -374,6 +453,24 @@ impl MachineContext for Executor {
     fn write_pc(&mut self, value: u64) {
         self.pc = value;
         self.pc_explicitly_written = true;
+    }
+
+    fn raise_exception(&mut self, cause: u64) -> Result<(), SimTrap> {
+        let pc = self.pc;
+        let Some(mut handler) = self.exception_handler.take() else {
+            return Err(SimTrap::Exception { cause, pc });
+        };
+        let action = handler(self, cause, pc);
+        if self.exception_handler.is_none() {
+            self.exception_handler = Some(handler);
+        }
+        match action {
+            ExceptionAction::Continue => Ok(()),
+            ExceptionAction::Halt => {
+                self.halted = true;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -621,6 +718,182 @@ mod tests {
             MachineContext::read_memory(&executor, data + 4, 4).unwrap(),
             0x1234_5678
         );
+    }
+
+    #[test]
+    fn zicsr_csr_instructions_read_then_modify() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let dialect = context.find_dialect::<RiscvDialect>().unwrap();
+        // Symbols are laid out in reverse declaration order: `first` executes
+        // at 0x8000_0000 and falls through to `last` at 0x8000_0010.
+        let asm = "
+            .global last
+            last:
+              add x0, x0, x0
+            .global first
+            first:
+              csrrw x2, mscratch, x1
+              csrrs x3, mscratch, x4
+              csrrc x5, mscratch, x6
+              csrrwi x7, mscratch, 9
+        ";
+        let module = dialect.get_asm_parser().parse_asm(&context, asm).unwrap();
+        let program =
+            ProgramImage::from_module(&context, module, 0x8000_0000, Some("first")).unwrap();
+
+        let mut executor = Executor::new(4096);
+        let mut write = |idx, v| {
+            tir_be_common::MachineContext::write_register(
+                &mut executor,
+                "GPR",
+                idx,
+                APInt::new(64, v),
+            )
+            .unwrap()
+        };
+        write(1, 0b0011);
+        write(4, 0b0100);
+        write(6, 0b0010);
+        executor.load(program).unwrap();
+        executor.run(0x8000_0010, 10).unwrap();
+
+        let reg = |class, idx| {
+            tir_be_common::MachineContext::read_register(&executor, class, idx)
+                .unwrap()
+                .to_u64()
+        };
+        // Every form returns the pre-write CSR value in rd, then applies its
+        // modification: write, set bits, clear bits, write immediate.
+        assert_eq!(reg("GPR", 2), 0, "csrrw reads the initial mscratch");
+        assert_eq!(reg("GPR", 3), 0b0011, "csrrs reads the csrrw result");
+        assert_eq!(reg("GPR", 5), 0b0111, "csrrc reads the csrrs result");
+        assert_eq!(reg("GPR", 7), 0b0101, "csrrwi reads the csrrc result");
+        // CSRs live in the register file at their architectural address.
+        assert_eq!(reg("CSR", 0x340), 9, "csrrwi wrote its immediate");
+    }
+
+    #[test]
+    fn counter_registers_track_retired_instructions_and_ignore_writes() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let dialect = context.find_dialect::<RiscvDialect>().unwrap();
+        let asm = "
+            .global last
+            last:
+              add x0, x0, x0
+            .global first
+            first:
+              add x1, x1, x1
+              add x1, x1, x1
+              csrrw x0, instret, x1
+              csrrs x2, instret, x0
+        ";
+        let module = dialect.get_asm_parser().parse_asm(&context, asm).unwrap();
+        let program =
+            ProgramImage::from_module(&context, module, 0x8000_0000, Some("first")).unwrap();
+
+        let mut executor = Executor::new(4096);
+        executor.set_counter_registers([(
+            "CSR",
+            0xC02,
+            tir_be_common::PerfCounter::InstructionsRetired,
+        )]);
+        executor.load(program).unwrap();
+        executor.run(0x8000_0010, 10).unwrap();
+
+        // The csrrw write to the read-only counter is ignored; the csrrs read
+        // sees the three instructions retired before it.
+        let x2 = tir_be_common::MachineContext::read_register(&executor, "GPR", 2).unwrap();
+        assert_eq!(x2.to_u64(), 3);
+        assert_eq!(executor.retired_instructions(), 4);
+    }
+
+    #[test]
+    fn ecall_without_handler_surfaces_an_exception_trap() {
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let dialect = context.find_dialect::<RiscvDialect>().unwrap();
+        let asm = "
+            .global first
+            first:
+              ecall
+        ";
+        let module = dialect.get_asm_parser().parse_asm(&context, asm).unwrap();
+        let program =
+            ProgramImage::from_module(&context, module, 0x8000_0000, Some("first")).unwrap();
+        let mut executor = Executor::new(4096);
+        executor.load(program).unwrap();
+
+        let err = executor.run(0xFFFF_FFFF, 10).unwrap_err();
+        match err {
+            Error::Trap(tir_be_common::SimTrap::Exception { cause, pc }) => {
+                assert_eq!(cause, 11, "ecall raises environment-call-from-M-mode");
+                assert_eq!(pc, 0x8000_0000);
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn exception_handler_controls_run_outcome() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let context = Context::with_default_dialects();
+        context.register_dialect::<AsmDialect>();
+        context.register_dialect::<RiscvDialect>();
+
+        let dialect = context.find_dialect::<RiscvDialect>().unwrap();
+        let asm = "
+            .global last
+            last:
+              add x0, x0, x0
+            .global first
+            first:
+              ecall
+              addi x1, x0, 7
+              ebreak
+              addi x2, x0, 9
+        ";
+        let module = dialect.get_asm_parser().parse_asm(&context, asm).unwrap();
+        let program =
+            ProgramImage::from_module(&context, module, 0x8000_0000, Some("first")).unwrap();
+
+        let traps = Rc::new(RefCell::new(Vec::new()));
+        let seen = traps.clone();
+        let mut executor = Executor::new(4096);
+        executor.set_exception_handler(Box::new(move |_executor, cause, pc| {
+            seen.borrow_mut().push((cause, pc));
+            // Resume after the ecall, stop at the ebreak.
+            if cause == 11 {
+                crate::ExceptionAction::Continue
+            } else {
+                crate::ExceptionAction::Halt
+            }
+        }));
+        executor.load(program).unwrap();
+        executor.run(0x8000_0010, 10).unwrap();
+
+        assert!(executor.halted());
+        assert_eq!(
+            *traps.borrow(),
+            vec![(11, 0x8000_0000), (3, 0x8000_0008)],
+            "handler saw the ecall and the ebreak with their PCs"
+        );
+        let reg = |idx| {
+            tir_be_common::MachineContext::read_register(&executor, "GPR", idx)
+                .unwrap()
+                .to_u64()
+        };
+        assert_eq!(reg(1), 7, "execution resumed after the ecall");
+        assert_eq!(reg(2), 0, "the halt stopped execution at the ebreak");
     }
 
     /// `cmp` writes all four AArch64 condition flags (`PSTATE` n/z/c/v), and a

--- a/simulator/simcore/src/executor.rs
+++ b/simulator/simcore/src/executor.rs
@@ -168,6 +168,9 @@ impl Executor {
             PerfCounter::Cycles | PerfCounter::Time | PerfCounter::InstructionsRetired => {
                 self.retired_instructions
             }
+            PerfCounter::CyclesHigh
+            | PerfCounter::TimeHigh
+            | PerfCounter::InstructionsRetiredHigh => self.retired_instructions >> 32,
         }
     }
 
@@ -811,6 +814,25 @@ mod tests {
         let x2 = tir_be_common::MachineContext::read_register(&executor, "GPR", 2).unwrap();
         assert_eq!(x2.to_u64(), 3);
         assert_eq!(executor.retired_instructions(), 4);
+    }
+
+    #[test]
+    fn rv32_counter_high_half_reads_upper_bits() {
+        let rv32 = [tir_riscv::Feature::RV32I, tir_riscv::Feature::Zicsr];
+        let mut executor = Executor::new(64);
+        executor.set_register_widths(tir_riscv::register_widths(&rv32));
+        executor.set_counter_registers([
+            ("CSR", 0xC00, tir_be_common::PerfCounter::Cycles),
+            ("CSR", 0xC80, tir_be_common::PerfCounter::CyclesHigh),
+        ]);
+        executor.retired_instructions = 0x0000_0005_8000_0001;
+
+        let reg =
+            |idx| tir_be_common::MachineContext::read_register(&executor, "CSR", idx).unwrap();
+        // cycle returns the low word (the CSR class is 32 bits wide on rv32),
+        // cycleh the upper word of the same 64-bit counter.
+        assert_eq!((reg(0xC00).to_u64(), reg(0xC00).width()), (0x8000_0001, 32));
+        assert_eq!(reg(0xC80).to_u64(), 5);
     }
 
     #[test]

--- a/tmdl/checks/Parser/simple.tmdl
+++ b/tmdl/checks/Parser/simple.tmdl
@@ -121,6 +121,7 @@
 // CHECK-NEXT:                             alias: Some(
 // CHECK-NEXT:                                 "zero",
 // CHECK-NEXT:                             ),
+// CHECK-NEXT:                             index: None,
 // CHECK-NEXT:                             traits: [
 // CHECK-NEXT:                                 HardwiredZero,
 // CHECK-NEXT:                             ],
@@ -134,6 +135,7 @@
 // CHECK-NEXT:                             alias: Some(
 // CHECK-NEXT:                                 "ra",
 // CHECK-NEXT:                             ),
+// CHECK-NEXT:                             index: None,
 // CHECK-NEXT:                             traits: [
 // CHECK-NEXT:                                 ReturnAddress,
 // CHECK-NEXT:                                 CallerSaved,

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -27,10 +27,21 @@ pub enum RegisterTrait {
 pub struct Register {
     pub name: String,
     pub alias: Option<String>,
+    /// Explicit encoding index (`index = 0xC00`), for registers whose
+    /// architectural number is not derivable from the name (e.g. CSRs).
+    pub index: Option<u16>,
     pub traits: Vec<RegisterTrait>,
     pub subregisters: Vec<Register>,
     #[serde(skip_serializing)]
     pub span: Span,
+}
+
+impl Register {
+    /// The register's canonical encoding index: the explicit `index` when
+    /// declared, otherwise the trailing number in the name (`x5` -> 5).
+    pub fn encoding_index(&self) -> Option<u16> {
+        self.index.or_else(|| parse_trailing_index(&self.name))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -402,6 +413,9 @@ pub enum BuiltinFunction {
     ZExt,
     Load,
     Store,
+    /// `trap(cause)`: raise a synchronous exception (e.g. ecall/ebreak). An
+    /// effect-only builtin handled directly by codegen; it produces no value.
+    Trap,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
@@ -1053,6 +1067,13 @@ impl Call {
                     &[address, bytes, value, address_space],
                 )
             }
+            // trap has no semantic-expression form; codegen intercepts trap
+            // calls before lowering, so reaching here means the behavior used
+            // it in a value position.
+            BuiltinFunction::Trap => {
+                ctx.had_error = true;
+                ctx.add_int_const(tir::utils::APInt::new(64, 0))
+            }
         }
     }
 }
@@ -1131,7 +1152,7 @@ impl RegisterClass {
             .resolve_registers()
             .map(|reg| {
                 (
-                    parse_trailing_index(&reg.name).unwrap_or(u16::MAX),
+                    reg.encoding_index().unwrap_or(u16::MAX),
                     reg.name,
                     reg.alias,
                 )
@@ -1176,7 +1197,7 @@ impl RegisterClass {
             reg.traits
                 .iter()
                 .any(|t| matches!(t, RegisterTrait::HardwiredZero))
-                .then(|| parse_trailing_index(&reg.name).unwrap_or(u16::MAX))
+                .then(|| reg.encoding_index().unwrap_or(u16::MAX))
         })
     }
 
@@ -1189,7 +1210,7 @@ impl RegisterClass {
     pub fn register_indices(&self) -> Vec<(String, u16)> {
         let mut out = Vec::new();
         for (position, reg) in self.resolve_registers().enumerate() {
-            let index = parse_trailing_index(&reg.name).unwrap_or(position as u16);
+            let index = reg.encoding_index().unwrap_or(position as u16);
             out.push((reg.name.clone(), index));
             if let Some(alias) = &reg.alias
                 && !alias.contains("{}")
@@ -1207,7 +1228,7 @@ impl RegisterClass {
     pub fn indexed_registers(&self) -> Vec<(u16, Vec<RegisterTrait>)> {
         let mut regs = self
             .resolve_registers()
-            .filter_map(|reg| parse_trailing_index(&reg.name).map(|idx| (idx, reg.traits)))
+            .filter_map(|reg| reg.encoding_index().map(|idx| (idx, reg.traits)))
             .collect::<Vec<_>>();
         regs.sort_by_key(|(idx, _)| *idx);
         regs
@@ -1316,6 +1337,7 @@ impl RegisterClass {
                         registers.push(Register {
                             name: format!("{prefix}{idx}"),
                             alias: range.alias_pattern.clone(),
+                            index: None,
                             traits: range.traits.clone(),
                             subregisters: Vec::new(),
                             span: range.span,
@@ -1369,9 +1391,9 @@ pub fn resolve_register_class_inheritance(files: &mut [File]) {
 
                 let mut registers: Vec<Register> = base.resolve_registers().collect();
                 for own in rc.resolve_registers() {
-                    let key = parse_trailing_index(&own.name);
+                    let key = own.encoding_index();
                     let existing = registers.iter().position(|r| match key {
-                        Some(idx) => parse_trailing_index(&r.name) == Some(idx),
+                        Some(idx) => r.encoding_index() == Some(idx),
                         None => r.name == own.name,
                     });
                     match existing {

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -943,17 +943,28 @@ where
 
     let reg_traits = register_traits();
 
+    // Optional explicit encoding index: `index = 0xC00`, before any traits.
+    let reg_index = just(Token::Identifier("index"))
+        .then_ignore(just(Token::Equals))
+        .ignore_then(select! { Token::Number(n) => n.to_string() })
+        .then_ignore(just(Token::Comma).or_not())
+        .or_not();
+
     let single = ident
         .then(alias)
         .then_ignore(just(Token::FatArrow))
         .then_ignore(just(Token::LBrace))
-        .then(reg_traits)
+        .then(reg_index)
+        .then(reg_traits.or_not())
         .then_ignore(just(Token::RBrace))
-        .map_with(|((name, alias), traits), e| {
+        .map_with(|(((name, alias), index), traits), e| {
+            let index = index
+                .map(|n| crate::utils::parse_literal_value(&ast::LitInt::new(n, e.span())) as u16);
             RegisterDef::Single(Register {
                 name,
                 alias,
-                traits,
+                index,
+                traits: traits.unwrap_or_default(),
                 subregisters: Vec::new(),
                 span: e.span(),
             })
@@ -1056,6 +1067,7 @@ where
                 "zext" => Some(BuiltinFunction::ZExt),
                 "load" => Some(BuiltinFunction::Load),
                 "store" => Some(BuiltinFunction::Store),
+                "trap" => Some(BuiltinFunction::Trap),
                 _ => None,
             }
         }

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -449,8 +449,17 @@ fn emit_instructions<'a>(
             acc
         };
 
-        if let Some(semantics) =
-            analyze_instruction_semantics(inst, &ops, &defined_register_operands, &numeric_params)
+        // Instructions defining several register operands (e.g. CSR ops writing
+        // both `rd` and `csr`) cannot be modeled by a single-value DAG pattern;
+        // emitting one for the last assignment would let isel match an
+        // unrelated expression, so they get no selection rule.
+        if defined_register_operands.len() <= 1
+            && let Some(semantics) = analyze_instruction_semantics(
+                inst,
+                &ops,
+                &defined_register_operands,
+                &numeric_params,
+            )
         {
             let emit_fn_ident = format_ident!("emit_isel_{}", inst.name.to_lowercase());
             let pattern_fn_ident = format_ident!("isel_pattern_{}", inst.name.to_lowercase());
@@ -734,6 +743,17 @@ fn emit_instructions<'a>(
         // Emit parser implementations based on asm template (simple template support)
         if let Some(template) = resolve_asm_template_for_instruction(inst, item_cache) {
             let actions = compile_asm_template(&template);
+            // Operand-less instructions (e.g. ecall) consume no tokens beyond
+            // the mnemonic and set no attributes.
+            let parses_operands = actions.iter().any(|a| {
+                matches!(
+                    a,
+                    AsmAction::Comma
+                        | AsmAction::LParen
+                        | AsmAction::RParen
+                        | AsmAction::Operand(_)
+                )
+            });
 
             let mut parse_steps: Vec<proc_macro2::TokenStream> = Vec::new();
             for act in actions {
@@ -829,6 +849,9 @@ fn emit_instructions<'a>(
             }
 
             let print_parts = compile_asm_printer_template(&template, mnemonic_name);
+            let prints_operands = print_parts
+                .iter()
+                .any(|p| matches!(p, AsmPrintPart::Operand(_)));
             let mut print_steps: Vec<proc_macro2::TokenStream> = Vec::new();
             for part in print_parts {
                 match part {
@@ -903,9 +926,15 @@ fn emit_instructions<'a>(
             }
 
             let print_fn_ident = format_ident!("print_{}_inst", &inst.name.to_lowercase());
+            // Operand-less instructions (e.g. ecall) never consult the attributes.
+            let (op_param, attrs_binding) = if prints_operands {
+                (quote! { op }, quote! { let attrs = &op.attributes; })
+            } else {
+                (quote! { _op }, quote! {})
+            };
             instruction_printers_impls.push(quote! {
-                fn #print_fn_ident(op: &tir::OpInstance) -> Option<String> {
-                    let attrs = &op.attributes;
+                fn #print_fn_ident(#op_param: &tir::OpInstance) -> Option<String> {
+                    #attrs_binding
                     let mut out = String::new();
                     #(#print_steps)*
                     Some(out)
@@ -919,13 +948,18 @@ fn emit_instructions<'a>(
             });
 
             let parse_fn_ident = format_ident!("parse_{}_inst", &inst.name.to_lowercase());
+            let (parser_param, builder_binding) = if parses_operands {
+                (quote! { parser }, quote! { let mut op_builder })
+            } else {
+                (quote! { _parser }, quote! { let op_builder })
+            };
             instruction_parsers_impls.push(quote! {
                 fn #parse_fn_ident<'src>(
                     context: &tir::Context,
                     builder: &mut tir::IRBuilder,
-                    parser: &mut tir::parse::tokens::Parser<'src, tir_be_common::Token<'src>>,
+                    #parser_param: &mut tir::parse::tokens::Parser<'src, tir_be_common::Token<'src>>,
                 ) -> Result<(), ()> {
-                    let mut op_builder = #builder_ident::new(context);
+                    #builder_binding = #builder_ident::new(context);
                     #(#parse_steps)*
                     let op = op_builder.build();
                     builder.insert(op);
@@ -2037,6 +2071,28 @@ fn is_store_call(expr: &ast::Expr) -> bool {
     )
 }
 
+fn is_trap_call(expr: &ast::Expr) -> bool {
+    matches!(
+        expr,
+        ast::Expr::Call(ast::Call {
+            callee,
+            ..
+        }) if matches!(callee.as_ref(), ast::Expr::BuiltinFunction(ast::BuiltinFunction::Trap))
+    )
+}
+
+/// The constant cause code of a `trap(cause)` call. `None` when the argument is
+/// not a single integer literal.
+fn trap_call_cause(expr: &ast::Expr) -> Option<u64> {
+    let ast::Expr::Call(call) = expr else {
+        return None;
+    };
+    match call.arguments.as_slice() {
+        [ast::Expr::Lit(ast::Lit::Int(li))] => Some(parse_literal_value(li)),
+        _ => None,
+    }
+}
+
 fn emit_behavior_exec(
     expr: &ast::Expr,
     ops: &[(String, Type)],
@@ -2063,6 +2119,13 @@ fn emit_behavior_exec(
             mnemonic_lit,
             register_index_map,
         ),
+        ast::Expr::Call(_) if is_trap_call(expr) => {
+            let cause = trap_call_cause(expr)?;
+            let cause_lit = proc_macro2::Literal::u64_unsuffixed(cause);
+            Some(quote! {
+                machine.raise_exception(#cause_lit)?;
+            })
+        }
         ast::Expr::Block(b) => {
             let mut steps = Vec::new();
             for stmt in &b.stmts {
@@ -2079,6 +2142,7 @@ fn emit_behavior_exec(
                     stmt,
                     ast::Expr::Assign(_) | ast::Expr::Block(_) | ast::Expr::If(_)
                 ) || is_store_call(stmt)
+                    || is_trap_call(stmt)
                 {
                     return None;
                 }

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -302,7 +302,8 @@ fn infer<'a>(
                 }
                 Type::Var(tvg.fresh())
             }
-            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Store) => {
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Store)
+            | ast::Expr::BuiltinFunction(ast::BuiltinFunction::Trap) => {
                 for arg in &call.arguments {
                     infer(arg, env, tvg, subst, cache, diags, file_name);
                 }


### PR DESCRIPTION
- tmdl: trap(cause) builtin lowered to a MachineContext::raise_exception
  callback; explicit register encoding indices (index = 0xC00) so CSRs
  carry their architectural addresses; no isel rules for instructions
  defining several register operands
- riscv: Zicsr CSR register class (cycle/time/instret/mscratch) and
  csrrw/csrrs/csrrc + immediate forms; ecall/ebreak SYSTEM instructions
- sim: counter-backed registers driven by a retired-instruction counter,
  exception handler callback with continue/halt semantics; isasim wires
  target counters and reports traps

https://claude.ai/code/session_01Cc5zeutE1gNaXDq3vfcyHm