### PR TITLE
feat(tmdl): add Rust-style for loop syntax

### DIFF
--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -57,7 +57,8 @@ pub fn execute_with_memory<M: Memory>(
 ) -> Result<Value, M::Error> {
     let root = graph.root().expect("cannot execute empty graph");
     let mut cache = vec![None::<Value>; graph.len()];
-    eval_node(graph, root, symbols, &mut cache, memory)
+    let mut frames: Vec<(Value, Value)> = Vec::new();
+    eval_node(graph, root, symbols, &mut cache, &mut frames, memory)
 }
 
 fn child_val(
@@ -124,20 +125,62 @@ fn ints_equal(a: APInt, b: APInt) -> bool {
     a.with_signed(false) == b.with_signed(false)
 }
 
+/// Evaluate a `Loop` node: fold `step` over `[start, end)`, threading the
+/// accumulator and exposing the induction value through the frame stack.
+fn eval_loop<M: Memory>(
+    graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
+    node: NodeId,
+    symbols: &[Value],
+    cache: &mut Vec<Option<Value>>,
+    frames: &mut Vec<(Value, Value)>,
+    memory: &mut M,
+) -> Result<Value, M::Error> {
+    let children: Vec<NodeId> = graph.children(node).collect();
+    let (start_n, end_n, init_n, step_n) = (children[0], children[1], children[2], children[3]);
+
+    let start = eval_node(graph, start_n, symbols, cache, frames, memory)?;
+    let end = eval_node(graph, end_n, symbols, cache, frames, memory)?;
+    let mut acc = eval_node(graph, init_n, symbols, cache, frames, memory)?;
+
+    let start = as_int!(start, "loop bound").to_i64();
+    let end = as_int!(end, "loop bound").to_i64();
+
+    for i in start..end {
+        frames.push((Value::Int(APInt::new_signed(64, i)), acc.clone()));
+        // `step` depends on the induction/accumulator values, which change each
+        // iteration, so it cannot share the surrounding cache: evaluate it fresh.
+        let mut step_cache = vec![None::<Value>; graph.len()];
+        let next = eval_node(graph, step_n, symbols, &mut step_cache, frames, memory);
+        frames.pop();
+        acc = next?;
+    }
+    Ok(acc)
+}
+
 fn eval_node<M: Memory>(
     graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
     node: NodeId,
     symbols: &[Value],
     cache: &mut Vec<Option<Value>>,
+    frames: &mut Vec<(Value, Value)>,
     memory: &mut M,
 ) -> Result<Value, M::Error> {
     if let Some(ref v) = cache[node.index()] {
         return Ok(v.clone());
     }
 
+    // A `Loop` must not have its `step` child pre-evaluated: `step` depends on the
+    // per-iteration induction/accumulator values, so it is evaluated repeatedly,
+    // by hand, below. Intercept before the generic child pre-evaluation.
+    if *graph.get_kind(node) == ExprKind::Loop {
+        let result = eval_loop(graph, node, symbols, cache, frames, memory)?;
+        cache[node.index()] = Some(result.clone());
+        return Ok(result);
+    }
+
     for child_id in graph.children(node) {
         if cache[child_id.index()].is_none() {
-            let v = eval_node(graph, child_id, symbols, cache, memory)?;
+            let v = eval_node(graph, child_id, symbols, cache, frames, memory)?;
             cache[child_id.index()] = Some(v);
         }
     }
@@ -145,6 +188,17 @@ fn eval_node<M: Memory>(
     let c = |idx: usize| child_val(graph, node, idx, cache);
 
     let result = match graph.get_kind(node) {
+        ExprKind::IndVar => frames
+            .last()
+            .expect("IndVar evaluated outside a loop")
+            .0
+            .clone(),
+        ExprKind::Acc => frames
+            .last()
+            .expect("Acc evaluated outside a loop")
+            .1
+            .clone(),
+        ExprKind::Loop => unreachable!("Loop handled before child pre-evaluation"),
         ExprKind::Symbol => {
             let ExprPayload::SymbolId(id) = graph.get_leaf_data(node).unwrap() else {
                 panic!("Symbol node must have SymbolId payload");
@@ -816,6 +870,54 @@ mod tests {
         let b = sym(&mut g, 1);
         inner(&mut g, ExprKind::Lt, &[a, b]);
         assert_eq!(as_i64(execute(&g, &[fv(1.0), fv(2.0)])), 1);
+    }
+
+    #[test]
+    fn loop_sums_induction_variable_with_symbolic_bound() {
+        // acc = 0; for i in 0..n { acc = acc + i }  ==>  0+1+...+(n-1).
+        let mut g = ExprPostGraph::new();
+        let start = int_con(&mut g, 0);
+        let end = sym(&mut g, 0); // n, a symbolic (runtime) bound
+        let init = int_con(&mut g, 0);
+        let ind = g.add_node(ExprKind::IndVar);
+        let acc = g.add_node(ExprKind::Acc);
+        let step = inner(&mut g, ExprKind::Add, &[acc, ind]);
+        inner(&mut g, ExprKind::Loop, &[start, end, init, step]);
+
+        assert_eq!(as_i64(execute(&g, &[iv(5)])), 0 + 1 + 2 + 3 + 4);
+        assert_eq!(as_i64(execute(&g, &[iv(1)])), 0);
+        assert_eq!(as_i64(execute(&g, &[iv(0)])), 0);
+    }
+
+    #[test]
+    fn loop_accumulates_from_nonzero_init() {
+        // acc = base; for i in 0..3 { acc = acc + step }  with step a symbol.
+        let mut g = ExprPostGraph::new();
+        let start = int_con(&mut g, 0);
+        let end = int_con(&mut g, 3);
+        let base = sym(&mut g, 0);
+        let acc = g.add_node(ExprKind::Acc);
+        let addend = sym(&mut g, 1);
+        let step = inner(&mut g, ExprKind::Add, &[acc, addend]);
+        inner(&mut g, ExprKind::Loop, &[start, end, base, step]);
+
+        // 10 + 4 + 4 + 4 = 22.
+        assert_eq!(as_i64(execute(&g, &[iv(10), iv(4)])), 22);
+    }
+
+    #[test]
+    fn nested_loop_multiplies_via_repeated_addition() {
+        // acc = 0; for i in 0..a { acc = acc + b }  ==> a*b, with b symbolic.
+        let mut g = ExprPostGraph::new();
+        let start = int_con(&mut g, 0);
+        let a = sym(&mut g, 0);
+        let init = int_con(&mut g, 0);
+        let acc = g.add_node(ExprKind::Acc);
+        let b = sym(&mut g, 1);
+        let step = inner(&mut g, ExprKind::Add, &[acc, b]);
+        inner(&mut g, ExprKind::Loop, &[start, a, init, step]);
+
+        assert_eq!(as_i64(execute(&g, &[iv(6), iv(7)])), 42);
     }
 
     #[test]

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -884,7 +884,7 @@ mod tests {
         let step = inner(&mut g, ExprKind::Add, &[acc, ind]);
         inner(&mut g, ExprKind::Loop, &[start, end, init, step]);
 
-        assert_eq!(as_i64(execute(&g, &[iv(5)])), 0 + 1 + 2 + 3 + 4);
+        assert_eq!(as_i64(execute(&g, &[iv(5)])), 1 + 2 + 3 + 4);
         assert_eq!(as_i64(execute(&g, &[iv(1)])), 0);
         assert_eq!(as_i64(execute(&g, &[iv(0)])), 0);
     }

--- a/core/src/sem_expr/infer.rs
+++ b/core/src/sem_expr/infer.rs
@@ -100,6 +100,14 @@ pub fn infer_widths(
                 .and_then(|&c| const_value(c))
                 .map(|bytes| (bytes as u32) * 8),
             ExprKind::StoreMemory => None,
+
+            // A loop is as wide as its accumulator, which starts at `init`.
+            ExprKind::Loop => child_width(2),
+            // The accumulator's width is the loop's, fixed up when the `Loop`
+            // node is processed; the induction value is a plain counter. Neither
+            // can be resolved structurally from a lower-indexed leaf, so they stay
+            // unknown and propagate.
+            ExprKind::IndVar | ExprKind::Acc => None,
         };
 
         widths[index] = width;

--- a/core/src/sem_expr/mod.rs
+++ b/core/src/sem_expr/mod.rs
@@ -8,10 +8,12 @@ use crate::{
 mod discover;
 mod exec;
 mod infer;
+mod unroll;
 
 pub use discover::{EquivalenceOracle, FuzzOracle, confirm_extension_via_shifts};
 pub use exec::{Memory, execute, execute_with_memory};
 pub use infer::{canonicalize_for_selection, infer_widths};
+pub use unroll::unroll_loops;
 
 pub type ExprPostGraph = PostOrderDag<ExprKind, ExprPayload>;
 
@@ -85,6 +87,24 @@ pub enum ExprKind {
     Sqrt,
     #[arity = 3]
     Fma,
+    /// Bounded fold/reduce, the IR's first-class loop. Arguments are
+    /// `[start, end, init, step]`: the accumulator begins at `init` and, for each
+    /// integer `i` in the half-open range `[start, end)`, is replaced by `step`.
+    /// Inside `step`, the current induction value is read with `IndVar` and the
+    /// running accumulator with `Acc`. The node's value is the final accumulator.
+    /// Bounds may be arbitrary subexpressions (the interpreter evaluates them at
+    /// run time); backends without native iteration unroll it when the bounds are
+    /// constant.
+    #[arity = 4]
+    Loop,
+    /// The induction variable of the innermost enclosing `Loop`. Only meaningful
+    /// inside that loop's `step` subexpression.
+    #[leaf]
+    IndVar,
+    /// The running accumulator of the innermost enclosing `Loop`. Only meaningful
+    /// inside that loop's `step` subexpression.
+    #[leaf]
+    Acc,
 }
 
 impl ExprKind {

--- a/core/src/sem_expr/unroll.rs
+++ b/core/src/sem_expr/unroll.rs
@@ -1,0 +1,235 @@
+use std::collections::HashMap;
+
+use crate::{
+    graph::{Dag, MutDag, NodeId},
+    utils::APInt,
+};
+
+use super::{ExprKind, ExprPayload, ExprPostGraph};
+
+/// Rewrite a semantic-expression graph so that every `Loop` with constant bounds
+/// is replaced by its unrolled expansion: the `step` subexpression is rebuilt
+/// once per iteration with `IndVar` folded to the iteration constant and `Acc`
+/// wired to the previous iteration's value. Loops whose bounds are not constant
+/// are copied verbatim, so a backend that cannot lower them (e.g. SMT, which has
+/// no iteration) can detect and reject them.
+pub fn unroll_loops(graph: &ExprPostGraph, root: NodeId) -> (ExprPostGraph, NodeId) {
+    let mut out = ExprPostGraph::new();
+    let mut memo: HashMap<usize, NodeId> = HashMap::new();
+    let mut frames: Vec<(i64, NodeId)> = Vec::new();
+    let new_root = rebuild(graph, root, &mut out, &mut memo, &mut frames);
+    (out, new_root)
+}
+
+/// Evaluate a bound subexpression to a constant, resolving `IndVar` through the
+/// active unrolling frames. Returns `None` for anything that is not statically
+/// known (symbols, the accumulator, unsupported operators).
+fn const_eval(graph: &ExprPostGraph, node: NodeId, frames: &[(i64, NodeId)]) -> Option<i64> {
+    let children: Vec<NodeId> = graph.children(node).collect();
+    match *graph.get_node(node) {
+        ExprKind::Constant => match graph.get_leaf_data(node)? {
+            ExprPayload::Int(v) => Some(v.to_i64()),
+            _ => None,
+        },
+        ExprKind::IndVar => frames.last().map(|&(i, _)| i),
+        ExprKind::Add => {
+            Some(const_eval(graph, children[0], frames)? + const_eval(graph, children[1], frames)?)
+        }
+        ExprKind::Sub => {
+            Some(const_eval(graph, children[0], frames)? - const_eval(graph, children[1], frames)?)
+        }
+        ExprKind::Mul => {
+            Some(const_eval(graph, children[0], frames)? * const_eval(graph, children[1], frames)?)
+        }
+        _ => None,
+    }
+}
+
+fn rebuild(
+    graph: &ExprPostGraph,
+    node: NodeId,
+    out: &mut ExprPostGraph,
+    memo: &mut HashMap<usize, NodeId>,
+    frames: &mut Vec<(i64, NodeId)>,
+) -> NodeId {
+    // Memoize only frame-independent nodes; inside a loop expansion the same
+    // source node maps to a different output node per iteration.
+    let memoizable = frames.is_empty();
+    if memoizable && let Some(&existing) = memo.get(&node.index()) {
+        return existing;
+    }
+
+    let kind = *graph.get_node(node);
+    let children: Vec<NodeId> = graph.children(node).collect();
+
+    let result = match kind {
+        ExprKind::IndVar => {
+            let &(i, _) = frames.last().expect("IndVar outside a loop");
+            int_const(out, i)
+        }
+        ExprKind::Acc => frames.last().expect("Acc outside a loop").1,
+        ExprKind::Loop => {
+            match (
+                const_eval(graph, children[0], frames),
+                const_eval(graph, children[1], frames),
+            ) {
+                (Some(start), Some(end)) => {
+                    let mut acc = rebuild(graph, children[2], out, memo, frames);
+                    for i in start..end {
+                        frames.push((i, acc));
+                        acc = rebuild(graph, children[3], out, memo, frames);
+                        frames.pop();
+                    }
+                    acc
+                }
+                // Symbolic bounds: keep the loop intact for the backend to reject.
+                _ => copy_subtree(graph, node, out, &mut HashMap::new()),
+            }
+        }
+        _ if children.is_empty() => {
+            let new = out.add_node(kind);
+            if let Some(data) = graph.get_leaf_data(node) {
+                out.set_leaf_data(new, data.clone());
+            }
+            new
+        }
+        _ => {
+            let new_children: Vec<NodeId> = children
+                .iter()
+                .map(|&c| rebuild(graph, c, out, memo, frames))
+                .collect();
+            let new = out.add_node(kind);
+            for c in new_children {
+                out.add_edge(new, c);
+            }
+            new
+        }
+    };
+
+    if memoizable {
+        memo.insert(node.index(), result);
+    }
+    result
+}
+
+/// Structural verbatim copy of a subtree, preserving `Loop`/`IndVar`/`Acc`.
+fn copy_subtree(
+    graph: &ExprPostGraph,
+    node: NodeId,
+    out: &mut ExprPostGraph,
+    memo: &mut HashMap<usize, NodeId>,
+) -> NodeId {
+    if let Some(&existing) = memo.get(&node.index()) {
+        return existing;
+    }
+    // Children must exist (lower index) before the parent in a post-order graph.
+    let new_children: Vec<NodeId> = graph
+        .children(node)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|c| copy_subtree(graph, c, out, memo))
+        .collect();
+    let new = out.add_node(*graph.get_node(node));
+    if let Some(data) = graph.get_leaf_data(node) {
+        out.set_leaf_data(new, data.clone());
+    }
+    for nc in new_children {
+        out.add_edge(new, nc);
+    }
+    memo.insert(node.index(), new);
+    new
+}
+
+fn int_const(out: &mut ExprPostGraph, value: i64) -> NodeId {
+    let node = out.add_node(ExprKind::Constant);
+    // Mirror the TMDL literal lowering: non-negative values are unsigned at their
+    // minimal width; negatives keep a sign bit. A signed 1-bit `1` would be `-1`.
+    let payload = if value < 0 {
+        let width = 64 - value.unsigned_abs().leading_zeros() + 1;
+        APInt::new_signed(width, value)
+    } else {
+        let v = value as u64;
+        let width = if v == 0 { 1 } else { 64 - v.leading_zeros() };
+        APInt::new(width, v)
+    };
+    out.set_leaf_data(node, ExprPayload::Int(payload));
+    node
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sem_expr::{Value, execute};
+
+    fn sym(g: &mut ExprPostGraph, id: u32) -> NodeId {
+        let node = g.add_node(ExprKind::Symbol);
+        g.set_leaf_data(node, ExprPayload::SymbolId(id));
+        node
+    }
+    fn con(g: &mut ExprPostGraph, v: i64) -> NodeId {
+        let node = g.add_node(ExprKind::Constant);
+        g.set_leaf_data(node, ExprPayload::Int(APInt::new_signed(64, v)));
+        node
+    }
+    fn op(g: &mut ExprPostGraph, k: ExprKind, ch: &[NodeId]) -> NodeId {
+        let node = g.add_node(k);
+        for &c in ch {
+            g.add_edge(node, c);
+        }
+        node
+    }
+    fn as_i64(v: Value) -> i64 {
+        match v {
+            Value::Int(i) => i.to_i64(),
+            Value::Float(_) => panic!(),
+        }
+    }
+
+    #[test]
+    fn constant_loop_unrolls_and_matches_native_execution() {
+        // acc = base; for i in 0..4 { acc = acc + i }  ==> base + 6.
+        let mut g = ExprPostGraph::new();
+        let start = con(&mut g, 0);
+        let end = con(&mut g, 4);
+        let base = sym(&mut g, 0);
+        let acc = g.add_node(ExprKind::Acc);
+        let ind = g.add_node(ExprKind::IndVar);
+        let step = op(&mut g, ExprKind::Add, &[acc, ind]);
+        let root = op(&mut g, ExprKind::Loop, &[start, end, base, step]);
+
+        let (unrolled, new_root) = unroll_loops(&g, root);
+        // No Loop/IndVar/Acc nodes survive a constant unroll.
+        for idx in 0..unrolled.len() {
+            let k = *unrolled.get_node(NodeId::from_index(idx));
+            assert!(!matches!(
+                k,
+                ExprKind::Loop | ExprKind::IndVar | ExprKind::Acc
+            ));
+        }
+        assert_eq!(new_root, unrolled.root().unwrap());
+        assert_eq!(
+            as_i64(execute(&unrolled, &[Value::Int(APInt::new_signed(64, 10))])),
+            16
+        );
+    }
+
+    #[test]
+    fn symbolic_loop_is_kept_verbatim() {
+        let mut g = ExprPostGraph::new();
+        let start = con(&mut g, 0);
+        let end = sym(&mut g, 0); // symbolic bound
+        let init = con(&mut g, 0);
+        let acc = g.add_node(ExprKind::Acc);
+        let ind = g.add_node(ExprKind::IndVar);
+        let step = op(&mut g, ExprKind::Add, &[acc, ind]);
+        let root = op(&mut g, ExprKind::Loop, &[start, end, init, step]);
+
+        let (out, new_root) = unroll_loops(&g, root);
+        assert_eq!(*out.get_node(new_root), ExprKind::Loop);
+        // Native interpretation still works on the preserved loop.
+        assert_eq!(
+            as_i64(execute(&out, &[Value::Int(APInt::new_signed(64, 5))])),
+            10
+        );
+    }
+}

--- a/docs/tmdl/syntax.md
+++ b/docs/tmdl/syntax.md
@@ -53,15 +53,22 @@ if cond { { ... } } else { { ... } }
 variable to each value:
 
 ```
-for i in 0..4 {
+for i in 0..n {
   rd = rd + i;
 }
 ```
 
-The bounds must be compile‑time constants (literals, ISA/instruction
-parameters such as `self.XLEN`, or arithmetic over them). Loops are fully
-unrolled before lowering, so they carry no runtime iteration and the loop
-variable behaves as a constant inside each copy of the body.
+A loop whose body is a single accumulating assignment (`dest = step`, where
+`step` may read `dest` and the loop variable) lowers to a first‑class `Loop`
+node in the semantic‑expression graph: a fold of `step` over the range, with
+`dest` as the accumulator. The interpreter evaluates it natively, so the bounds
+may be symbolic (depend on operands). Backends without native iteration — the
+SMT backend — unroll it, which requires the bounds to be compile‑time constants
+(literals, ISA/instruction parameters such as `self.XLEN`, or arithmetic over
+them); a symbolic‑bound loop is reported as unsupported there.
+
+Other loop shapes (multiple statements, memory effects) are not folds; they are
+unrolled at compile time and therefore require constant bounds.
 
 ## Top‑Level Items
 

--- a/docs/tmdl/syntax.md
+++ b/docs/tmdl/syntax.md
@@ -49,6 +49,20 @@ Blocks and if‑expressions are supported for richer constructs:
 if cond { { ... } } else { { ... } }
 ```
 
+`for` loops repeat a block over a half‑open integer range, binding the loop
+variable to each value:
+
+```
+for i in 0..4 {
+  rd = rd + i;
+}
+```
+
+The bounds must be compile‑time constants (literals, ISA/instruction
+parameters such as `self.XLEN`, or arithmetic over them). Loops are fully
+unrolled before lowering, so they carry no runtime iteration and the loop
+variable behaves as a constant inside each copy of the body.
+
 ## Top‑Level Items
 
 TMDL files contain a sequence of items in any order:

--- a/tmdl/checks/Inputs/smtlib.tmdl
+++ b/tmdl/checks/Inputs/smtlib.tmdl
@@ -159,6 +159,19 @@ instruction TLoad for [TestIsa] : RType {
     }
 }
 
+instruction TAccum for [TestIsa] : RType {
+    param MNEMONIC: String = "taccum";
+    param OPCODE: bits<7> = 0b0001001;
+
+    // The loop is unrolled at compile time: rd accumulates rs2 four times.
+    behavior {
+        rd = rs1;
+        for i in 0..4 {
+            rd = rd + rs2;
+        }
+    }
+}
+
 instruction TTrap for [TestIsa] : RType {
     param MNEMONIC: String = "ttrap";
     param OPCODE: bits<7> = 0b0001000;

--- a/tmdl/checks/SmtLib/semantics.tmdl
+++ b/tmdl/checks/SmtLib/semantics.tmdl
@@ -47,11 +47,12 @@
 // CHECK: (define-fun execute_tload
 // CHECK-NEXT: (let ((exc_addr0 (bvadd (read_gpr st rs1) (read_gpr st rs2)))) (ite (distinct (bvand exc_addr0 (_ bv3 64)) (_ bv0 64)) (write_pc (write_csr (write_csr (write_csr st (_ bv833 12) (pc st)) (_ bv834 12) ((_ zero_extend 61) (_ bv4 3))) (_ bv835 12) exc_addr0) (bvshl (bvlshr (read_csr st (_ bv773 12)) ((_ zero_extend 62) (_ bv2 2))) ((_ zero_extend 62) (_ bv2 2)))) (write_gpr st rd ((_ sign_extend 32) (read_mem_4 st (bvadd (read_gpr st rs1) (read_gpr st rs2))))))))
 
-// A `for` loop is unrolled at compile time: the body's effect (adding rs2 to
-// rd) is replayed once per iteration as a chain of state transitions.
+// A `for` loop lowers to a first-class `Loop` node in the semantic graph; the
+// SMT backend, which has no iteration, unrolls its constant bounds into the
+// accumulator fold: rd becomes its entry value plus rs2 added four times.
 // CHECK: ; INSTRUCTION: taccum writes-pc=false rd:reg:gpr:5 rs1:reg:gpr:5 rs2:reg:gpr:5
 // CHECK: (define-fun execute_taccum
-// CHECK-NEXT: (write_gpr (write_gpr (write_gpr (write_gpr (write_gpr st rd (read_gpr st rs1)) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))))
+// CHECK-NEXT: (write_gpr (write_gpr st rd (read_gpr st rs1)) rd (bvadd (bvadd (bvadd (bvadd (read_gpr st rd) (read_gpr st rs2)) (read_gpr st rs2)) (read_gpr st rs2)) (read_gpr st rs2))))
 
 // `trap()` delegates to the machine and stays out of the SMT model: marked,
 // with identity semantics.

--- a/tmdl/checks/SmtLib/semantics.tmdl
+++ b/tmdl/checks/SmtLib/semantics.tmdl
@@ -47,6 +47,12 @@
 // CHECK: (define-fun execute_tload
 // CHECK-NEXT: (let ((exc_addr0 (bvadd (read_gpr st rs1) (read_gpr st rs2)))) (ite (distinct (bvand exc_addr0 (_ bv3 64)) (_ bv0 64)) (write_pc (write_csr (write_csr (write_csr st (_ bv833 12) (pc st)) (_ bv834 12) ((_ zero_extend 61) (_ bv4 3))) (_ bv835 12) exc_addr0) (bvshl (bvlshr (read_csr st (_ bv773 12)) ((_ zero_extend 62) (_ bv2 2))) ((_ zero_extend 62) (_ bv2 2)))) (write_gpr st rd ((_ sign_extend 32) (read_mem_4 st (bvadd (read_gpr st rs1) (read_gpr st rs2))))))))
 
+// A `for` loop is unrolled at compile time: the body's effect (adding rs2 to
+// rd) is replayed once per iteration as a chain of state transitions.
+// CHECK: ; INSTRUCTION: taccum writes-pc=false rd:reg:gpr:5 rs1:reg:gpr:5 rs2:reg:gpr:5
+// CHECK: (define-fun execute_taccum
+// CHECK-NEXT: (write_gpr (write_gpr (write_gpr (write_gpr (write_gpr st rd (read_gpr st rs1)) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))) rd (bvadd (read_gpr st rd) (read_gpr st rs2))))
+
 // `trap()` delegates to the machine and stays out of the SMT model: marked,
 // with identity semantics.
 // CHECK: ; UNSUPPORTED-BEHAVIOR: ttrap

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -637,6 +637,68 @@ pub(crate) fn unroll_for(f: &For, consts: &HashMap<String, i64>) -> Option<Expr>
     }))
 }
 
+/// Whether two expressions name the same assignment target (register operand,
+/// register path, or status-flag field), ignoring spans.
+fn same_target(a: &Expr, b: &Expr) -> bool {
+    match (a, b) {
+        (Expr::Ident(x), Expr::Ident(y)) => x.name == y.name,
+        (Expr::Path(x), Expr::Path(y)) => x.base == y.base && x.remainder == y.remainder,
+        (Expr::Field(x), Expr::Field(y)) => x.member == y.member && same_target(&x.base, &y.base),
+        _ => false,
+    }
+}
+
+impl For {
+    /// If the body is a single assignment `dest = step` (optionally wrapped in a
+    /// one-statement block), return `(dest, step)`. This accumulator form is what
+    /// lowers to a first-class `Loop` node; other shapes fall back to unrolling.
+    pub(crate) fn accumulator(&self) -> Option<(&Expr, &Expr)> {
+        let body = match &*self.body {
+            Expr::Block(b) if b.stmts.len() == 1 => &b.stmts[0],
+            other => other,
+        };
+        match body {
+            Expr::Assign(a) => Some((&a.dest, &a.value)),
+            _ => None,
+        }
+    }
+
+    fn as_sema_expr<
+        G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>,
+    >(
+        &self,
+        ctx: &mut SemaExprLoweringCtx<'_, G>,
+    ) -> tir::graph::NodeId {
+        let Some((dest, step)) = self.accumulator() else {
+            // Non-accumulator loops are not first-class values: unroll constant
+            // bounds, otherwise the lowering cannot represent them.
+            return match unroll_for(self, ctx.params) {
+                Some(block) => block.lower_with_ctx(ctx),
+                None => {
+                    ctx.had_error = true;
+                    ctx.add_int_const(tir::utils::APInt::new(64, 0))
+                }
+            };
+        };
+
+        let start = self.start.lower_with_ctx(ctx);
+        let end = self.end.lower_with_ctx(ctx);
+        // `init` is the accumulator's value at loop entry, lowered outside the
+        // loop context so the destination reads its surrounding value.
+        let init = dest.lower_with_ctx(ctx);
+
+        let prev = ctx.loop_ctx.take();
+        ctx.loop_ctx = Some((self.var.clone(), dest.clone()));
+        let step_node = step.lower_with_ctx(ctx);
+        ctx.loop_ctx = prev;
+
+        ctx.add_node(
+            tir::sem_expr::ExprKind::Loop,
+            &[start, end, init, step_node],
+        )
+    }
+}
+
 impl Expr {
     /// Return a clone of this expression with every `for` loop fully unrolled
     /// (recursively). Loops whose bounds are not constant under `consts` are left
@@ -654,7 +716,11 @@ fn expand_loops_inplace(expr: &mut Expr, consts: &HashMap<String, i64>) {
             expand_loops_inplace(&mut f.start, consts);
             expand_loops_inplace(&mut f.end, consts);
             expand_loops_inplace(&mut f.body, consts);
-            if let Some(block) = unroll_for(f, consts) {
+            // Accumulator loops lower to a first-class `Loop` node, so leave them
+            // intact; only non-accumulator loops are unrolled here.
+            if f.accumulator().is_none()
+                && let Some(block) = unroll_for(f, consts)
+            {
                 *expr = block;
             }
         }
@@ -723,6 +789,10 @@ struct SemaExprLoweringCtx<
     register_symbols: HashMap<(String, u32), u32>,
     variable_symbols: HashMap<String, u32>,
     had_error: bool,
+    /// Active while lowering a loop's `step`: `(induction-variable name, dest)`.
+    /// References to `dest` lower to the loop accumulator and references to the
+    /// induction variable to the loop counter, so the body becomes a `Loop` node.
+    loop_ctx: Option<(String, Expr)>,
 }
 
 impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>>
@@ -737,6 +807,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             register_symbols: HashMap::new(),
             variable_symbols: HashMap::new(),
             had_error: false,
+            loop_ctx: None,
         }
     }
 
@@ -753,6 +824,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             register_symbols: HashMap::new(),
             variable_symbols: HashMap::new(),
             had_error: false,
+            loop_ctx: None,
         }
     }
 
@@ -910,6 +982,26 @@ impl Expr {
         &self,
         ctx: &mut SemaExprLoweringCtx<'_, G>,
     ) -> tir::graph::NodeId {
+        // Inside a loop's `step`, references to the accumulator and induction
+        // variable become the dedicated leaf nodes the `Loop` reads.
+        let loop_leaf = ctx
+            .loop_ctx
+            .as_ref()
+            .map(|(var, dest)| {
+                if same_target(self, dest) {
+                    1u8
+                } else if matches!(self, Expr::Ident(id) if &id.name == var) {
+                    2
+                } else {
+                    0
+                }
+            })
+            .unwrap_or(0);
+        match loop_leaf {
+            1 => return ctx.graph.add_node(tir::sem_expr::ExprKind::Acc),
+            2 => return ctx.graph.add_node(tir::sem_expr::ExprKind::IndVar),
+            _ => {}
+        }
         match self {
             Expr::Assign(x) => x.as_sema_expr(ctx),
             Expr::Binary(x) => x.as_sema_expr(ctx),
@@ -919,13 +1011,7 @@ impl Expr {
             Expr::Field(x) => x.as_sema_expr(ctx),
             Expr::Ident(x) => x.as_sema_expr(ctx),
             Expr::If(x) => x.as_sema_expr(ctx),
-            Expr::For(f) => match unroll_for(f, ctx.params) {
-                Some(block) => block.lower_with_ctx(ctx),
-                None => {
-                    ctx.had_error = true;
-                    ctx.add_int_const(tir::utils::APInt::new(64, 0))
-                }
-            },
+            Expr::For(f) => f.as_sema_expr(ctx),
             Expr::IndexAccess(x) => x.as_sema_expr(ctx),
             Expr::Path(x) => x.as_sema_expr(ctx),
             Expr::Lit(x) => x.as_sema_expr(ctx),

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -352,6 +352,20 @@ pub struct If {
     pub span: Span,
 }
 
+/// `for VAR in START..END { body }`: a statement that runs `body` once for each
+/// integer in the half-open range `[START, END)`, with `VAR` bound to the current
+/// value. Bounds must be compile-time constants; the loop is unrolled before
+/// lowering, so it carries no runtime iteration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct For {
+    pub var: String,
+    pub start: Box<Expr>,
+    pub end: Box<Expr>,
+    pub body: Box<Expr>,
+    #[serde(skip_serializing)]
+    pub span: Span,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Block {
     pub stmts: Vec<Expr>,
@@ -507,6 +521,7 @@ pub enum Expr {
     Field(Field),
     Ident(Ident),
     If(If),
+    For(For),
     IndexAccess(IndexAccess),
     Path(Path),
     Lit(Lit),
@@ -514,6 +529,177 @@ pub enum Expr {
     Try(TryExcept),
     BuiltinFunction(BuiltinFunction),
     Invalid,
+}
+
+/// Evaluate a compile-time integer expression used as a `for` loop bound.
+/// Supports literals, known constants (`consts`: ISA/instruction parameters and
+/// enclosing loop variables), `self.PARAM`, and basic integer arithmetic.
+pub(crate) fn eval_const_int(expr: &Expr, consts: &HashMap<String, i64>) -> Option<i64> {
+    match expr {
+        Expr::Lit(Lit::Int(li)) => Some(li.parse_u64() as i64),
+        Expr::Ident(id) => consts.get(&id.name).copied(),
+        Expr::Field(f) => match &*f.base {
+            Expr::Ident(b) if b.name == "self" => consts.get(&f.member).copied(),
+            _ => None,
+        },
+        Expr::Unary(u) => match u.op {
+            UnOp::BitwiseNot => Some(!eval_const_int(&u.x, consts)?),
+        },
+        Expr::Binary(b) => {
+            let l = eval_const_int(&b.lhs, consts)?;
+            let r = eval_const_int(&b.rhs, consts)?;
+            Some(match b.op {
+                BinOp::Add => l + r,
+                BinOp::Sub => l - r,
+                BinOp::Mul => l * r,
+                BinOp::Div | BinOp::UnsignedDiv if r != 0 => l / r,
+                _ => return None,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Replace every `Ident` named `var` with the integer literal `value`.
+fn subst_ident(expr: &mut Expr, var: &str, value: i64) {
+    match expr {
+        Expr::Ident(id) if id.name == var => {
+            *expr = Expr::Lit(Lit::Int(LitInt::new(value.to_string(), id.span)));
+        }
+        Expr::Ident(_)
+        | Expr::Lit(_)
+        | Expr::Path(_)
+        | Expr::BuiltinFunction(_)
+        | Expr::Invalid => {}
+        Expr::Assign(a) => {
+            subst_ident(&mut a.dest, var, value);
+            subst_ident(&mut a.value, var, value);
+        }
+        Expr::Binary(b) => {
+            subst_ident(&mut b.lhs, var, value);
+            subst_ident(&mut b.rhs, var, value);
+        }
+        Expr::Unary(u) => subst_ident(&mut u.x, var, value),
+        Expr::Block(b) => {
+            for stmt in &mut b.stmts {
+                subst_ident(stmt, var, value);
+            }
+        }
+        Expr::Call(c) => {
+            subst_ident(&mut c.callee, var, value);
+            for arg in &mut c.arguments {
+                subst_ident(arg, var, value);
+            }
+        }
+        Expr::Field(f) => subst_ident(&mut f.base, var, value),
+        Expr::If(i) => {
+            subst_ident(&mut i.cond, var, value);
+            subst_ident(&mut i.then, var, value);
+            if let Some(e) = &mut i.else_ {
+                subst_ident(e, var, value);
+            }
+        }
+        Expr::For(f) => {
+            subst_ident(&mut f.start, var, value);
+            subst_ident(&mut f.end, var, value);
+            // A nested loop reusing the same variable name shadows the outer one.
+            if f.var != var {
+                subst_ident(&mut f.body, var, value);
+            }
+        }
+        Expr::IndexAccess(i) => subst_ident(&mut i.base, var, value),
+        Expr::Slice(s) => subst_ident(&mut s.base, var, value),
+        Expr::Try(t) => {
+            subst_ident(&mut t.body, var, value);
+            for h in &mut t.handlers {
+                subst_ident(&mut h.body, var, value);
+            }
+        }
+    }
+}
+
+/// Unroll a `for` loop into a `Block` of its body repeated once per iteration,
+/// each copy binding the loop variable to its concrete value. Returns `None`
+/// when the bounds are not compile-time constants.
+pub(crate) fn unroll_for(f: &For, consts: &HashMap<String, i64>) -> Option<Expr> {
+    let start = eval_const_int(&f.start, consts)?;
+    let end = eval_const_int(&f.end, consts)?;
+    let mut stmts = Vec::new();
+    for i in start..end {
+        let mut body = (*f.body).clone();
+        subst_ident(&mut body, &f.var, i);
+        stmts.push(body);
+    }
+    Some(Expr::Block(Block {
+        stmts,
+        last_expr_return: false,
+        span: f.span,
+    }))
+}
+
+impl Expr {
+    /// Return a clone of this expression with every `for` loop fully unrolled
+    /// (recursively). Loops whose bounds are not constant under `consts` are left
+    /// in place.
+    pub(crate) fn expand_loops(&self, consts: &HashMap<String, i64>) -> Expr {
+        let mut out = self.clone();
+        expand_loops_inplace(&mut out, consts);
+        out
+    }
+}
+
+fn expand_loops_inplace(expr: &mut Expr, consts: &HashMap<String, i64>) {
+    match expr {
+        Expr::For(f) => {
+            expand_loops_inplace(&mut f.start, consts);
+            expand_loops_inplace(&mut f.end, consts);
+            expand_loops_inplace(&mut f.body, consts);
+            if let Some(block) = unroll_for(f, consts) {
+                *expr = block;
+            }
+        }
+        Expr::Ident(_)
+        | Expr::Lit(_)
+        | Expr::Path(_)
+        | Expr::BuiltinFunction(_)
+        | Expr::Invalid => {}
+        Expr::Assign(a) => {
+            expand_loops_inplace(&mut a.dest, consts);
+            expand_loops_inplace(&mut a.value, consts);
+        }
+        Expr::Binary(b) => {
+            expand_loops_inplace(&mut b.lhs, consts);
+            expand_loops_inplace(&mut b.rhs, consts);
+        }
+        Expr::Unary(u) => expand_loops_inplace(&mut u.x, consts),
+        Expr::Block(b) => {
+            for stmt in &mut b.stmts {
+                expand_loops_inplace(stmt, consts);
+            }
+        }
+        Expr::Call(c) => {
+            expand_loops_inplace(&mut c.callee, consts);
+            for arg in &mut c.arguments {
+                expand_loops_inplace(arg, consts);
+            }
+        }
+        Expr::Field(f) => expand_loops_inplace(&mut f.base, consts),
+        Expr::If(i) => {
+            expand_loops_inplace(&mut i.cond, consts);
+            expand_loops_inplace(&mut i.then, consts);
+            if let Some(e) = &mut i.else_ {
+                expand_loops_inplace(e, consts);
+            }
+        }
+        Expr::IndexAccess(i) => expand_loops_inplace(&mut i.base, consts),
+        Expr::Slice(s) => expand_loops_inplace(&mut s.base, consts),
+        Expr::Try(t) => {
+            expand_loops_inplace(&mut t.body, consts);
+            for h in &mut t.handlers {
+                expand_loops_inplace(&mut h.body, consts);
+            }
+        }
+    }
 }
 
 pub struct SemaLowering {
@@ -733,6 +919,13 @@ impl Expr {
             Expr::Field(x) => x.as_sema_expr(ctx),
             Expr::Ident(x) => x.as_sema_expr(ctx),
             Expr::If(x) => x.as_sema_expr(ctx),
+            Expr::For(f) => match unroll_for(f, ctx.params) {
+                Some(block) => block.lower_with_ctx(ctx),
+                None => {
+                    ctx.had_error = true;
+                    ctx.add_int_const(tir::utils::APInt::new(64, 0))
+                }
+            },
             Expr::IndexAccess(x) => x.as_sema_expr(ctx),
             Expr::Path(x) => x.as_sema_expr(ctx),
             Expr::Lit(x) => x.as_sema_expr(ctx),

--- a/tmdl/src/lexer.rs
+++ b/tmdl/src/lexer.rs
@@ -77,6 +77,8 @@ pub enum Token<'a> {
     KwRegClass,
     /// `for`
     KwFor,
+    /// `in`
+    KwIn,
     /// `registers`
     KwRegisters,
     /// `parameters`
@@ -191,6 +193,7 @@ pub(crate) fn lexer<'src>()
         "isa" => Token::KwIsa,
         "requires" => Token::KwRequires,
         "for" => Token::KwFor,
+        "in" => Token::KwIn,
         "registers" => Token::KwRegisters,
         "register_class" => Token::KwRegClass,
         "parameters" => Token::KwParameters,
@@ -270,6 +273,7 @@ impl<'a> fmt::Display for Token<'a> {
             Token::KwRequires => f.write_str("requires"),
             Token::KwRegClass => f.write_str("register_class"),
             Token::KwFor => f.write_str("for"),
+            Token::KwIn => f.write_str("in"),
             Token::KwRegisters => f.write_str("registers"),
             Token::KwTemplate => f.write_str("template"),
             Token::KwInstruction => f.write_str("instruction"),

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -1621,40 +1621,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn expr_parses_for_loop() {
-        use std::collections::HashMap;
-
-        let code = "for i in 0..4 { rd = rd + i; }";
+    fn parse_expr(code: &str) -> Expr {
         let (tokens, _e) = lexer().parse(code).into_output_errors();
         let tokens = tokens.unwrap();
-        let parsed = expr().then(end()).parse(
-            tokens
-                .as_slice()
-                .map((code.len()..code.len()).into(), |(t, s)| (t, s)),
-        );
-        let parsed = parsed.output().unwrap().0.clone();
-        let Expr::For(for_) = &parsed else {
-            panic!("expected for loop, got {parsed:?}");
-        };
-        assert_eq!(for_.var, "i");
-
-        // Unrolling replaces the loop with one body copy per iteration, the loop
-        // variable substituted by a literal each time.
-        let Expr::Block(block) = parsed.expand_loops(&HashMap::new()) else {
-            panic!("unrolled loop must be a block");
-        };
-        assert_eq!(block.stmts.len(), 4);
-    }
-
-    #[test]
-    fn expr_parses_for_loop_parametric_bound() {
-        use std::collections::HashMap;
-
-        let code = "for i in 0..XLEN { rd = rd + i; }";
-        let (tokens, _e) = lexer().parse(code).into_output_errors();
-        let tokens = tokens.unwrap();
-        let parsed = expr()
+        expr()
             .then(end())
             .parse(
                 tokens
@@ -1664,9 +1634,49 @@ mod tests {
             .output()
             .unwrap()
             .0
-            .clone();
-        let consts = HashMap::from([("XLEN".to_string(), 3i64)]);
-        let Expr::Block(block) = parsed.expand_loops(&consts) else {
+            .clone()
+    }
+
+    #[test]
+    fn expr_parses_for_loop_as_accumulator() {
+        let parsed = parse_expr("for i in 0..4 { rd = rd + i; }");
+        let Expr::For(for_) = &parsed else {
+            panic!("expected for loop, got {parsed:?}");
+        };
+        assert_eq!(for_.var, "i");
+        // A single accumulating assignment is recognized as the fold form.
+        assert!(for_.accumulator().is_some());
+    }
+
+    #[test]
+    fn accumulator_loop_lowers_to_loop_node() {
+        use tir::graph::Dag;
+        use tir::sem_expr::{ExprKind, ExprPostGraph};
+
+        // Symbolic bound `n`: the loop survives as a first-class `Loop` node
+        // rather than being unrolled.
+        let parsed = parse_expr("for i in 0..n { acc = acc + i }");
+        let mut graph = ExprPostGraph::new();
+        let lowering = parsed
+            .lower_to_sema(&mut graph, &std::collections::HashMap::new())
+            .expect("loop should lower");
+        assert_eq!(*graph.get_node(lowering.root), ExprKind::Loop);
+        let has_indvar = (0..graph.len())
+            .any(|i| *graph.get_node(tir::graph::NodeId::from_index(i)) == ExprKind::IndVar);
+        let has_acc = (0..graph.len())
+            .any(|i| *graph.get_node(tir::graph::NodeId::from_index(i)) == ExprKind::Acc);
+        assert!(
+            has_indvar && has_acc,
+            "loop body must reference IndVar and Acc"
+        );
+    }
+
+    #[test]
+    fn non_accumulator_loop_unrolls() {
+        // A body that is not a single accumulating assignment falls back to
+        // compile-time unrolling.
+        let parsed = parse_expr("for i in 0..3 { store(i, 4, i); }");
+        let Expr::Block(block) = parsed.expand_loops(&std::collections::HashMap::new()) else {
             panic!("unrolled loop must be a block");
         };
         assert_eq!(block.stmts.len(), 3);

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -1399,6 +1399,25 @@ where
                 .boxed()
         });
 
+        let loop_var = select! { Token::Identifier(i) => i.to_string() };
+        let for_ = just(Token::KwFor)
+            .ignore_then(loop_var)
+            .then_ignore(just(Token::KwIn))
+            .then(inline_expr())
+            .then_ignore(just(Token::Range))
+            .then(inline_expr())
+            .then(block.clone())
+            .map_with(|(((var, start), end), body), e| {
+                Expr::For(For {
+                    var,
+                    start: Box::new(start),
+                    end: Box::new(end),
+                    body: Box::new(body),
+                    span: e.span(),
+                })
+            })
+            .boxed();
+
         let except = just(Token::KwExcept)
             .ignore_then(ident)
             .then(
@@ -1425,7 +1444,7 @@ where
             })
             .boxed();
 
-        choice((block.clone(), if_, try_))
+        choice((block.clone(), if_, for_, try_))
     })
 }
 
@@ -1474,7 +1493,9 @@ mod tests {
         lexer::lexer,
     };
 
-    use super::{inline_expr, instruction_def, isa_def, machine_def, register_class_def, unit_def};
+    use super::{
+        expr, inline_expr, instruction_def, isa_def, machine_def, register_class_def, unit_def,
+    };
 
     #[test]
     fn register_class_parses_inheritance() {
@@ -1598,6 +1619,57 @@ mod tests {
             Expr::Binary(bin) => assert_eq!(bin.op, BinOp::LessThenEqual),
             _ => panic!("Expected binary expression"),
         }
+    }
+
+    #[test]
+    fn expr_parses_for_loop() {
+        use std::collections::HashMap;
+
+        let code = "for i in 0..4 { rd = rd + i; }";
+        let (tokens, _e) = lexer().parse(code).into_output_errors();
+        let tokens = tokens.unwrap();
+        let parsed = expr().then(end()).parse(
+            tokens
+                .as_slice()
+                .map((code.len()..code.len()).into(), |(t, s)| (t, s)),
+        );
+        let parsed = parsed.output().unwrap().0.clone();
+        let Expr::For(for_) = &parsed else {
+            panic!("expected for loop, got {parsed:?}");
+        };
+        assert_eq!(for_.var, "i");
+
+        // Unrolling replaces the loop with one body copy per iteration, the loop
+        // variable substituted by a literal each time.
+        let Expr::Block(block) = parsed.expand_loops(&HashMap::new()) else {
+            panic!("unrolled loop must be a block");
+        };
+        assert_eq!(block.stmts.len(), 4);
+    }
+
+    #[test]
+    fn expr_parses_for_loop_parametric_bound() {
+        use std::collections::HashMap;
+
+        let code = "for i in 0..XLEN { rd = rd + i; }";
+        let (tokens, _e) = lexer().parse(code).into_output_errors();
+        let tokens = tokens.unwrap();
+        let parsed = expr()
+            .then(end())
+            .parse(
+                tokens
+                    .as_slice()
+                    .map((code.len()..code.len()).into(), |(t, s)| (t, s)),
+            )
+            .output()
+            .unwrap()
+            .0
+            .clone();
+        let consts = HashMap::from([("XLEN".to_string(), 3i64)]);
+        let Expr::Block(block) = parsed.expand_loops(&consts) else {
+            panic!("unrolled loop must be a block");
+        };
+        assert_eq!(block.stmts.len(), 3);
     }
 
     #[test]

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -2190,6 +2190,7 @@ fn emit_behavior_exec(
                         | ast::Expr::Block(_)
                         | ast::Expr::If(_)
                         | ast::Expr::Try(_)
+                        | ast::Expr::For(_)
                 ) || is_store_call(stmt)
                     || is_trap_call(stmt)
                 {
@@ -2199,19 +2200,34 @@ fn emit_behavior_exec(
             Some(quote! { #(#steps)* })
         }
         ast::Expr::For(f) => {
-            let mut consts = numeric_params.clone();
-            for (k, v) in isa_param_values {
-                consts.entry(k.clone()).or_insert(*v);
+            // An accumulator loop writes its folded value to `dest`; the value
+            // lowers to a `Loop` node the runtime interpreter executes (so even
+            // symbolic bounds work). Other loop shapes unroll for constant bounds.
+            if let Some((dest, _)) = f.accumulator() {
+                emit_assignment_exec(
+                    dest,
+                    expr,
+                    ops,
+                    numeric_params,
+                    isa_param_values,
+                    mnemonic_lit,
+                    register_index_map,
+                )
+            } else {
+                let mut consts = numeric_params.clone();
+                for (k, v) in isa_param_values {
+                    consts.entry(k.clone()).or_insert(*v);
+                }
+                let block = ast::unroll_for(f, &consts)?;
+                emit_behavior_exec(
+                    &block,
+                    ops,
+                    numeric_params,
+                    isa_param_values,
+                    mnemonic_lit,
+                    register_index_map,
+                )
             }
-            let block = ast::unroll_for(f, &consts)?;
-            emit_behavior_exec(
-                &block,
-                ops,
-                numeric_params,
-                isa_param_values,
-                mnemonic_lit,
-                register_index_map,
-            )
         }
         ast::Expr::If(i) => {
             let cond_eval = emit_value_eval(
@@ -2592,6 +2608,9 @@ fn emit_expr_kind_ts(kind: &tir::sem_expr::ExprKind) -> proc_macro2::TokenStream
         ExprKind::Log2Ceil => quote! { tir::sem_expr::ExprKind::Log2Ceil },
         ExprKind::Sqrt => quote! { tir::sem_expr::ExprKind::Sqrt },
         ExprKind::Fma => quote! { tir::sem_expr::ExprKind::Fma },
+        ExprKind::Loop => quote! { tir::sem_expr::ExprKind::Loop },
+        ExprKind::IndVar => quote! { tir::sem_expr::ExprKind::IndVar },
+        ExprKind::Acc => quote! { tir::sem_expr::ExprKind::Acc },
     }
 }
 

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -1781,6 +1781,7 @@ fn collect_behavior_assignments<'a>(expr: &'a ast::Expr, out: &mut Vec<(String, 
         }
         // Only the no-trap path defines values; handler writes are trap state.
         ast::Expr::Try(t) => collect_behavior_assignments(&t.body, out),
+        ast::Expr::For(f) => collect_behavior_assignments(&f.body, out),
         _ => {}
     }
 }
@@ -1837,6 +1838,7 @@ fn find_store_effect_expr(expr: &ast::Expr) -> Option<&ast::Expr> {
         ast::Expr::Call(_) if is_store_call(expr) => Some(expr),
         ast::Expr::Block(b) => b.stmts.iter().find_map(find_store_effect_expr),
         ast::Expr::Try(t) => find_store_effect_expr(&t.body),
+        ast::Expr::For(f) => find_store_effect_expr(&f.body),
         _ => None,
     }
 }
@@ -2063,6 +2065,8 @@ fn pc_writes(e: &ast::Expr) -> (bool, bool) {
         // Control-flow kind reflects the no-trap path; handler PC writes are
         // trap entries, not branches.
         ast::Expr::Try(t) => pc_writes(&t.body),
+        // A loop may run zero times, so it never *always* writes PC.
+        ast::Expr::For(f) => (false, pc_writes(&f.body).1),
         _ => (false, false),
     }
 }
@@ -2193,6 +2197,21 @@ fn emit_behavior_exec(
                 }
             }
             Some(quote! { #(#steps)* })
+        }
+        ast::Expr::For(f) => {
+            let mut consts = numeric_params.clone();
+            for (k, v) in isa_param_values {
+                consts.entry(k.clone()).or_insert(*v);
+            }
+            let block = ast::unroll_for(f, &consts)?;
+            emit_behavior_exec(
+                &block,
+                ops,
+                numeric_params,
+                isa_param_values,
+                mnemonic_lit,
+                register_index_map,
+            )
         }
         ast::Expr::If(i) => {
             let cond_eval = emit_value_eval(

--- a/tmdl/src/sem_expr_state.rs
+++ b/tmdl/src/sem_expr_state.rs
@@ -73,6 +73,7 @@ pub fn compile_to_state(expr: &ast::Expr, st_name: &str, em: &dyn StateEmitter) 
                         | ast::Expr::Block(_)
                         | ast::Expr::If(_)
                         | ast::Expr::Try(_)
+                        | ast::Expr::For(_)
                 ) || is_store_call(stmt)
                     || is_trap_call(stmt)
                 {
@@ -99,6 +100,23 @@ pub fn compile_to_state(expr: &ast::Expr, st_name: &str, em: &dyn StateEmitter) 
                 compile_to_state(e, st, em)
             }))
         }
+        // An accumulator loop `for i in s..e { dest = step }` is a single state
+        // update writing the loop's folded value to `dest`; the value lowers to a
+        // `Loop` node. Other loop shapes are unrolled before reaching here.
+        ast::Expr::For(f) => match f.accumulator() {
+            Some((dest, _)) => {
+                let assign = ast::Assign {
+                    dest: Box::new(dest.clone()),
+                    value: Box::new(expr.clone()),
+                    span: f.span,
+                };
+                or_unsupported(em.assign(&assign, st_name))
+            }
+            None => {
+                em.unsupported(expr);
+                st_name.to_string()
+            }
+        },
         _ => {
             em.unsupported(expr);
             st_name.to_string()

--- a/tmdl/src/sema.rs
+++ b/tmdl/src/sema.rs
@@ -826,6 +826,11 @@ fn check_behavior(
                     walk_paths(e, out);
                 }
             }
+            ast::Expr::For(f) => {
+                walk_paths(&f.start, out);
+                walk_paths(&f.end, out);
+                walk_paths(&f.body, out);
+            }
             ast::Expr::IndexAccess(i) => walk_paths(&i.base, out),
             ast::Expr::Slice(s) => walk_paths(&s.base, out),
             ast::Expr::Try(t) => {
@@ -861,6 +866,7 @@ fn check_behavior(
                     walk_excepts(e, out);
                 }
             }
+            ast::Expr::For(f) => walk_excepts(&f.body, out),
             _ => {}
         }
     }

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1064,6 +1064,11 @@ fn collect_mem_ops<'a>(e: &'a ast::Expr, out: &mut Vec<MemOp<'a>>) -> Option<()>
         ast::Expr::Slice(s) => collect_mem_ops(&s.base, out)?,
         ast::Expr::IndexAccess(i) => collect_mem_ops(&i.base, out)?,
         ast::Expr::Field(f) => collect_mem_ops(&f.base, out)?,
+        ast::Expr::For(f) => {
+            collect_mem_ops(&f.start, out)?;
+            collect_mem_ops(&f.end, out)?;
+            collect_mem_ops(&f.body, out)?;
+        }
         ast::Expr::Try(_)
         | ast::Expr::Ident(_)
         | ast::Expr::Path(_)
@@ -1357,7 +1362,8 @@ fn build_smt_behavior<'a>(
         failed: Default::default(),
         writes_pc: Default::default(),
     };
-    let body = sem_expr_state::compile_to_state(&instruction.behavior, "st", &emitter);
+    let behavior = instruction.behavior.expand_loops(&numeric_params);
+    let body = sem_expr_state::compile_to_state(&behavior, "st", &emitter);
     if emitter.failed.get() {
         None
     } else {

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1001,6 +1001,9 @@ fn emit_sem_expr(
         }
         // Stores are effect statements, handled by `BehaviorEmitter::store`.
         ExprKind::StoreMemory | ExprKind::Sqrt | ExprKind::Fma => None,
+        // Loops are eliminated by `unroll_loops` before emission; a surviving one
+        // has symbolic bounds, which SMT-LIB cannot express, so it is unsupported.
+        ExprKind::Loop | ExprKind::IndVar | ExprKind::Acc => None,
     }
 }
 
@@ -1105,6 +1108,9 @@ impl BehaviorEmitter<'_> {
                 self.failed.set(true);
                 None
             })?;
+        // SMT-LIB has no iteration: unroll constant-bound loops to plain
+        // expressions. Symbolic-bound loops survive and fail emission below.
+        let (graph, root) = tir::sem_expr::unroll_loops(&graph, lowering.root);
         let mut symbols = HashMap::new();
         for (name, id) in &lowering.variable_symbols {
             symbols.insert(*id, SmtSymbolInfo::Variable { name: name.clone() });
@@ -1126,7 +1132,7 @@ impl BehaviorEmitter<'_> {
             state_name: "st",
             ctx: self.ctx,
         };
-        emit_sem_expr(&graph, lowering.root, &resolver).or_else(|| {
+        emit_sem_expr(&graph, root, &resolver).or_else(|| {
             self.failed.set(true);
             None
         })

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -434,6 +434,15 @@ fn infer<'a>(
             Type::Integer
         }
 
+        ast::Expr::For(f) => {
+            infer(&f.start, env, tvg, subst, cache, diags, file_name);
+            infer(&f.end, env, tvg, subst, cache, diags, file_name);
+            let mut body_env = env.clone();
+            body_env.bind(f.var.clone(), TypeScheme::mono(Type::Integer));
+            infer(&f.body, &body_env, tvg, subst, cache, diags, file_name);
+            Type::Integer
+        }
+
         ast::Expr::BuiltinFunction(_) | ast::Expr::Invalid => Type::Var(tvg.fresh()),
     };
 


### PR DESCRIPTION
Add "for VAR in START..END { body }" to the TMDL behavior language. Bounds
must be compile-time constants (literals, ISA/instruction parameters, or
arithmetic over them); loops are fully unrolled before lowering, substituting
the loop variable with a literal in each body copy. This keeps every backend
(semantic graph, SMT, simulator) loop-free.

- lexer: add "in" keyword
- parser: parse for loops in expression position
- ast: For node, constant bound evaluation, unrolling and full expansion
- typeck/sema: bind the loop variable and validate the body
- smtlibgen: expand loops before folding behavior to state
- rustgen: unroll loops in simulator behavior emission