### PR TITLE
feat(tmdl): add BTOR2 backend emitting an RVFI-style instruction checker

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,5 +10,6 @@
 - [TIR Machine Description Language](./tmdl/index.md)
   - [TMDL Syntax Guide](./tmdl/syntax.md)
   - [SMT Equivalence Checking](./tmdl/smt_verification.md)
+  - [BTOR2 Hardware Model Checking](./tmdl/btor2_model_checking.md)
 - [TMDL Parser Design](./tmdl/parser.md)
 - [API Docs](./api_docs.md)

--- a/docs/tmdl/btor2_model_checking.md
+++ b/docs/tmdl/btor2_model_checking.md
@@ -56,18 +56,23 @@ falsely flagged.
 ## End-to-end run
 
 1. **Lower the implementation to BTOR2.** From a Chisel design (e.g. Svarog),
-   elaborate a formal top exposing the retirement outputs, then:
+   elaborate a formal top exposing the retirement outputs, then run Yosys:
 
    ```sh
-   # Chisel -> Verilog
-   firtool FormalTop.fir --format=mlir -o FormalTop.sv
-   # Verilog -> BTOR2
-   yosys -p 'read_verilog -sv FormalTop.sv; prep -top FormalTop; \
-            flatten; setundef -zero; write_btor2 impl.btor2'
+   # Chisel -> Verilog (Svarog ships this generator; firtool is fetched by Chisel)
+   ./mill svarog.runMain svarog.formal.FormalGenerator \
+       --config=configs/svg-micro.yaml --target-dir=out/formal
+
+   # Verilog -> BTOR2 (the writer is `write_btor`, which emits BTOR2)
+   yosys -p 'read_verilog -sv out/formal/FormalTop.sv; prep -top FormalTop; \
+            flatten; setundef -zero; write_btor impl.btor2'
    ```
 
-   Svarog ships such a top (`testbench/formal/FormalTop.scala`) and a wrapper
-   that names the outputs to match the table above.
+   The generator passes the firtool lowering options
+   `disallowLocalVariables,disallowPackedArrays` and
+   `--default-layer-specialization=enable` so the emitted SystemVerilog stays
+   within the Yosys Verilog frontend. Svarog's `FormalTop` names the outputs to
+   match the table above.
 
 2. **Generate, stitch and check.**
 

--- a/docs/tmdl/btor2_model_checking.md
+++ b/docs/tmdl/btor2_model_checking.md
@@ -1,0 +1,104 @@
+# BTOR2 hardware model checking against the TMDL model
+
+`cargo xtask verify-btor2 <isa> <impl.btor2>` searches a hardware
+implementation for instructions that diverge from the TMDL specification. Where
+[SMT equivalence checking](./smt_verification.md) proves *spec vs spec* (TMDL ≡
+Sail), this checks *implementation vs spec* (RTL ≡ TMDL) with a word-level model
+checker. Because TMDL is already proven against Sail, agreement with TMDL
+transitively relates the hardware to the canonical model.
+
+## Why a checker, not a transition-system diff
+
+A pipelined core and a single-step ISA model cannot be compared cycle by cycle.
+The flow follows [riscv-formal](https://github.com/SymbioticEDA/riscv-formal):
+the implementation exposes a **retirement interface** — for each committed
+instruction it reports what it did — and a *combinational* reference checker
+recomputes the architectural result and asserts they agree. Timing is decoupled
+from semantics, so the pipeline depth, forwarding and hazards are all in scope
+without modeling the microarchitecture.
+
+`tmdlc --action=emit-btor2 --isa=<ISA>` generates that checker
+(`tmdl/src/btor2gen.rs`). It is purely combinational over the retirement
+signals and ends in one `bad` property: the mismatch.
+
+## The retirement interface
+
+The implementation's BTOR2 must expose these as **outputs**, named exactly. The
+stitcher wires them into the checker by name (`xtask/src/verify_btor2.rs`,
+`RVFI_SIGNALS`):
+
+| Signal     | Width  | Meaning                                                        |
+|------------|--------|---------------------------------------------------------------|
+| `valid`    | 1      | A modeled instruction retired this step.                      |
+| `insn`     | 32     | The retired instruction word.                                 |
+| `pc`       | XLEN   | Its program counter.                                          |
+| `rs1_val`  | XLEN   | Value read for the `rs1` source.                              |
+| `rs2_val`  | XLEN   | Value read for the `rs2` source.                              |
+| `rd_addr`  | 5      | Destination register index it wrote.                          |
+| `rd_we`    | 1      | Whether it wrote the integer register file.                   |
+| `rd_val`   | XLEN   | Value written to `rd`.                                        |
+| `next_pc`  | XLEN   | PC of the next retired instruction (branch target or pc + 4). |
+
+The checker computes the golden `rd_we`/`rd_val`/`rd_addr`/`next_pc` from
+`insn`, `pc`, `rs1_val`, `rs2_val` and raises `bad` when, on a `valid` step,
+any of them disagree. Reads come from the reported source *values*, so the
+implementation's register file and forwarding are exercised, not re-modeled.
+
+## Scope
+
+Matches `verify-smt`: register-only instructions (RV32I/RV64I arithmetic,
+logic, shifts, comparisons, branches, jumps, LUI/AUIPC, and the M extension).
+Behaviors touching memory or traps are dropped from the dispatch, so loads,
+stores, CSRs and exceptions are out of scope. The property only fires on
+decoded, modeled instructions: an unmodeled retired instruction is ignored, not
+falsely flagged.
+
+## End-to-end run
+
+1. **Lower the implementation to BTOR2.** From a Chisel design (e.g. Svarog),
+   elaborate a formal top exposing the retirement outputs, then:
+
+   ```sh
+   # Chisel -> Verilog
+   firtool FormalTop.fir --format=mlir -o FormalTop.sv
+   # Verilog -> BTOR2
+   yosys -p 'read_verilog -sv FormalTop.sv; prep -top FormalTop; \
+            flatten; setundef -zero; write_btor2 impl.btor2'
+   ```
+
+   Svarog ships such a top (`testbench/formal/FormalTop.scala`) and a wrapper
+   that names the outputs to match the table above.
+
+2. **Generate, stitch and check.**
+
+   ```sh
+   cargo xtask verify-btor2 riscv32 impl.btor2
+   ```
+
+   This emits the checker, writes the miter to `target/verify/btor2/miter.btor2`,
+   and — if `btormc` (Boolector/Bitwuzla) is on `PATH` — runs it.
+
+3. **Run the checker manually** if you prefer a different engine or bound:
+
+   ```sh
+   btormc -kmax 20 target/verify/btor2/miter.btor2
+   pono --engine bmc target/verify/btor2/miter.btor2
+   ```
+
+## Reading the result
+
+`unsat` (up to the bound) means no divergence was found. `sat` is a
+counterexample: the witness assigns the `insn`, `pc` and source values that
+expose the bug, and the implementation outputs that disagree with the spec.
+Decode `insn` to identify the instruction and compare `rd_val`/`next_pc`
+against the spec to see which field is wrong.
+
+## Limitations
+
+- **Bounded.** BMC finds bugs up to depth *k*; it is not a proof of correctness.
+  For unbounded guarantees use k-induction (Pono), which needs invariants for
+  pipelines. For bug-finding, BMC is the right tool.
+- **Register-only**, as above. Memory and CSR checking need a shared-memory
+  miter and are not implemented.
+- The implementation must honor the retirement contract faithfully; a buggy
+  retirement interface can mask or fabricate divergences.

--- a/docs/tmdl/btor2_model_checking.md
+++ b/docs/tmdl/btor2_model_checking.md
@@ -98,6 +98,23 @@ expose the bug, and the implementation outputs that disagree with the spec.
 Decode `insn` to identify the instruction and compare `rd_val`/`next_pc`
 against the spec to see which field is wrong.
 
+The stitcher drives a one-cycle reset pulse (constraining the design's `reset`
+input) and gates the property until reset deasserts, so uninitialized pipeline
+state at step 0 cannot raise a spurious counterexample.
+
+## Constraining the memory interface
+
+`FormalTop` leaves the instruction/data memory responses as free inputs. That
+suffices to explore every fetched word, but with no protocol constraint the
+fetch unit can ingest phantom responses (a `resp.valid` with no outstanding
+request), which produce retirements that no real memory would and so spurious
+counterexamples. Before trusting a `sat`, constrain the memory to follow the
+request/response handshake and return a stable word per address (the
+riscv-formal "memory abstraction"). As a sanity check, forcing the
+instruction-response valid bits low makes the model `unsat`: no instruction
+retires, confirming such counterexamples are interface artifacts, not core
+bugs.
+
 ## Limitations
 
 - **Bounded.** BMC finds bugs up to depth *k*; it is not a proof of correctness.

--- a/docs/tmdl/btor2_model_checking.md
+++ b/docs/tmdl/btor2_model_checking.md
@@ -63,9 +63,10 @@ falsely flagged.
    ./mill svarog.runMain svarog.formal.FormalGenerator \
        --config=configs/svg-micro.yaml --target-dir=out/formal
 
-   # Verilog -> BTOR2 (the writer is `write_btor`, which emits BTOR2)
+   # Verilog -> BTOR2 (the writer is `write_btor`, which emits BTOR2;
+   # `memory_collect` keeps the memory as a BTOR2 array rather than bit-blasting it)
    yosys -p 'read_verilog -sv out/formal/FormalTop.sv; prep -top FormalTop; \
-            flatten; setundef -zero; write_btor impl.btor2'
+            flatten; memory_collect; setundef -zero; write_btor impl.btor2'
    ```
 
    The generator passes the firtool lowering options
@@ -104,16 +105,23 @@ state at step 0 cannot raise a spurious counterexample.
 
 ## Constraining the memory interface
 
-`FormalTop` leaves the instruction/data memory responses as free inputs. That
-suffices to explore every fetched word, but with no protocol constraint the
-fetch unit can ingest phantom responses (a `resp.valid` with no outstanding
-request), which produce retirements that no real memory would and so spurious
-counterexamples. Before trusting a `sat`, constrain the memory to follow the
-request/response handshake and return a stable word per address (the
-riscv-formal "memory abstraction"). As a sanity check, forcing the
-instruction-response valid bits low makes the model `unsat`: no instruction
-retires, confirming such counterexamples are interface artifacts, not core
-bugs.
+Leaving the memory responses as free inputs lets the fetch unit ingest phantom
+responses (a `resp.valid` with no outstanding request), producing retirements
+no real memory would and so spurious counterexamples. Svarog's `FormalMemory`
+avoids this: it honors the request/response handshake (one outstanding request)
+and backs reads with a free, uninitialized array, so each address holds an
+arbitrary-but-stable word and BMC still explores every program. A response can
+never appear without a prior request.
+
+## A found discrepancy (worked example)
+
+Running this flow against Svarog surfaced a real decode-strictness gap. The TMDL
+`ShiftImm` template encodes the RV32 `shamt` in a 6-bit field (`20..25`) but
+declares it 5 bits, leaving bit 25 unconstrained — so the checker accepted
+illegal shift-immediate encodings (`shamt[5]=1`, reserved) that the hardware
+correctly rejects. `verify-smt` cannot see this (it only *encodes* legal words);
+exploring all 32-bit words does. The BTOR2 checker now constrains the spare
+high bits of any over-wide operand field to zero, matching the hardware.
 
 ## Limitations
 

--- a/tmdl/checks/Btor2/checker.tmdl
+++ b/tmdl/checks/Btor2/checker.tmdl
@@ -1,0 +1,29 @@
+// Hand-written checks for the BTOR2 backend's RVFI-style instruction checker.
+// Node ids are positional, so matches use regex captures rather than literal
+// ids. Do not regenerate with update_checks.py.
+
+// RUN: tmdlc --action=emit-btor2 --isa=TestIsa --output=- %S/../Inputs/smtlib.tmdl | filecheck %s
+
+// CHECK: ; TMDL RVFI-style instruction checker
+
+// The retirement interface: the implementation reports these per committed
+// instruction, and the checker computes the golden post-state from them.
+// CHECK: {{[0-9]+}} input {{[0-9]+}} insn
+// CHECK: {{[0-9]+}} input {{[0-9]+}} pc
+// CHECK: {{[0-9]+}} input {{[0-9]+}} rs1_val
+// CHECK: {{[0-9]+}} input {{[0-9]+}} rs2_val
+// CHECK: {{[0-9]+}} input {{[0-9]+}} rd_addr
+// CHECK: {{[0-9]+}} input {{[0-9]+}} rd_we
+// CHECK: {{[0-9]+}} input {{[0-9]+}} rd_val
+// CHECK: {{[0-9]+}} input {{[0-9]+}} next_pc
+// CHECK: {{[0-9]+}} input {{[0-9]+}} valid
+
+// Fall-through next-pc is pc + 4.
+// CHECK: {{[0-9]+}} constd {{[0-9]+}} 4
+// CHECK: {{[0-9]+}} add {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+
+// `tadd` computes rs1_val + rs2_val with the result written to rd.
+// CHECK: {{[0-9]+}} add {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+
+// The model terminates in a single bad property (the mismatch).
+// CHECK: {{[0-9]+}} bad {{[0-9]+}}

--- a/tmdl/src/btor2gen.rs
+++ b/tmdl/src/btor2gen.rs
@@ -493,7 +493,13 @@ fn emit(graph: &ExprPostGraph, node: NodeId, r: &Resolver<'_>, b: &mut Btor2) ->
             let hi = b.ite(above, max, input, input.signed);
             Some(b.ite(below, min, hi, input.signed))
         }
-        ExprKind::LoadMemory | ExprKind::StoreMemory | ExprKind::Sqrt | ExprKind::Fma => None,
+        ExprKind::LoadMemory
+        | ExprKind::StoreMemory
+        | ExprKind::Sqrt
+        | ExprKind::Fma
+        | ExprKind::Loop
+        | ExprKind::IndVar
+        | ExprKind::Acc => None,
     }
 }
 

--- a/tmdl/src/btor2gen.rs
+++ b/tmdl/src/btor2gen.rs
@@ -742,15 +742,19 @@ fn decode_layout(
 }
 
 /// Reconstruct one operand from its word pieces, zero-filling gaps, then fit to
-/// `target_width`.
+/// `target_width`. When the encoding field is wider than the operand (e.g. the
+/// RV32 shift-immediate `shamt` occupies a 6-bit field but is 5 bits), the
+/// spare high bits are reserved-zero in the architecture; the returned guard
+/// (1-bit, true when they are zero) constrains decode to reject the otherwise
+/// illegal encodings the hardware rejects.
 fn decode_operand(
     b: &mut Btor2,
     insn: Bv,
     mut pieces: Vec<(u16, u16, u16, u16)>,
     target_width: u16,
-) -> Bv {
+) -> (Bv, Option<Bv>) {
     if pieces.is_empty() {
-        return b.konst(target_width as u32, 0);
+        return (b.konst(target_width as u32, 0), None);
     }
     pieces.sort_by_key(|p| std::cmp::Reverse(p.1));
     let mut acc: Option<Bv> = None;
@@ -777,7 +781,15 @@ fn decode_operand(
         push(b, &mut acc, pad);
     }
     let raw = acc.unwrap();
-    b.fit(raw, target_width as u32)
+    let target = target_width as u32;
+    let guard = if raw.width > target {
+        let spare = b.slice(raw, raw.width - 1, target);
+        let zero = b.konst(spare.width, 0);
+        Some(b.cmp("eq", spare, zero))
+    } else {
+        None
+    };
+    (b.fit(raw, target), guard)
 }
 
 fn build_guard(b: &mut Btor2, insn: Bv, guards: &[(u16, u16, u128)]) -> Bv {
@@ -897,17 +909,19 @@ pub fn generate_btor2<'a>(
         // decoded for the `rd_addr` check.
         let mut operand_vals = HashMap::new();
         let mut operand_addrs = HashMap::new();
+        let mut spare_guards: Vec<Bv> = Vec::new();
         for (name, ty) in &operand_list {
             let lname = name.to_lowercase();
             match ty {
                 Type::Struct(rc) if ctx.pc_classes.contains(&rc.to_lowercase()) => {}
                 Type::Struct(rc) => {
-                    let addr = decode_operand(
+                    let (addr, guard) = decode_operand(
                         &mut b,
                         insn,
                         pieces.get(name).cloned().unwrap_or_default(),
                         ctx.idx_width(rc),
                     );
+                    spare_guards.extend(guard);
                     operand_addrs.insert(lname.clone(), (addr, rc.clone()));
                     operand_vals.insert(
                         lname,
@@ -919,19 +933,23 @@ pub fn generate_btor2<'a>(
                     );
                 }
                 Type::Bits(n) => {
-                    let v = decode_operand(
+                    let (v, guard) = decode_operand(
                         &mut b,
                         insn,
                         pieces.get(name).cloned().unwrap_or_default(),
                         *n,
                     );
+                    spare_guards.extend(guard);
                     operand_vals.insert(lname, v);
                 }
                 _ => {}
             }
         }
 
-        let guard = build_guard(&mut b, insn, &guards);
+        let mut guard = build_guard(&mut b, insn, &guards);
+        for sg in spare_guards {
+            guard = b.bin("and", guard, sg, false);
+        }
 
         let init = PostState {
             rd_we: b.konst(1, 0),
@@ -990,8 +1008,15 @@ pub fn generate_btor2<'a>(
         legal = b.bin("or", legal, *guard, false);
     }
 
-    // Mismatch: the implementation's report diverges from the spec.
-    let we_bad = b.cmp("neq", rd_we_impl, spec.rd_we);
+    // Mismatch: the implementation's report diverges from the spec. A write to
+    // the hardwired-zero register is architecturally a no-op, so mask the
+    // implementation's write-enable with `rd_addr != 0` before comparing — an
+    // implementation may legitimately assert it while the register file drops
+    // the write.
+    let zero_addr2 = b.konst(idx_w, 0);
+    let rd_nonzero = b.cmp("neq", rd_addr_impl, zero_addr2);
+    let impl_we_eff = b.bin("and", rd_we_impl, rd_nonzero, false);
+    let we_bad = b.cmp("neq", impl_we_eff, spec.rd_we);
     let val_ne = b.cmp("neq", rd_val_impl, spec.rd_val);
     let val_bad = b.bin("and", spec.rd_we, val_ne, false);
     let addr_ne = b.cmp("neq", rd_addr_impl, spec.rd_addr);

--- a/tmdl/src/btor2gen.rs
+++ b/tmdl/src/btor2gen.rs
@@ -1008,11 +1008,9 @@ pub fn generate_btor2<'a>(
         legal = b.bin("or", legal, *guard, false);
     }
 
-    // Mismatch: the implementation's report diverges from the spec. A write to
-    // the hardwired-zero register is architecturally a no-op, so mask the
-    // implementation's write-enable with `rd_addr != 0` before comparing — an
-    // implementation may legitimately assert it while the register file drops
-    // the write.
+    // Mismatch, split per field so a model checker reports which one diverged.
+    // A write to the hardwired-zero register is architecturally a no-op, so mask
+    // the implementation's write-enable with `rd_addr != 0` before comparing.
     let zero_addr2 = b.konst(idx_w, 0);
     let rd_nonzero = b.cmp("neq", rd_addr_impl, zero_addr2);
     let impl_we_eff = b.bin("and", rd_we_impl, rd_nonzero, false);
@@ -1022,12 +1020,25 @@ pub fn generate_btor2<'a>(
     let addr_ne = b.cmp("neq", rd_addr_impl, spec.rd_addr);
     let addr_bad = b.bin("and", spec.rd_we, addr_ne, false);
     let pc_bad = b.cmp("neq", next_pc_impl, spec.next_pc);
-    let any1 = b.bin("or", we_bad, val_bad, false);
-    let any2 = b.bin("or", addr_bad, pc_bad, false);
-    let any = b.bin("or", any1, any2, false);
+
+    // Observable spec/impl values for counterexample triage (ignored by BMC).
+    b.line(&format!("output {} decode_legal", legal.nid));
+    b.line(&format!("output {} impl_rd_we_eff", impl_we_eff.nid));
+    b.line(&format!("output {} spec_rd_we", spec.rd_we.nid));
+    b.line(&format!("output {} spec_rd_val", spec.rd_val.nid));
+    b.line(&format!("output {} spec_rd_addr", spec.rd_addr.nid));
+    b.line(&format!("output {} spec_next_pc", spec.next_pc.nid));
+
     let gated = b.bin("and", valid, legal, false);
-    let bad = b.bin("and", gated, any, false);
-    b.line(&format!("bad {}", bad.nid));
+    for (cond, name) in [
+        (we_bad, "rd_we_mismatch"),
+        (val_bad, "rd_val_mismatch"),
+        (addr_bad, "rd_addr_mismatch"),
+        (pc_bad, "next_pc_mismatch"),
+    ] {
+        let g = b.bin("and", gated, cond, false);
+        b.line(&format!("bad {} {}", g.nid, name));
+    }
 
     output.write_all(b.out.as_bytes())?;
     Ok(())
@@ -1092,6 +1103,7 @@ mod tests {
                     &[]
                 }
                 "input" | "constd" | "const" | "one" | "zero" | "ones" => &[],
+                "output" => &[2],
                 "bad" => {
                     bads += 1;
                     &[2]
@@ -1100,7 +1112,7 @@ mod tests {
                 "ite" => &[3, 4, 5],
                 _ => &[3, 4],
             };
-            if op != "sort" && op != "bad" {
+            if !matches!(op, "sort" | "bad" | "output") {
                 assert!(
                     sorts.contains(&p[2].parse().unwrap()),
                     "sort ref at: {line}"
@@ -1112,7 +1124,7 @@ mod tests {
             }
             defined.insert(nid);
         }
-        assert_eq!(bads, 1, "exactly one bad property expected");
+        assert!(bads >= 1, "at least one bad property expected");
     }
 
     const SPEC: &str = include_str!("../checks/Inputs/smtlib.tmdl");

--- a/tmdl/src/btor2gen.rs
+++ b/tmdl/src/btor2gen.rs
@@ -1,0 +1,1117 @@
+//! BTOR2 emission of a per-instruction reference *checker* for hardware model
+//! checking (the riscv-formal / RVFI shape).
+//!
+//! Why a checker and not a full transition system: a pipelined implementation
+//! and a single-step ISA model can only be compared by decoupling timing from
+//! semantics. The implementation exposes a retirement interface — for each
+//! committed instruction it reports `pc`, `insn`, the source register *values*
+//! it read (`rs1_val`, `rs2_val`), and the destination it wrote (`rd_addr`,
+//! `rd_we`, `rd_val`, `next_pc`). This model is the golden side: from `insn`,
+//! `pc` and the reported source values it decodes the instruction and computes
+//! the architectural post-state, then asserts the implementation's report
+//! matches. The result is a purely combinational relation over the retirement
+//! signals; composed with the implementation's own BTOR2 it becomes a miter a
+//! BMC engine (btormc/Bitwuzla) drives to a counterexample.
+//!
+//! Scope mirrors `verify-smt`: register-only instructions. Behaviors touching
+//! memory or traps are not modeled and are dropped from the dispatch (the
+//! property only fires on decoded, modeled instructions, so dropping cannot
+//! produce a false counterexample).
+
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, HashMap};
+use std::io::Write;
+
+use crate::Type;
+use crate::ast;
+use crate::error::TMDLError;
+use crate::sem_expr_state::{self, StateEmitter};
+use crate::utils::{
+    get_encoding_arms, isa_param_values, item_supports_isa, parse_literal_value,
+    resolve_isa_param_values, resolve_operand_widths, resolve_operands_for_instruction,
+    resolve_params_for_instruction,
+};
+use tir::graph::{Dag, NodeId};
+use tir::sem_expr::{ExprKind, ExprPayload, ExprPostGraph};
+
+// ---------------------------------------------------------------------------
+// Target context (register-file layout resolved against the ISA)
+// ---------------------------------------------------------------------------
+
+struct ClassInfo {
+    idx_width: u16,
+    val_width: u16,
+    zero_index: Option<u16>,
+}
+
+struct Ctx<'a> {
+    isa: &'a str,
+    xlen: u16,
+    classes: BTreeMap<String, ClassInfo>,
+    pc_classes: std::collections::HashSet<String>,
+    isa_params: HashMap<String, i64>,
+}
+
+impl Ctx<'_> {
+    fn idx_width(&self, class: &str) -> u16 {
+        self.classes
+            .get(&class.to_lowercase())
+            .map_or(5, |c| c.idx_width)
+    }
+
+    fn val_width(&self, class: &str) -> u16 {
+        let class = class.to_lowercase();
+        if self.pc_classes.contains(&class) {
+            return self.xlen;
+        }
+        self.classes.get(&class).map_or(self.xlen, |c| c.val_width)
+    }
+
+    fn zero_index(&self, class: &str) -> Option<u16> {
+        self.classes
+            .get(&class.to_lowercase())
+            .and_then(|c| c.zero_index)
+    }
+}
+
+fn eval_class_param(
+    rc: &ast::RegisterClass,
+    name: &str,
+    isa_params: &HashMap<String, i64>,
+) -> Option<i64> {
+    match rc.parameters.get(name)? {
+        (_, Some(ast::Expr::Lit(ast::Lit::Int(li)))) => Some(parse_literal_value(li) as i64),
+        (_, Some(ast::Expr::Field(f))) if matches!(&*f.base, ast::Expr::Ident(id) if id.name == "self") => {
+            isa_params.get(f.member.as_str()).copied()
+        }
+        _ => None,
+    }
+}
+
+fn is_pc_class(rc: &ast::RegisterClass) -> bool {
+    rc.resolve_registers()
+        .any(|r| r.traits.contains(&ast::RegisterTrait::ProgramCounter))
+}
+
+// ---------------------------------------------------------------------------
+// BTOR2 node builder
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct Bv {
+    nid: u32,
+    width: u32,
+    signed: bool,
+}
+
+struct Btor2 {
+    out: String,
+    next: u32,
+    sorts: BTreeMap<u32, u32>,
+}
+
+impl Btor2 {
+    fn new() -> Self {
+        Btor2 {
+            out: String::new(),
+            next: 0,
+            sorts: BTreeMap::new(),
+        }
+    }
+
+    fn line(&mut self, body: &str) -> u32 {
+        self.next += 1;
+        let nid = self.next;
+        self.out.push_str(&format!("{} {}\n", nid, body));
+        nid
+    }
+
+    fn sort(&mut self, width: u32) -> u32 {
+        if let Some(s) = self.sorts.get(&width) {
+            return *s;
+        }
+        let s = self.line(&format!("sort bitvec {}", width));
+        self.sorts.insert(width, s);
+        s
+    }
+
+    fn input(&mut self, width: u32, name: &str) -> Bv {
+        let s = self.sort(width);
+        let nid = self.line(&format!("input {} {}", s, name));
+        Bv {
+            nid,
+            width,
+            signed: false,
+        }
+    }
+
+    fn konst(&mut self, width: u32, value: u64) -> Bv {
+        let s = self.sort(width);
+        let nid = self.line(&format!("constd {} {}", s, value));
+        Bv {
+            nid,
+            width,
+            signed: false,
+        }
+    }
+
+    /// Width-preserving binary op (`add`, `and`, `sll`, ...).
+    fn bin(&mut self, op: &str, a: Bv, b: Bv, signed: bool) -> Bv {
+        debug_assert_eq!(a.width, b.width);
+        let s = self.sort(a.width);
+        let nid = self.line(&format!("{} {} {} {}", op, s, a.nid, b.nid));
+        Bv {
+            nid,
+            width: a.width,
+            signed,
+        }
+    }
+
+    /// Comparison producing a 1-bit result.
+    fn cmp(&mut self, op: &str, a: Bv, b: Bv) -> Bv {
+        debug_assert_eq!(a.width, b.width);
+        let s = self.sort(1);
+        let nid = self.line(&format!("{} {} {} {}", op, s, a.nid, b.nid));
+        Bv {
+            nid,
+            width: 1,
+            signed: false,
+        }
+    }
+
+    fn not(&mut self, a: Bv) -> Bv {
+        let s = self.sort(a.width);
+        let nid = self.line(&format!("not {} {}", s, a.nid));
+        Bv {
+            nid,
+            width: a.width,
+            signed: a.signed,
+        }
+    }
+
+    fn ite(&mut self, cond: Bv, t: Bv, e: Bv, signed: bool) -> Bv {
+        debug_assert_eq!(t.width, e.width);
+        let s = self.sort(t.width);
+        let nid = self.line(&format!("ite {} {} {} {}", s, cond.nid, t.nid, e.nid));
+        Bv {
+            nid,
+            width: t.width,
+            signed,
+        }
+    }
+
+    fn ext(&mut self, op: &str, a: Bv, by: u32, signed: bool) -> Bv {
+        if by == 0 {
+            return Bv { signed, ..a };
+        }
+        let s = self.sort(a.width + by);
+        let nid = self.line(&format!("{} {} {} {}", op, s, a.nid, by));
+        Bv {
+            nid,
+            width: a.width + by,
+            signed,
+        }
+    }
+
+    fn slice(&mut self, a: Bv, high: u32, low: u32) -> Bv {
+        let width = high - low + 1;
+        if width == a.width {
+            return a;
+        }
+        let s = self.sort(width);
+        let nid = self.line(&format!("slice {} {} {} {}", s, a.nid, high, low));
+        Bv {
+            nid,
+            width,
+            signed: false,
+        }
+    }
+
+    fn concat(&mut self, a: Bv, b: Bv) -> Bv {
+        let width = a.width + b.width;
+        let s = self.sort(width);
+        let nid = self.line(&format!("concat {} {} {}", s, a.nid, b.nid));
+        Bv {
+            nid,
+            width,
+            signed: false,
+        }
+    }
+
+    fn widen(&mut self, a: Bv, target: u32, signed: bool) -> Bv {
+        if a.width >= target {
+            return a;
+        }
+        let op = if signed { "sext" } else { "uext" };
+        self.ext(op, a, target - a.width, signed)
+    }
+
+    fn fit(&mut self, a: Bv, target: u32) -> Bv {
+        if a.width > target {
+            self.slice(a, target - 1, 0)
+        } else {
+            self.widen(a, target, a.signed)
+        }
+    }
+
+    fn coerce(&mut self, a: Bv, b: Bv) -> (Bv, Bv) {
+        let w = a.width.max(b.width);
+        (self.widen(a, w, a.signed), self.widen(b, w, b.signed))
+    }
+
+    /// Reduce any value to a 1-bit truth: nonzero -> 1.
+    fn as_bool(&mut self, a: Bv) -> Bv {
+        if a.width == 1 {
+            return a;
+        }
+        let zero = self.konst(a.width, 0);
+        self.cmp("neq", a, zero)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Expression lowering (mirror of smtlibgen::emit_sem_expr over BTOR2 nodes)
+// ---------------------------------------------------------------------------
+
+enum SymbolInfo {
+    Register { class: String },
+    Variable { name: String },
+}
+
+struct Resolver<'a> {
+    symbols: HashMap<u32, SymbolInfo>,
+    operands: &'a HashMap<String, Type>,
+    /// Decoded operand values keyed by lowercase operand name: source register
+    /// values (`rs1`, `rs2`) come from retirement inputs, immediates from the
+    /// instruction word.
+    operand_vals: &'a HashMap<String, Bv>,
+    pc: Bv,
+    ctx: &'a Ctx<'a>,
+}
+
+impl Resolver<'_> {
+    fn resolve(&self, id: u32) -> Option<Bv> {
+        match self.symbols.get(&id)? {
+            SymbolInfo::Register { class, .. }
+                if self.ctx.pc_classes.contains(&class.to_lowercase()) =>
+            {
+                Some(self.pc)
+            }
+            // A fixed non-PC register read is not part of the RVFI retirement
+            // contract; reject so the instruction is dropped.
+            SymbolInfo::Register { .. } => None,
+            SymbolInfo::Variable { name } => match self.operands.get(name)? {
+                Type::Struct(rc) if self.ctx.pc_classes.contains(&rc.to_lowercase()) => {
+                    Some(self.pc)
+                }
+                _ => self.operand_vals.get(&name.to_lowercase()).copied(),
+            },
+        }
+    }
+}
+
+/// Fold a symbol-free subtree to a constant (width expressions such as
+/// `log2Ceil(self.XLEN) - 1` reach the emitter unfolded).
+fn eval_const(graph: &ExprPostGraph, node: NodeId) -> Option<(u64, u32)> {
+    let child = |idx: usize| eval_const(graph, graph.children(node).nth(idx)?);
+    let arith = |f: fn(u64, u64) -> u64| -> Option<(u64, u32)> {
+        let (a, wa) = child(0)?;
+        let (b, wb) = child(1)?;
+        let w = wa.max(wb);
+        let mask = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+        Some((f(a, b) & mask, w))
+    };
+    match graph.get_node(node) {
+        ExprKind::Constant => match graph.get_leaf_data(node)? {
+            ExprPayload::Int(i) => Some((i.to_u64(), i.width())),
+            _ => None,
+        },
+        ExprKind::Add => arith(u64::wrapping_add),
+        ExprKind::Sub => arith(u64::wrapping_sub),
+        ExprKind::Mul => arith(u64::wrapping_mul),
+        ExprKind::Log2Ceil => {
+            let (v, w) = child(0)?;
+            let r = if v <= 1 {
+                0
+            } else {
+                64 - (v - 1).leading_zeros() as u64
+            };
+            Some((r, w))
+        }
+        _ => None,
+    }
+}
+
+fn emit(graph: &ExprPostGraph, node: NodeId, r: &Resolver<'_>, b: &mut Btor2) -> Option<Bv> {
+    let child_node = |idx: usize| graph.children(node).nth(idx);
+    let const_child = |idx: usize| -> Option<u64> { Some(eval_const(graph, child_node(idx)?)?.0) };
+
+    macro_rules! ch {
+        ($i:expr) => {
+            emit(graph, child_node($i)?, r, b)?
+        };
+    }
+    macro_rules! arith {
+        ($op:expr) => {{
+            let (x, y) = (ch!(0), ch!(1));
+            let signed = x.signed && y.signed;
+            let (x, y) = b.coerce(x, y);
+            Some(b.bin($op, x, y, signed))
+        }};
+    }
+    macro_rules! cmp {
+        ($op:expr) => {{
+            let (x, y) = (ch!(0), ch!(1));
+            let (x, y) = b.coerce(x, y);
+            Some(b.cmp($op, x, y))
+        }};
+    }
+    // Result width is the left operand's; the amount is reinterpreted at that
+    // width, matching the interpreter.
+    macro_rules! shift {
+        ($op:expr, $sgn:expr) => {{
+            let lhs = ch!(0);
+            let amt = ch!(1);
+            let amt = b.fit(amt, lhs.width);
+            let sgn: fn(bool) -> bool = $sgn;
+            Some(b.bin($op, lhs, amt, sgn(lhs.signed)))
+        }};
+    }
+
+    match graph.get_node(node) {
+        ExprKind::Symbol => match graph.get_leaf_data(node)? {
+            ExprPayload::SymbolId(id) => r.resolve(*id),
+            _ => None,
+        },
+        ExprKind::Constant => match graph.get_leaf_data(node)? {
+            ExprPayload::Int(i) => {
+                let w = i.width();
+                let mask = if w >= 64 { u64::MAX } else { (1u64 << w) - 1 };
+                Some(Bv {
+                    signed: i.is_signed(),
+                    ..b.konst(w, i.to_u64() & mask)
+                })
+            }
+            _ => None,
+        },
+        ExprKind::Add => arith!("add"),
+        ExprKind::Sub => arith!("sub"),
+        ExprKind::Mul => arith!("mul"),
+        ExprKind::Div => arith!("sdiv"),
+        ExprKind::UDiv => arith!("udiv"),
+        ExprKind::Or => arith!("or"),
+        ExprKind::And => arith!("and"),
+        ExprKind::Xor => arith!("xor"),
+        ExprKind::Eq => cmp!("eq"),
+        ExprKind::Ne => cmp!("neq"),
+        ExprKind::Lt => cmp!("slt"),
+        ExprKind::Gt => cmp!("sgt"),
+        ExprKind::Ge => cmp!("sgte"),
+        ExprKind::ULt => cmp!("ult"),
+        ExprKind::ULe => cmp!("ulte"),
+        ExprKind::UGt => cmp!("ugt"),
+        ExprKind::UGe => cmp!("ugte"),
+        ExprKind::ShiftLeft => shift!("sll", |s| s),
+        ExprKind::ShiftRightLogic => shift!("srl", |_| false),
+        ExprKind::ShiftRightArithmetic => shift!("sra", |_| true),
+        ExprKind::Not => {
+            let x = ch!(0);
+            Some(b.not(x))
+        }
+        ExprKind::If => {
+            let cond = ch!(0);
+            let cond = b.as_bool(cond);
+            let (t, e) = (ch!(1), ch!(2));
+            let signed = t.signed || e.signed;
+            let (t, e) = b.coerce(t, e);
+            Some(b.ite(cond, t, e, signed))
+        }
+        ExprKind::ZExt => {
+            let x = ch!(0);
+            let target = const_child(1)? as u32;
+            if target < x.width {
+                return None;
+            }
+            Some(b.widen(x, target, false))
+        }
+        ExprKind::SExt => {
+            let x = ch!(0);
+            let target = const_child(1)? as u32;
+            if target < x.width {
+                return None;
+            }
+            Some(b.widen(x, target, true))
+        }
+        ExprKind::Extract => {
+            let high = const_child(1)? as u32;
+            let low = const_child(2)? as u32;
+            if high < low {
+                return None;
+            }
+            let mul = child_node(0)?;
+            if low >= ch!(0).width && matches!(graph.get_node(mul), ExprKind::Mul) {
+                // `extract(a * b, 2N-1, N)`: high half of a signed full multiply
+                // (RISC-V `mulh`). Recompute as a double-width signed product.
+                let m0 = emit(graph, graph.children(mul).next()?, r, b)?;
+                let m1 = emit(graph, graph.children(mul).nth(1)?, r, b)?;
+                let (m0, m1) = b.coerce(m0, m1);
+                let wm = m0.width;
+                if high >= 2 * wm {
+                    return None;
+                }
+                let m0 = b.widen(m0, 2 * wm, true);
+                let m1 = b.widen(m1, 2 * wm, true);
+                let prod = b.bin("mul", m0, m1, true);
+                Some(b.slice(prod, high, low))
+            } else {
+                let x = ch!(0);
+                if high >= x.width {
+                    return None;
+                }
+                Some(b.slice(x, high, low))
+            }
+        }
+        ExprKind::Log2Ceil => {
+            let (v, w) = eval_const(graph, node)?;
+            Some(b.konst(w, v))
+        }
+        ExprKind::Clamp => {
+            let input = ch!(0);
+            let (lt, gt) = if input.signed {
+                ("slt", "sgt")
+            } else {
+                ("ult", "ugt")
+            };
+            let min = ch!(1);
+            let max = ch!(2);
+            let w = input.width.max(min.width).max(max.width);
+            let input = b.widen(input, w, input.signed);
+            let min = b.widen(min, w, false);
+            let max = b.widen(max, w, false);
+            let below = b.cmp(lt, input, min);
+            let above = b.cmp(gt, input, max);
+            let hi = b.ite(above, max, input, input.signed);
+            Some(b.ite(below, min, hi, input.signed))
+        }
+        ExprKind::LoadMemory | ExprKind::StoreMemory | ExprKind::Sqrt | ExprKind::Fma => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-instruction checker: decode + execute over retirement signals
+// ---------------------------------------------------------------------------
+
+/// Architectural post-state the checker computes for one decoded instruction.
+#[derive(Clone, Copy)]
+struct PostState {
+    rd_we: Bv,
+    rd_val: Bv,
+    rd_addr: Bv,
+    next_pc: Bv,
+}
+
+struct Checker<'a> {
+    ctx: &'a Ctx<'a>,
+    operands: HashMap<String, Type>,
+    operand_vals: HashMap<String, Bv>,
+    /// Decoded destination index, for the `rd_addr` cross-check and the
+    /// hardwired-zero mask. Present only for register write targets.
+    operand_addrs: HashMap<String, (Bv, String)>,
+    numeric_params: HashMap<String, i64>,
+    register_index_map: &'a HashMap<(String, String), u32>,
+    pc: Bv,
+    b: RefCell<&'a mut Btor2>,
+    states: RefCell<HashMap<String, PostState>>,
+    counter: Cell<usize>,
+    failed: Cell<bool>,
+}
+
+impl Checker<'_> {
+    fn fresh(&self, st: PostState) -> String {
+        let n = self.counter.get();
+        self.counter.set(n + 1);
+        let name = format!("s{}", n);
+        self.states.borrow_mut().insert(name.clone(), st);
+        name
+    }
+
+    fn get(&self, name: &str) -> PostState {
+        self.states.borrow()[name]
+    }
+
+    fn emit_val(&self, e: &ast::Expr) -> Option<Bv> {
+        let mut graph = ExprPostGraph::new();
+        let lowering = e
+            .lower_to_sema_with_registers(&mut graph, &self.numeric_params, self.register_index_map)
+            .or_else(|| {
+                self.failed.set(true);
+                None
+            })?;
+        let mut symbols = HashMap::new();
+        for (name, id) in &lowering.variable_symbols {
+            symbols.insert(*id, SymbolInfo::Variable { name: name.clone() });
+        }
+        for ((class, _number), id) in &lowering.register_symbols {
+            symbols.insert(
+                *id,
+                SymbolInfo::Register {
+                    class: class.clone(),
+                },
+            );
+        }
+        let resolver = Resolver {
+            symbols,
+            operands: &self.operands,
+            operand_vals: &self.operand_vals,
+            pc: self.pc,
+            ctx: self.ctx,
+        };
+        let mut b = self.b.borrow_mut();
+        emit(&graph, lowering.root, &resolver, &mut b).or_else(|| {
+            self.failed.set(true);
+            None
+        })
+    }
+}
+
+impl StateEmitter for Checker<'_> {
+    fn cond(&self, e: &ast::Expr) -> String {
+        match self.emit_val(e) {
+            Some(v) => {
+                let mut b = self.b.borrow_mut();
+                b.as_bool(v).nid.to_string()
+            }
+            None => "0".to_string(),
+        }
+    }
+
+    fn assign(&self, a: &ast::Assign, st_name: &str) -> Option<String> {
+        let value = self.emit_val(&a.value)?;
+        let st = self.get(st_name);
+        let dest = match &*a.dest {
+            ast::Expr::Ident(id) => Some(id.name.as_str()),
+            ast::Expr::Path(p) if p.remainder.len() == 1 => Some(p.remainder[0].as_str()),
+            _ => None,
+        }?;
+
+        let xlen = self.ctx.xlen as u32;
+        let mut b = self.b.borrow_mut();
+
+        if dest == "pc" {
+            let next_pc = b.fit(value, xlen);
+            return Some(self.fresh(PostState { next_pc, ..st }));
+        }
+        match self.operands.get(dest) {
+            Some(Type::Struct(rc)) if self.ctx.pc_classes.contains(&rc.to_lowercase()) => {
+                let next_pc = b.fit(value, xlen);
+                Some(self.fresh(PostState { next_pc, ..st }))
+            }
+            Some(Type::Struct(rc)) => {
+                let rd_val = b.fit(value, self.ctx.val_width(rc) as u32);
+                let (rd_addr, class) = self.operand_addrs.get(dest)?.clone();
+                // A write to the hardwired-zero register is dropped.
+                let rd_we = match self.ctx.zero_index(&class) {
+                    Some(z) => {
+                        let zc = b.konst(rd_addr.width, z as u64);
+                        b.cmp("neq", rd_addr, zc)
+                    }
+                    None => b.konst(1, 1),
+                };
+                Some(self.fresh(PostState {
+                    rd_we,
+                    rd_val,
+                    rd_addr,
+                    ..st
+                }))
+            }
+            _ => None,
+        }
+    }
+
+    fn store(&self, _c: &ast::Call, _st: &str) -> Option<String> {
+        None
+    }
+
+    fn trap(
+        &self,
+        _c: &ast::Call,
+        _st: &str,
+        _compile: &dyn Fn(&ast::Expr, &str) -> String,
+    ) -> Option<String> {
+        None
+    }
+
+    fn ite(&self, cond: &str, then_state: &str, else_state: &str) -> String {
+        let cond_nid: u32 = cond.parse().unwrap_or(0);
+        if cond_nid == 0 {
+            return else_state.to_string();
+        }
+        let (t, e) = (self.get(then_state), self.get(else_state));
+        let mut b = self.b.borrow_mut();
+        let cond = Bv {
+            nid: cond_nid,
+            width: 1,
+            signed: false,
+        };
+        let merged = PostState {
+            rd_we: b.ite(cond, t.rd_we, e.rd_we, false),
+            rd_val: b.ite(cond, t.rd_val, e.rd_val, false),
+            rd_addr: b.ite(cond, t.rd_addr, e.rd_addr, false),
+            next_pc: b.ite(cond, t.next_pc, e.next_pc, false),
+        };
+        drop(b);
+        self.fresh(merged)
+    }
+
+    fn try_except(
+        &self,
+        _t: &ast::TryExcept,
+        _st: &str,
+        _body: &str,
+        _compile: &dyn Fn(&ast::Expr, &str) -> String,
+    ) -> Option<String> {
+        None
+    }
+
+    fn unsupported(&self, _e: &ast::Expr) {
+        self.failed.set(true);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decode: reconstruct operands and the match guard from the instruction word
+// ---------------------------------------------------------------------------
+
+type Pieces = HashMap<String, Vec<(u16, u16, u16, u16)>>;
+
+/// Collect fixed-field guards and per-operand bit pieces from the encoding,
+/// mirroring `smtlibgen::build_decoder`.
+fn decode_layout(
+    instruction: &ast::Instruction,
+    item_cache: &HashMap<&str, &ast::Item>,
+    operands: &HashMap<String, Type>,
+) -> (Vec<(u16, u16, u128)>, Pieces) {
+    let params = resolve_params_for_instruction(instruction, item_cache);
+    let mut guards = Vec::new();
+    let mut pieces: Pieces = HashMap::new();
+
+    for arm in get_encoding_arms(instruction, item_cache) {
+        let word_lo = arm.start;
+        let word_hi = arm.end.unwrap_or(arm.start);
+        match &arm.value {
+            ast::Expr::Lit(ast::Lit::Int(li)) => {
+                guards.push((word_hi, word_lo, parse_literal_value(li) as u128));
+            }
+            ast::Expr::Ident(id) => {
+                if operands.contains_key(&id.name) {
+                    let w = word_hi - word_lo;
+                    pieces
+                        .entry(id.name.clone())
+                        .or_default()
+                        .push((0, w, word_lo, word_hi));
+                } else if let Some((_, Some(ast::Expr::Lit(ast::Lit::Int(li))))) =
+                    params.get(&id.name)
+                {
+                    guards.push((word_hi, word_lo, parse_literal_value(li) as u128));
+                }
+            }
+            ast::Expr::Slice(s) => {
+                if let ast::Expr::Ident(id) = &*s.base
+                    && operands.contains_key(&id.name)
+                {
+                    pieces
+                        .entry(id.name.clone())
+                        .or_default()
+                        .push((s.start, s.end, word_lo, word_hi));
+                }
+            }
+            ast::Expr::IndexAccess(s) => {
+                if let ast::Expr::Ident(id) = &*s.base
+                    && operands.contains_key(&id.name)
+                {
+                    pieces
+                        .entry(id.name.clone())
+                        .or_default()
+                        .push((s.index, s.index, word_lo, word_hi));
+                }
+            }
+            _ => {}
+        }
+    }
+    (guards, pieces)
+}
+
+/// Reconstruct one operand from its word pieces, zero-filling gaps, then fit to
+/// `target_width`.
+fn decode_operand(
+    b: &mut Btor2,
+    insn: Bv,
+    mut pieces: Vec<(u16, u16, u16, u16)>,
+    target_width: u16,
+) -> Bv {
+    if pieces.is_empty() {
+        return b.konst(target_width as u32, 0);
+    }
+    pieces.sort_by_key(|p| std::cmp::Reverse(p.1));
+    let mut acc: Option<Bv> = None;
+    let push = |b: &mut Btor2, acc: &mut Option<Bv>, frag: Bv| {
+        *acc = Some(match acc.take() {
+            Some(a) => b.concat(a, frag),
+            None => frag,
+        });
+    };
+
+    let mut expected_hi = pieces[0].1;
+    for (op_lo, op_hi, word_lo, word_hi) in &pieces {
+        if *op_hi < expected_hi {
+            let gap = b.konst((expected_hi - op_hi) as u32, 0);
+            push(b, &mut acc, gap);
+        }
+        let frag = b.slice(insn, *word_hi as u32, *word_lo as u32);
+        push(b, &mut acc, frag);
+        expected_hi = op_lo.saturating_sub(1);
+    }
+    let lowest = pieces.last().map(|p| p.0).unwrap_or(0);
+    if lowest > 0 {
+        let pad = b.konst(lowest as u32, 0);
+        push(b, &mut acc, pad);
+    }
+    let raw = acc.unwrap();
+    b.fit(raw, target_width as u32)
+}
+
+fn build_guard(b: &mut Btor2, insn: Bv, guards: &[(u16, u16, u128)]) -> Bv {
+    let mut acc: Option<Bv> = None;
+    for (hi, lo, val) in guards {
+        let field = b.slice(insn, *hi as u32, *lo as u32);
+        let k = b.konst(field.width, *val as u64);
+        let eq = b.cmp("eq", field, k);
+        acc = Some(match acc {
+            Some(a) => b.bin("and", a, eq, false),
+            None => eq,
+        });
+    }
+    acc.unwrap_or_else(|| b.konst(1, 1))
+}
+
+// ---------------------------------------------------------------------------
+// Top-level emission
+// ---------------------------------------------------------------------------
+
+fn resolved_operands(
+    ctx: &Ctx<'_>,
+    inst: &ast::Instruction,
+    item_cache: &HashMap<&str, &ast::Item>,
+) -> Vec<(String, Type)> {
+    let mut params = resolve_isa_param_values(inst, item_cache);
+    params.extend(ctx.isa_params.iter().map(|(k, v)| (k.clone(), *v)));
+    resolve_operand_widths(resolve_operands_for_instruction(inst, item_cache), &params)
+}
+
+pub fn generate_btor2<'a>(
+    isa: &str,
+    files: &'a [ast::File],
+    item_cache: &HashMap<&'a str, &'a ast::Item>,
+    mut output: Box<dyn Write>,
+) -> Result<(), TMDLError> {
+    let isa_params = isa_param_values(isa, item_cache);
+    let xlen = isa_params.get("XLEN").copied().unwrap_or(64) as u16;
+
+    let mut classes = BTreeMap::new();
+    let mut pc_classes = std::collections::HashSet::new();
+    for rc in files.iter().flat_map(|f| f.register_classes()) {
+        if !item_supports_isa(&rc.for_isas, isa, item_cache) {
+            continue;
+        }
+        let name = rc.name.to_lowercase();
+        if is_pc_class(rc) {
+            pc_classes.insert(name);
+            continue;
+        }
+        classes.insert(
+            name,
+            ClassInfo {
+                idx_width: eval_class_param(rc, "ENCODING_LEN", &isa_params).unwrap_or(5) as u16,
+                val_width: eval_class_param(rc, "WIDTH", &isa_params).unwrap_or(xlen as i64) as u16,
+                zero_index: rc.hardwired_zero_register_index(),
+            },
+        );
+    }
+    let ctx = Ctx {
+        isa,
+        xlen,
+        classes,
+        pc_classes,
+        isa_params,
+    };
+
+    let register_index_map: HashMap<(String, String), u32> = files
+        .iter()
+        .flat_map(|f| f.register_classes())
+        .flat_map(|rc| {
+            let class = rc.name.clone();
+            rc.register_indices()
+                .into_iter()
+                .map(move |(name, idx)| ((class.clone(), name), u32::from(idx)))
+        })
+        .collect();
+
+    let mut b = Btor2::new();
+    b.out.push_str("; TMDL RVFI-style instruction checker\n");
+    let x = xlen as u32;
+    // The retirement `rd_addr` indexes the integer register file (the class
+    // with a hardwired-zero slot, RISC-V `x0`); CSR/PC classes are out of scope.
+    let idx_w = ctx
+        .classes
+        .values()
+        .find(|c| c.zero_index.is_some())
+        .or_else(|| ctx.classes.values().next())
+        .map_or(5, |c| c.idx_width as u32);
+
+    // Retirement interface inputs.
+    let insn = b.input(32, "insn");
+    let pc = b.input(x, "pc");
+    let rs1_val = b.input(x, "rs1_val");
+    let rs2_val = b.input(x, "rs2_val");
+    let rd_addr_impl = b.input(idx_w, "rd_addr");
+    let rd_we_impl = b.input(1, "rd_we");
+    let rd_val_impl = b.input(x, "rd_val");
+    let next_pc_impl = b.input(x, "next_pc");
+    let valid = b.input(1, "valid");
+
+    let four = b.konst(x, 4);
+    let pc_plus4 = b.bin("add", pc, four, false);
+
+    let mut specs: Vec<(Bv, PostState)> = Vec::new();
+    for inst in files.iter().flat_map(|f| f.instructions()) {
+        if !item_supports_isa(&inst.for_isas, ctx.isa, item_cache) {
+            continue;
+        }
+        let behavior = &inst.behavior;
+        let operand_list = resolved_operands(&ctx, inst, item_cache);
+        let operands: HashMap<String, Type> = operand_list.iter().cloned().collect();
+        let (guards, pieces) = decode_layout(inst, item_cache, &operands);
+
+        // Decode the values the behavior consumes: source registers come from
+        // retirement inputs, immediates from the word; destination indices are
+        // decoded for the `rd_addr` check.
+        let mut operand_vals = HashMap::new();
+        let mut operand_addrs = HashMap::new();
+        for (name, ty) in &operand_list {
+            let lname = name.to_lowercase();
+            match ty {
+                Type::Struct(rc) if ctx.pc_classes.contains(&rc.to_lowercase()) => {}
+                Type::Struct(rc) => {
+                    let addr = decode_operand(
+                        &mut b,
+                        insn,
+                        pieces.get(name).cloned().unwrap_or_default(),
+                        ctx.idx_width(rc),
+                    );
+                    operand_addrs.insert(lname.clone(), (addr, rc.clone()));
+                    operand_vals.insert(
+                        lname,
+                        match name.as_str() {
+                            "rs1" => rs1_val,
+                            "rs2" => rs2_val,
+                            _ => continue,
+                        },
+                    );
+                }
+                Type::Bits(n) => {
+                    let v = decode_operand(
+                        &mut b,
+                        insn,
+                        pieces.get(name).cloned().unwrap_or_default(),
+                        *n,
+                    );
+                    operand_vals.insert(lname, v);
+                }
+                _ => {}
+            }
+        }
+
+        let guard = build_guard(&mut b, insn, &guards);
+
+        let init = PostState {
+            rd_we: b.konst(1, 0),
+            rd_val: b.konst(x, 0),
+            rd_addr: b.konst(idx_w, 0),
+            next_pc: pc_plus4,
+        };
+
+        let checker = Checker {
+            ctx: &ctx,
+            operands,
+            operand_vals,
+            operand_addrs,
+            numeric_params: ctx.isa_params.clone(),
+            register_index_map: &register_index_map,
+            pc,
+            b: RefCell::new(&mut b),
+            states: RefCell::new(HashMap::new()),
+            counter: Cell::new(0),
+            failed: Cell::new(false),
+        };
+        let init_handle = checker.fresh(init);
+        let final_handle = sem_expr_state::compile_to_state(behavior, &init_handle, &checker);
+        if checker.failed.get() {
+            continue;
+        }
+        let post = checker.get(&final_handle);
+        drop(checker);
+        // rd_addr is decoded at idx_width; the retirement input may be wider.
+        let post = PostState {
+            rd_addr: b.fit(post.rd_addr, idx_w),
+            ..post
+        };
+        specs.push((guard, post));
+    }
+
+    // Fold per-instruction specs into one selected post-state; unmatched words
+    // default to a fall-through with no register write.
+    let no_we = b.konst(1, 0);
+    let zero_val = b.konst(x, 0);
+    let zero_addr = b.konst(idx_w, 0);
+    let mut legal = b.konst(1, 0);
+    let mut spec = PostState {
+        rd_we: no_we,
+        rd_val: zero_val,
+        rd_addr: zero_addr,
+        next_pc: pc_plus4,
+    };
+    for (guard, post) in specs.iter().rev() {
+        spec = PostState {
+            rd_we: b.ite(*guard, post.rd_we, spec.rd_we, false),
+            rd_val: b.ite(*guard, post.rd_val, spec.rd_val, false),
+            rd_addr: b.ite(*guard, post.rd_addr, spec.rd_addr, false),
+            next_pc: b.ite(*guard, post.next_pc, spec.next_pc, false),
+        };
+        legal = b.bin("or", legal, *guard, false);
+    }
+
+    // Mismatch: the implementation's report diverges from the spec.
+    let we_bad = b.cmp("neq", rd_we_impl, spec.rd_we);
+    let val_ne = b.cmp("neq", rd_val_impl, spec.rd_val);
+    let val_bad = b.bin("and", spec.rd_we, val_ne, false);
+    let addr_ne = b.cmp("neq", rd_addr_impl, spec.rd_addr);
+    let addr_bad = b.bin("and", spec.rd_we, addr_ne, false);
+    let pc_bad = b.cmp("neq", next_pc_impl, spec.next_pc);
+    let any1 = b.bin("or", we_bad, val_bad, false);
+    let any2 = b.bin("or", addr_bad, pc_bad, false);
+    let any = b.bin("or", any1, any2, false);
+    let gated = b.bin("and", valid, legal, false);
+    let bad = b.bin("and", gated, any, false);
+    b.line(&format!("bad {}", bad.nid));
+
+    output.write_all(b.out.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn emit(source: &str, isa: &str) -> String {
+        let (tokens, errs) = crate::lex(source);
+        assert!(errs.is_empty(), "lex errors");
+        let (file, errs) = crate::parse(source, &tokens, "test");
+        assert!(errs.is_empty(), "parse errors");
+        let mut files = vec![file.unwrap()];
+        crate::ast::resolve_register_class_inheritance(&mut files);
+        assert!(crate::sema_analyze(&files).is_empty(), "sema errors");
+        assert!(crate::type_check(&files).1.is_empty(), "typeck errors");
+        let item_cache: HashMap<&str, &ast::Item> = files
+            .iter()
+            .flat_map(|f| f.items.iter().map(|i| (i.name(), i)))
+            .collect();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("tmdl_btor2_{nanos}.btor2"));
+        generate_btor2(
+            isa,
+            &files,
+            &item_cache,
+            Box::new(std::fs::File::create(&path).unwrap()),
+        )
+        .unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        out
+    }
+
+    /// Every operand reference must point at an already-defined node, ids must
+    /// be sequential, and the model must end in exactly one `bad` property —
+    /// the invariants a BTOR2 consumer relies on.
+    fn assert_valid(model: &str) {
+        let mut defined = std::collections::HashSet::new();
+        let mut sorts = std::collections::HashSet::new();
+        let mut expect = 1u32;
+        let mut bads = 0;
+        for line in model.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with(';') {
+                continue;
+            }
+            let p: Vec<&str> = line.split_whitespace().collect();
+            let nid: u32 = p[0].parse().unwrap();
+            assert_eq!(nid, expect, "non-sequential id at: {line}");
+            expect += 1;
+            let op = p[1];
+            // Node-id operand positions per opcode; sorts and immediates excluded.
+            let refs: &[usize] = match op {
+                "sort" => {
+                    sorts.insert(nid);
+                    &[]
+                }
+                "input" | "constd" | "const" | "one" | "zero" | "ones" => &[],
+                "bad" => {
+                    bads += 1;
+                    &[2]
+                }
+                "slice" | "sext" | "uext" | "not" => &[3],
+                "ite" => &[3, 4, 5],
+                _ => &[3, 4],
+            };
+            if op != "sort" && op != "bad" {
+                assert!(
+                    sorts.contains(&p[2].parse().unwrap()),
+                    "sort ref at: {line}"
+                );
+            }
+            for &i in refs {
+                let r: u32 = p[i].parse().unwrap();
+                assert!(defined.contains(&r), "undefined ref {r} at: {line}");
+            }
+            defined.insert(nid);
+        }
+        assert_eq!(bads, 1, "exactly one bad property expected");
+    }
+
+    const SPEC: &str = include_str!("../checks/Inputs/smtlib.tmdl");
+
+    #[test]
+    fn checker_is_structurally_valid() {
+        assert_valid(&emit(SPEC, "TestIsa"));
+    }
+
+    #[test]
+    fn exposes_retirement_interface_and_property() {
+        let m = emit(SPEC, "TestIsa");
+        for name in [
+            "insn", "pc", "rs1_val", "rs2_val", "rd_addr", "rd_we", "rd_val", "next_pc", "valid",
+        ] {
+            assert!(
+                m.lines()
+                    .any(|l| l.contains(" input ") && l.ends_with(&format!(" {name}"))),
+                "missing retirement input `{name}`"
+            );
+        }
+        assert!(
+            m.lines().any(|l| l.contains(" bad ")),
+            "missing bad property"
+        );
+    }
+}

--- a/tmdl/src/compiler.rs
+++ b/tmdl/src/compiler.rs
@@ -9,6 +9,7 @@ use chumsky::error::{Cheap, Rich};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, ValueEnum};
 
 use crate::Span;
+use crate::btor2gen::generate_btor2;
 use crate::error::TMDLError;
 use crate::lexer::lex;
 use crate::parser::parse;
@@ -46,11 +47,15 @@ pub enum Action {
     EmitAstJson,
     EmitRust,
     EmitSmtlib,
+    EmitBtor2,
 }
 
 impl Action {
     fn needs_whole_program(&self) -> bool {
-        matches!(self, Action::EmitRust | Action::EmitSmtlib)
+        matches!(
+            self,
+            Action::EmitRust | Action::EmitSmtlib | Action::EmitBtor2
+        )
     }
 }
 
@@ -186,11 +191,11 @@ impl Compiler {
             )
             .exit();
         }
-        if matches!(self.action, Action::EmitSmtlib) && self.isa.is_none() {
+        if matches!(self.action, Action::EmitSmtlib | Action::EmitBtor2) && self.isa.is_none() {
             let mut cmd = Cli::command();
             cmd.error(
                 clap::error::ErrorKind::ArgumentConflict,
-                "--isa must be specified with --action=emit-smtlib",
+                "--isa must be specified with --action=emit-smtlib or --action=emit-btor2",
             )
             .exit();
         }
@@ -268,6 +273,15 @@ impl Compiler {
                 let writer: Box<dyn Write> = self.create_output_writer()?;
                 generate_smtlib(
                     self.dialect.as_ref().unwrap(),
+                    self.isa.as_ref().unwrap(),
+                    &parsed_files,
+                    &item_cache,
+                    writer,
+                )?;
+            }
+            Action::EmitBtor2 => {
+                let writer: Box<dyn Write> = self.create_output_writer()?;
+                generate_btor2(
                     self.isa.as_ref().unwrap(),
                     &parsed_files,
                     &item_cache,

--- a/tmdl/src/lib.rs
+++ b/tmdl/src/lib.rs
@@ -1,4 +1,5 @@
 mod ast;
+mod btor2gen;
 mod compiler;
 mod error;
 mod lexer;

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1468,62 +1468,84 @@ fn build_decoder<'a>(
             }
         }
 
+        // Build the constructor arguments in operand declaration order. When an
+        // operand's encoding field is wider than the operand (e.g. the RV32
+        // shift-immediate `shamt` sits in a 6-bit field but is 5 bits), the
+        // encoder zero-fills the spare high bits, so a faithful decoder must
+        // require them zero — otherwise it accepts the reserved encodings the
+        // hardware rejects.
+        let mut constructor_args: Vec<String> = Vec::with_capacity(operand_list.len());
+        for (op_name, op_ty) in &operand_list {
+            // Immediates are reconstructed at XLEN, but the reserved-zero check
+            // is against the operand's *declared* width (e.g. a 5-bit RV32
+            // `shamt`), so an over-wide field is rejected even though the value
+            // is later XLEN-extended.
+            let target_width = match op_ty {
+                Type::Struct(rc) => ctx.idx_width(rc),
+                _ => ctx.xlen,
+            };
+            let declared_width = match op_ty {
+                Type::Struct(rc) => ctx.idx_width(rc),
+                Type::Bits(n) => *n,
+                _ => ctx.xlen,
+            };
+
+            let Some(mut pieces) = operand_pieces.remove(op_name) else {
+                constructor_args.push(zero_bv(target_width));
+                continue;
+            };
+
+            // Sort pieces by op_hi descending so the concat builds high→low.
+            pieces.sort_by_key(|piece| std::cmp::Reverse(piece.1));
+
+            // Reconstruct the operand from its pieces, filling any gaps
+            // between non-contiguous slices with zero bits.
+            // `expected_hi` tracks the next op bit we expect; it starts at
+            // the top bit of the highest piece and steps downward.
+            let mut fragments: Vec<String> = vec![];
+            let mut raw_width: u16 = 0;
+            let mut expected_hi = pieces[0].1;
+
+            for (op_lo, op_hi, word_lo, word_hi) in &pieces {
+                // Fill any gap between the previous piece and this one.
+                if *op_hi < expected_hi {
+                    let gap = expected_hi - op_hi; // bits [expected_hi..op_hi+1]
+                    fragments.push(zero_bv(gap));
+                    raw_width += gap;
+                }
+                fragments.push(format!("((_ extract {} {}) word)", word_hi, word_lo));
+                raw_width += op_hi - op_lo + 1;
+                expected_hi = op_lo.saturating_sub(1);
+            }
+            // Fill any gap below the lowest piece (bits [op_lo-1..0]).
+            let lowest_op_lo = pieces.last().map(|(lo, _, _, _)| *lo).unwrap_or(0);
+            if lowest_op_lo > 0 {
+                fragments.push(zero_bv(lowest_op_lo));
+                raw_width += lowest_op_lo;
+            }
+
+            let raw = fragments
+                .into_iter()
+                .reduce(|acc, f| format!("(concat {} {})", acc, f))
+                .unwrap_or_else(|| zero_bv(target_width));
+
+            if raw_width > declared_width {
+                guards.push(format!(
+                    "(= ((_ extract {} {}) {}) (_ bv0 {}))",
+                    raw_width - 1,
+                    declared_width,
+                    raw,
+                    raw_width - declared_width
+                ));
+            }
+            constructor_args.push(cast_bv_smt(&raw, raw_width, target_width));
+        }
+
         let guard = match guards.len() {
             0 => "true".to_string(),
             1 => guards.remove(0),
             _ => format!("(and {})", guards.join(" ")),
         };
-
-        // Build the constructor arguments in operand declaration order.
-        let constructor_args: Vec<String> = operand_list
-            .iter()
-            .map(|(op_name, op_ty)| {
-                let target_width = match op_ty {
-                    Type::Struct(rc) => ctx.idx_width(rc),
-                    _ => ctx.xlen,
-                };
-
-                let Some(mut pieces) = operand_pieces.remove(op_name) else {
-                    return zero_bv(target_width);
-                };
-
-                // Sort pieces by op_hi descending so the concat builds high→low.
-                pieces.sort_by_key(|piece| std::cmp::Reverse(piece.1));
-
-                // Reconstruct the operand from its pieces, filling any gaps
-                // between non-contiguous slices with zero bits.
-                // `expected_hi` tracks the next op bit we expect; it starts at
-                // the top bit of the highest piece and steps downward.
-                let mut fragments: Vec<String> = vec![];
-                let mut raw_width: u16 = 0;
-                let mut expected_hi = pieces[0].1;
-
-                for (op_lo, op_hi, word_lo, word_hi) in &pieces {
-                    // Fill any gap between the previous piece and this one.
-                    if *op_hi < expected_hi {
-                        let gap = expected_hi - op_hi; // bits [expected_hi..op_hi+1]
-                        fragments.push(zero_bv(gap));
-                        raw_width += gap;
-                    }
-                    fragments.push(format!("((_ extract {} {}) word)", word_hi, word_lo));
-                    raw_width += op_hi - op_lo + 1;
-                    expected_hi = op_lo.saturating_sub(1);
-                }
-                // Fill any gap below the lowest piece (bits [op_lo-1..0]).
-                let lowest_op_lo = pieces.last().map(|(lo, _, _, _)| *lo).unwrap_or(0);
-                if lowest_op_lo > 0 {
-                    fragments.push(zero_bv(lowest_op_lo));
-                    raw_width += lowest_op_lo;
-                }
-
-                let raw = fragments
-                    .into_iter()
-                    .reduce(|acc, f| format!("(concat {} {})", acc, f))
-                    .unwrap_or_else(|| zero_bv(target_width));
-
-                cast_bv_smt(&raw, raw_width, target_width)
-            })
-            .collect();
 
         let constructor = if constructor_args.is_empty() {
             name_upper.clone()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,5 @@
 pub mod utils;
+mod verify_btor2;
 mod verify_smt;
 
 use std::{env, path::PathBuf};
@@ -20,6 +21,14 @@ fn main() -> anyhow::Result<()> {
             let isa = env::args().nth(2);
             match isa.as_deref() {
                 Some(isa) => verify_smt::verify_smt(&sh, isa)?,
+                _ => print_help(),
+            }
+        }
+        Some("verify-btor2") => {
+            let isa = env::args().nth(2);
+            let impl_btor2 = env::args().nth(3);
+            match (isa.as_deref(), impl_btor2.as_deref()) {
+                (Some(isa), Some(path)) => verify_btor2::run(&sh, isa, std::path::Path::new(path))?,
                 _ => print_help(),
             }
         }

--- a/xtask/src/verify_btor2.rs
+++ b/xtask/src/verify_btor2.rs
@@ -1,0 +1,264 @@
+//! `cargo xtask verify-btor2 <isa>` — model-check a Chisel/RTL implementation
+//! against the TMDL golden model.
+//!
+//! The flow has three parts:
+//!   1. `tmdlc --emit-btor2` builds the per-instruction reference checker (see
+//!      `tmdl/src/btor2gen.rs`).
+//!   2. The implementation is lowered to BTOR2 out-of-band (firtool + Yosys);
+//!      its formal top must expose the retirement signals as outputs named
+//!      exactly as in [`RVFI_SIGNALS`].
+//!   3. [`stitch`] composes the two into one miter: the checker's retirement
+//!      inputs are rewired to the implementation's like-named outputs, and the
+//!      checker's `bad` becomes the miter's property. A BMC engine (btormc /
+//!      Bitwuzla) then searches for a divergence.
+//!
+//! Stitching is kept pure and unit-tested here; the external tool invocations
+//! are documented in `docs/tmdl/btor2_model_checking.md`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use xshell::{cmd, Shell};
+
+/// Resolve the ISA to its TMDL name and definitions, then drive the flow.
+/// `impl_btor2` is the implementation lowered to BTOR2 out-of-band (firtool +
+/// Yosys); see `docs/tmdl/btor2_model_checking.md`.
+pub fn run(sh: &Shell, isa: &str, impl_btor2: &Path) -> Result<()> {
+    let (tmdl_isa, defs_dir) = match isa {
+        "riscv32" => ("RV32I", "backends/riscv/defs"),
+        "riscv64" => ("RV64I", "backends/riscv/defs"),
+        _ => bail!("unsupported isa `{isa}`; use riscv32 or riscv64"),
+    };
+    let mut defs: Vec<PathBuf> = std::fs::read_dir(defs_dir)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "tmdl"))
+        .collect();
+    defs.sort();
+    let defs_ref: Vec<&Path> = defs.iter().map(PathBuf::as_path).collect();
+    verify_btor2(sh, isa, tmdl_isa, &defs_ref, impl_btor2)
+}
+
+/// Retirement interface the implementation's BTOR2 must expose as outputs and
+/// the checker consumes as inputs. Order is irrelevant; names must match.
+pub const RVFI_SIGNALS: [&str; 9] = [
+    "insn", "pc", "rs1_val", "rs2_val", "rd_addr", "rd_we", "rd_val", "next_pc", "valid",
+];
+
+/// Node-reference token positions for the BTOR2 opcodes the checker emits.
+/// Position 0 is the node id (always renumbered); a `Some(())` sort flag marks
+/// opcodes carrying a sort id at position 2. Remaining entries are operand
+/// node positions. Literal fields (slice bounds, extend amounts, constants,
+/// names) are left untouched.
+fn ref_positions(op: &str) -> (bool, &'static [usize]) {
+    match op {
+        "sort" => (false, &[]),
+        "input" | "constd" | "const" | "one" | "zero" | "ones" => (true, &[]),
+        "bad" => (false, &[2]),
+        "not" | "sext" | "uext" | "slice" => (true, &[3]),
+        "ite" => (true, &[3, 4, 5]),
+        // binops, comparisons, concat
+        _ => (true, &[3, 4]),
+    }
+}
+
+/// Merge an implementation BTOR2 and the TMDL checker BTOR2 into one miter.
+///
+/// The implementation lines are emitted verbatim; the checker is appended with
+/// every node id shifted past the implementation's, except its retirement
+/// inputs, whose references are redirected to the implementation outputs of the
+/// same name.
+pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<String> {
+    let mut max_id = 0u32;
+    let mut name_to_node: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
+    for line in non_blank(implementation) {
+        let t: Vec<&str> = line.split_whitespace().collect();
+        let id: u32 = t[0]
+            .parse()
+            .with_context(|| format!("implementation: bad node id in `{line}`"))?;
+        max_id = max_id.max(id);
+        // `<id> output <node> <name>`: record the driver node for each name.
+        if t.get(1) == Some(&"output") && t.len() >= 4 {
+            let node: u32 = t[2].parse()?;
+            name_to_node.insert(t[3], node);
+        }
+    }
+
+    // Resolve each retirement signal to its implementation node up front so a
+    // missing one is a clear contract error, not a dangling reference.
+    let offset = max_id;
+    let mut wired: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+    let mut checker_inputs: std::collections::HashMap<u32, &str> = std::collections::HashMap::new();
+    for line in non_blank(checker) {
+        let t: Vec<&str> = line.split_whitespace().collect();
+        if t.get(1) == Some(&"input") && t.len() >= 4 {
+            checker_inputs.insert(t[0].parse()?, t[3]);
+        }
+    }
+    for &sig in signals {
+        let input_id = checker_inputs
+            .iter()
+            .find(|(_, n)| **n == sig)
+            .map(|(id, _)| *id)
+            .ok_or_else(|| anyhow!("checker has no retirement input `{sig}`"))?;
+        let impl_node = *name_to_node
+            .get(sig)
+            .ok_or_else(|| anyhow!("implementation exposes no output named `{sig}`"))?;
+        wired.insert(input_id, impl_node);
+    }
+    let wired_names: std::collections::HashSet<&str> = signals.iter().copied().collect();
+
+    let remap = |orig: u32| -> u32 { *wired.get(&orig).unwrap_or(&(orig + offset)) };
+
+    let mut out = String::new();
+    out.push_str(implementation.trim_end());
+    out.push_str("\n; --- TMDL checker (stitched) ---\n");
+    for line in non_blank(checker) {
+        let mut t: Vec<String> = line.split_whitespace().map(String::from).collect();
+        // Drop the rewired retirement inputs; their uses point at the
+        // implementation instead.
+        if t.get(1).map(String::as_str) == Some("input")
+            && t.len() >= 4
+            && wired_names.contains(t[3].as_str())
+        {
+            continue;
+        }
+        let (has_sort, positions) = ref_positions(&t[1]);
+        t[0] = remap(t[0].parse()?).to_string();
+        if has_sort {
+            t[2] = remap(t[2].parse()?).to_string();
+        }
+        for &p in positions {
+            if p < t.len() {
+                t[p] = remap(t[p].parse()?).to_string();
+            }
+        }
+        out.push_str(&t.join(" "));
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+fn non_blank(s: &str) -> impl Iterator<Item = &str> {
+    s.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with(';'))
+}
+
+/// Driver: emit the checker, stitch against a pre-built implementation BTOR2,
+/// and run btormc when available.
+pub fn verify_btor2(
+    sh: &Shell,
+    isa: &str,
+    tmdl_isa: &str,
+    defs: &[&Path],
+    impl_btor2: &Path,
+) -> Result<()> {
+    let out_dir = Path::new("target/verify/btor2");
+    sh.create_dir(out_dir)?;
+    let checker_path = out_dir.join("checker.btor2");
+    let checker_str = checker_path.to_string_lossy().to_string();
+    let defs: Vec<String> = defs
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    cmd!(
+        sh,
+        "cargo run -q -p tmdl --bin tmdlc -- --action=emit-btor2 --isa={tmdl_isa} --output={checker_str} {defs...}"
+    )
+    .run()
+    .context("emitting TMDL checker btor2")?;
+
+    let implementation = sh.read_file(impl_btor2)?;
+    let checker = sh.read_file(&checker_path)?;
+    let miter = stitch(&implementation, &checker, &RVFI_SIGNALS)?;
+    let miter_path = out_dir.join("miter.btor2");
+    sh.write_file(&miter_path, &miter)?;
+    println!("wrote miter: {} ({isa})", miter_path.display());
+
+    if which("btormc") {
+        let miter_str = miter_path.to_string_lossy().to_string();
+        let output = cmd!(sh, "btormc {miter_str}").read()?;
+        if output.lines().next().map(str::trim) == Some("sat") {
+            println!("SAT: implementation diverges from the TMDL model\n{output}");
+            bail!("model checking found a counterexample");
+        }
+        println!("UNSAT up to bound: no divergence found\n{output}");
+    } else {
+        println!("btormc not found; run it on the miter to search for bugs");
+    }
+    Ok(())
+}
+
+fn which(bin: &str) -> bool {
+    std::process::Command::new(bin)
+        .arg("--help")
+        .output()
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Implementation exposing two retirement signals as outputs.
+    const IMPL: &str = "\
+1 sort bitvec 8
+2 input 1 clk
+3 state 1 reg
+4 output 3 x
+5 input 1 raw
+6 output 5 y
+";
+
+    // Checker reading x and y, asserting they differ.
+    const CHECKER: &str = "\
+1 sort bitvec 8
+2 input 1 x
+3 input 1 y
+4 neq 1 2 3
+5 bad 4
+";
+
+    #[test]
+    fn wires_signals_by_name_and_shifts_ids() {
+        let m = stitch(IMPL, CHECKER, &["x", "y"]).unwrap();
+        // Implementation kept verbatim.
+        assert!(m.contains("3 state 1 reg"));
+        // Checker offset by max impl id (6): its sort 1 -> 7, neq 4 -> 10, bad -> 11.
+        // The neq operands are rewired to impl nodes 3 (x) and 5 (y).
+        assert!(m.contains("10 neq 7 3 5"), "neq not rewired: {m}");
+        assert!(m.contains("11 bad 10"), "bad not shifted: {m}");
+        // The checker's own input lines are dropped.
+        assert!(!m.contains("input 7 x"));
+    }
+
+    #[test]
+    fn errors_when_signal_missing_from_impl() {
+        let err = stitch(IMPL, CHECKER, &["x", "z"]).unwrap_err();
+        assert!(err.to_string().contains("`z`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn merged_graph_is_valid() {
+        let m = stitch(IMPL, CHECKER, &["x", "y"]).unwrap();
+        let mut defined = std::collections::HashSet::new();
+        for line in super::non_blank(&m) {
+            let t: Vec<&str> = line.split_whitespace().collect();
+            let id: u32 = t[0].parse().unwrap();
+            let (has_sort, refs) = match t[1] {
+                "output" => (false, &[2usize][..]),
+                "next" => (true, &[3, 4][..]),
+                "bad" => (false, &[2][..]),
+                "state" | "input" | "sort" => (false, &[][..]),
+                "neq" => (true, &[2, 3][..]),
+                _ => (false, &[][..]),
+            };
+            let _ = has_sort;
+            for &p in refs {
+                let r: u32 = t[p].parse().unwrap();
+                assert!(defined.contains(&r), "dangling ref {r} in `{line}`");
+            }
+            defined.insert(id);
+        }
+    }
+}

--- a/xtask/src/verify_btor2.rs
+++ b/xtask/src/verify_btor2.rs
@@ -70,6 +70,7 @@ fn ref_positions(op: &str) -> (bool, &'static [usize]) {
 pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<String> {
     let mut max_id = 0u32;
     let mut name_to_node: std::collections::HashMap<&str, u32> = std::collections::HashMap::new();
+    let mut reset_node: Option<u32> = None;
     for line in non_blank(implementation) {
         let t: Vec<&str> = line.split_whitespace().collect();
         let id: u32 = t[0]
@@ -80,6 +81,9 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
         if t.get(1) == Some(&"output") && t.len() >= 4 {
             let node: u32 = t[2].parse()?;
             name_to_node.insert(t[3], node);
+        }
+        if t.get(1) == Some(&"input") && t.get(3) == Some(&"reset") {
+            reset_node = Some(id);
         }
     }
 
@@ -112,14 +116,22 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
     let mut out = String::new();
     out.push_str(implementation.trim_end());
     out.push_str("\n; --- TMDL checker (stitched) ---\n");
+    let mut last = offset;
+    let mut bad_operand: Option<u32> = None;
     for line in non_blank(checker) {
         let mut t: Vec<String> = line.split_whitespace().map(String::from).collect();
+        last = last.max(remap(t[0].parse()?));
         // Drop the rewired retirement inputs; their uses point at the
         // implementation instead.
         if t.get(1).map(String::as_str) == Some("input")
             && t.len() >= 4
             && wired_names.contains(t[3].as_str())
         {
+            continue;
+        }
+        // Hold the property aside so it can be gated on the reset pulse below.
+        if t[1] == "bad" {
+            bad_operand = Some(remap(t[2].parse()?));
             continue;
         }
         let (has_sort, positions) = ref_positions(&t[1]);
@@ -135,7 +147,40 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
         out.push_str(&t.join(" "));
         out.push('\n');
     }
+
+    let bad = bad_operand.ok_or_else(|| anyhow!("checker has no `bad` property"))?;
+    emit_property(&mut out, last, bad, reset_node);
     Ok(out)
+}
+
+/// Emit the miter property. When the implementation has a `reset` input, drive
+/// a one-cycle reset pulse and gate the mismatch until reset has deasserted, so
+/// uninitialized pipeline state at step 0 cannot raise a spurious counterexample.
+fn emit_property(out: &mut String, last: u32, bad: u32, reset_node: Option<u32>) {
+    out.push_str("; --- reset-gated property ---\n");
+    let mut nid = last;
+    let mut node = |body: String| -> u32 {
+        nid += 1;
+        out.push_str(&format!("{nid} {body}\n"));
+        nid
+    };
+    let Some(reset) = reset_node else {
+        node(format!("bad {bad}"));
+        return;
+    };
+    let s1 = node("sort bitvec 1".into());
+    let one = node(format!("one {s1}"));
+    let zero = node(format!("zero {s1}"));
+    // `started` is 0 at step 0 and 1 thereafter.
+    let started = node(format!("state {s1} started"));
+    node(format!("init {s1} {started} {zero}"));
+    node(format!("next {s1} {started} {one}"));
+    // Force a one-cycle reset pulse: reset high at step 0, low afterwards.
+    let not_started = node(format!("not {s1} {started}"));
+    let reset_ok = node(format!("eq {s1} {reset} {not_started}"));
+    node(format!("constraint {reset_ok}"));
+    let gated = node(format!("and {s1} {bad} {started}"));
+    node(format!("bad {gated}"));
 }
 
 fn non_blank(s: &str) -> impl Iterator<Item = &str> {
@@ -224,12 +269,35 @@ mod tests {
         let m = stitch(IMPL, CHECKER, &["x", "y"]).unwrap();
         // Implementation kept verbatim.
         assert!(m.contains("3 state 1 reg"));
-        // Checker offset by max impl id (6): its sort 1 -> 7, neq 4 -> 10, bad -> 11.
+        // Checker offset by max impl id (6): its sort 1 -> 7, neq 4 -> 10.
         // The neq operands are rewired to impl nodes 3 (x) and 5 (y).
         assert!(m.contains("10 neq 7 3 5"), "neq not rewired: {m}");
-        assert!(m.contains("11 bad 10"), "bad not shifted: {m}");
+        // IMPL has no `reset` input, so the property is emitted ungated.
+        assert!(m.contains("bad 10"), "bad not preserved: {m}");
         // The checker's own input lines are dropped.
         assert!(!m.contains("input 7 x"));
+    }
+
+    #[test]
+    fn reset_gates_property_when_reset_present() {
+        let impl_with_reset = format!("{IMPL}7 input 1 reset\n");
+        let m = stitch(&impl_with_reset, CHECKER, &["x", "y"]).unwrap();
+        // A started-state machine, a reset constraint, and a gated bad appear.
+        assert!(
+            m.lines().any(|l| l.ends_with(" started")),
+            "no started state: {m}"
+        );
+        assert!(
+            m.lines().any(|l| l.contains(" constraint ")),
+            "no reset constraint: {m}"
+        );
+        // The final bad references an `and` node (mismatch gated by started).
+        let bad_line = m.lines().rev().find(|l| l.contains(" bad ")).unwrap();
+        let gated = bad_line.split_whitespace().last().unwrap();
+        assert!(
+            m.lines().any(|l| l.starts_with(&format!("{gated} and "))),
+            "bad not gated: {m}"
+        );
     }
 
     #[test]

--- a/xtask/src/verify_btor2.rs
+++ b/xtask/src/verify_btor2.rs
@@ -53,7 +53,8 @@ fn ref_positions(op: &str) -> (bool, &'static [usize]) {
     match op {
         "sort" => (false, &[]),
         "input" | "constd" | "const" | "one" | "zero" | "ones" => (true, &[]),
-        "bad" => (false, &[2]),
+        // `output <node> <name>` carries no sort; the node is at position 2.
+        "output" | "bad" => (false, &[2]),
         "not" | "sext" | "uext" | "slice" => (true, &[3]),
         "ite" => (true, &[3, 4, 5]),
         // binops, comparisons, concat
@@ -117,7 +118,7 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
     out.push_str(implementation.trim_end());
     out.push_str("\n; --- TMDL checker (stitched) ---\n");
     let mut last = offset;
-    let mut bad_operand: Option<u32> = None;
+    let mut bads: Vec<(u32, String)> = Vec::new();
     for line in non_blank(checker) {
         let mut t: Vec<String> = line.split_whitespace().map(String::from).collect();
         last = last.max(remap(t[0].parse()?));
@@ -129,9 +130,10 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
         {
             continue;
         }
-        // Hold the property aside so it can be gated on the reset pulse below.
+        // Hold each property aside so it can be gated on the reset pulse below.
         if t[1] == "bad" {
-            bad_operand = Some(remap(t[2].parse()?));
+            let name = t.get(3).cloned().unwrap_or_default();
+            bads.push((remap(t[2].parse()?), name));
             continue;
         }
         let (has_sort, positions) = ref_positions(&t[1]);
@@ -148,16 +150,18 @@ pub fn stitch(implementation: &str, checker: &str, signals: &[&str]) -> Result<S
         out.push('\n');
     }
 
-    let bad = bad_operand.ok_or_else(|| anyhow!("checker has no `bad` property"))?;
-    emit_property(&mut out, last, bad, reset_node);
+    if bads.is_empty() {
+        bail!("checker has no `bad` property");
+    }
+    emit_property(&mut out, last, &bads, reset_node);
     Ok(out)
 }
 
-/// Emit the miter property. When the implementation has a `reset` input, drive
-/// a one-cycle reset pulse and gate the mismatch until reset has deasserted, so
+/// Emit the miter properties. When the implementation has a `reset` input, drive
+/// a one-cycle reset pulse and gate each mismatch until reset has deasserted, so
 /// uninitialized pipeline state at step 0 cannot raise a spurious counterexample.
-fn emit_property(out: &mut String, last: u32, bad: u32, reset_node: Option<u32>) {
-    out.push_str("; --- reset-gated property ---\n");
+fn emit_property(out: &mut String, last: u32, bads: &[(u32, String)], reset_node: Option<u32>) {
+    out.push_str("; --- reset-gated properties ---\n");
     let mut nid = last;
     let mut node = |body: String| -> u32 {
         nid += 1;
@@ -165,7 +169,9 @@ fn emit_property(out: &mut String, last: u32, bad: u32, reset_node: Option<u32>)
         nid
     };
     let Some(reset) = reset_node else {
-        node(format!("bad {bad}"));
+        for (bad, name) in bads {
+            node(format!("bad {bad} {name}"));
+        }
         return;
     };
     let s1 = node("sort bitvec 1".into());
@@ -179,8 +185,10 @@ fn emit_property(out: &mut String, last: u32, bad: u32, reset_node: Option<u32>)
     let not_started = node(format!("not {s1} {started}"));
     let reset_ok = node(format!("eq {s1} {reset} {not_started}"));
     node(format!("constraint {reset_ok}"));
-    let gated = node(format!("and {s1} {bad} {started}"));
-    node(format!("bad {gated}"));
+    for (bad, name) in bads {
+        let gated = node(format!("and {s1} {bad} {started}"));
+        node(format!("bad {gated} {name}"));
+    }
 }
 
 fn non_blank(s: &str) -> impl Iterator<Item = &str> {


### PR DESCRIPTION
`tmdlc --action=emit-btor2 --isa=<ISA>` lowers TMDL instruction semantics to
a word-level BTOR2 model for hardware model checking. The model is a
per-instruction reference checker in the riscv-formal / RVFI shape: it takes a
retirement report (insn, pc, rs1_val, rs2_val, rd_addr, rd_we, rd_val,
next_pc, valid), decodes the instruction, computes the golden post-state from
the reported source values, and raises a `bad` property on any divergence.
Composed with an implementation's own BTOR2 it forms a miter a BMC engine
drives to a counterexample.

Reuses the semantic-expression DAG and the StateEmitter control-flow folder
behind the SMT backend; scope matches verify-smt (register-only instructions,
memory/trap behaviors are dropped from the dispatch). Covers RV32I plus M
(mul/div, including the mulh double-width product idiom).