### PR TITLE
feat(vector): add vector dialect and macro loop-sem construct

### DIFF
--- a/backends/common/src/isel/emit.rs
+++ b/backends/common/src/isel/emit.rs
@@ -21,6 +21,19 @@ pub(crate) enum BlockDecision {
 pub(crate) struct BlockPlan {
     pub(crate) op_decisions: HashMap<OpId, BlockDecision>,
     pub(crate) introduced: Vec<IntroducedEmit>,
+    /// Definer instructions to insert ahead of an op for the implicit register
+    /// uses in its behavior (e.g. `vsetvli` defining `VCSR::vl` that `vadd` reads).
+    pub(crate) definers: Vec<DefinerEmit>,
+}
+
+/// A definer instruction to materialize just before `anchor`: it defines a
+/// register the anchor implicitly reads, consuming the value that read bound to.
+/// It has no SSA destination of its own (its emitter hardwires one, e.g. `x0`).
+#[derive(Clone, Debug)]
+pub(crate) struct DefinerEmit {
+    pub(crate) definer_index: usize,
+    pub(crate) m: RuleMatch,
+    pub(crate) anchor: OpId,
 }
 
 /// An instruction to materialize for an introduced e-class: emitted with a fresh

--- a/backends/common/src/isel/mod.rs
+++ b/backends/common/src/isel/mod.rs
@@ -33,7 +33,8 @@ use cover::{
     CaptureBindings, FullMatchBindings, PatternNodeBinding, PbqpIselAlternative, PbqpIselMatch,
     build_eclass_cover, completeness_error, prune_dominated_matches,
 };
-use emit::{BlockDecision, BlockPlan, EmissionBuilder};
+use emit::{BlockDecision, BlockPlan, DefinerEmit, EmissionBuilder};
+use node::{Binding, class_binding};
 use pattern::{CompiledIselPattern, compile_isel_pattern};
 use rewrites::discover_rewrites;
 #[cfg(test)]
@@ -122,6 +123,32 @@ impl IselCostModel for DefaultIselCostModel {}
 pub type RuleEmitFn =
     fn(&Context, &EmitRequest, &RuleMatch) -> Result<Box<dyn Operation>, PassError>;
 
+/// A register an instruction reads implicitly — declared in its behavior but not
+/// among its encoded operands (e.g. `vadd` reading `VCSR::vl`). The read is a real
+/// dependency: selection introduces the register's definer ahead of the reader,
+/// passing the value bound to `symbol`.
+#[derive(Clone, Debug)]
+pub struct ImplicitUse {
+    pub symbol: u32,
+    pub register_class: &'static str,
+    pub register_index: u32,
+}
+
+/// An instruction that defines a register implicitly (writes it in its behavior
+/// with no encoded result, e.g. `vsetvli`/`vsetivli` defining `VCSR::vl`). It is
+/// never selected by value matching; selection introduces it ahead of a reader of
+/// `register_index`, binding `value_symbol` to the value that read bound to (an
+/// immediate when `value_is_immediate`, else a register value). Its `emit_fn`
+/// hardwires the destination to `x0`. Nothing here is target-specific: the
+/// definer's input is exactly the value flowing across the register def/use.
+pub struct RegisterDefiner {
+    pub register_class: &'static str,
+    pub register_index: u32,
+    pub value_is_immediate: bool,
+    pub value_symbol: u32,
+    pub emit_fn: RuleEmitFn,
+}
+
 pub struct Rule {
     pub name: &'static str,
     pub pattern: ExprPostGraph,
@@ -130,6 +157,9 @@ pub struct Rule {
     /// are unconstrained, so hand-written and synthesized rules keep matching any
     /// value.
     pub operand_constraints: Vec<(u32, OperandConstraint)>,
+    /// Registers this instruction reads implicitly (from its behavior, not its
+    /// encoded operands); selection introduces each one's definer ahead of this op.
+    pub implicit_uses: Vec<ImplicitUse>,
     pub emit_fn: RuleEmitFn,
 }
 
@@ -145,6 +175,7 @@ impl Rule {
             pattern,
             base_cost,
             operand_constraints: Vec::new(),
+            implicit_uses: Vec::new(),
             emit_fn,
         }
     }
@@ -153,6 +184,13 @@ impl Rule {
     /// immediate-shift pattern only matches a constant shift amount.
     pub fn with_operand_constraints(mut self, constraints: Vec<(u32, OperandConstraint)>) -> Self {
         self.operand_constraints = constraints;
+        self
+    }
+
+    /// Declare the registers this instruction reads implicitly, so selection
+    /// introduces their definers ahead of it.
+    pub fn with_implicit_uses(mut self, uses: Vec<ImplicitUse>) -> Self {
+        self.implicit_uses = uses;
         self
     }
 }
@@ -187,6 +225,9 @@ pub struct InstructionSelectPass {
     /// with before covering (e.g. discovered `sext`/shift bridges). Populated by
     /// rewrite discovery; empty means selection is purely syntactic tiling.
     rewrites: Vec<Rewrite<SemNode, ()>>,
+    /// Instructions that define a register implicitly; selection introduces one
+    /// ahead of any op whose `implicit_uses` name a matching register.
+    definers: Vec<RegisterDefiner>,
     cost_model: Box<dyn IselCostModel>,
     op_lowerings: Vec<OpLowering>,
     block_cache: HashMap<BlockId, BlockSelectionCache>,
@@ -209,11 +250,19 @@ impl InstructionSelectPass {
             rules,
             compiled_patterns,
             rewrites,
+            definers: Vec::new(),
             cost_model: Box::new(DefaultIselCostModel),
             op_lowerings: vec![],
             block_cache: HashMap::new(),
             emitted_blocks: HashSet::new(),
         }
+    }
+
+    /// Install the instructions that define registers implicitly (e.g.
+    /// `vsetvli`/`vsetivli`), introduced ahead of ops that read those registers.
+    pub fn with_register_definers(mut self, definers: Vec<RegisterDefiner>) -> Self {
+        self.definers = definers;
+        self
     }
 
     /// Install the algebraic identities used to saturate the program e-graph before
@@ -414,6 +463,24 @@ impl InstructionSelectPass {
             rewriter.insert_op_before(&anchor, new_op.as_ref())?;
         }
 
+        // Insert the definer of each implicit register use just before the op that
+        // reads it. The definer has no destination value (its emitter hardwires one).
+        for definer in &plan.definers {
+            let request = EmitRequest {
+                op: None,
+                results: &[],
+                result_ty: None,
+            };
+            let emit_fn = self.definers[definer.definer_index].emit_fn;
+            let new_op = emit_fn(context, &request, &definer.m)?;
+            let anchor = OperationRef::new(
+                context.get_op(definer.anchor),
+                Some(block_arc.clone()),
+                None,
+            );
+            rewriter.insert_op_before(&anchor, new_op.as_ref())?;
+        }
+
         // Rewrite the original ops in reverse block order — consumers before
         // defs — so when a def's replacement remaps SSA uses of its results
         // (`replace_op`), every already-emitted consumer is visible. Positions
@@ -545,9 +612,66 @@ impl InstructionSelectPass {
             }
         }
 
+        // Honor each selected op's implicit register reads: introduce the register's
+        // definer ahead of it, passing exactly the value that read bound to. This is
+        // the register def/use edge declared in the instruction's behavior; the
+        // value crossing it is the only thing threaded — nothing here inspects the
+        // operands' types.
+        let mut definers = Vec::new();
+        for op_id in block.op_ids() {
+            let Some(BlockDecision::Emit { rule_index, .. }) = op_decisions.get(&op_id) else {
+                continue;
+            };
+            let rule = &self.rules[*rule_index];
+            if rule.implicit_uses.is_empty() {
+                continue;
+            }
+            let Some(class) = cache.op_root.get(&op_id).map(|c| cache.egraph.find(*c)) else {
+                continue;
+            };
+            let Some(&match_id) = root_match.get(&class) else {
+                continue;
+            };
+            for implicit_use in &rule.implicit_uses {
+                let Some((_, bound)) = matches[match_id]
+                    .bindings
+                    .captures
+                    .entries
+                    .iter()
+                    .find(|(sym, _)| *sym == implicit_use.symbol)
+                else {
+                    continue;
+                };
+                let bound = cache.egraph.find(*bound);
+                let Some(binding) = class_binding(&cache.egraph, &cache.class_value, bound) else {
+                    continue;
+                };
+                let value_immediate = matches!(binding, Binding::Int(_));
+                let Some((definer_index, definer)) =
+                    self.definers.iter().enumerate().find(|(_, d)| {
+                        d.register_class == implicit_use.register_class
+                            && d.register_index == implicit_use.register_index
+                            && d.value_is_immediate == value_immediate
+                    })
+                else {
+                    continue;
+                };
+                let m = match binding {
+                    Binding::Int(v) => RuleMatch::new(vec![(definer.value_symbol, v)], vec![]),
+                    Binding::Value(v) => RuleMatch::new(vec![], vec![(definer.value_symbol, v)]),
+                };
+                definers.push(DefinerEmit {
+                    definer_index,
+                    m,
+                    anchor: op_id,
+                });
+            }
+        }
+
         Ok(BlockPlan {
             op_decisions,
             introduced: emit.introduced,
+            definers,
         })
     }
 

--- a/backends/riscv/build.rs
+++ b/backends/riscv/build.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .add_input("./defs/multiplication.tmdl")
         .add_input("./defs/zicsr.tmdl")
         .add_input("./defs/perf.tmdl")
+        .add_input("./defs/vector.tmdl")
         .add_input("./defs/syntacore_scr1.tmdl")
         .output(OutputKind::File(format!(
             "{}/riscv.rs",

--- a/backends/riscv/checks/isel/vector.tir
+++ b/backends/riscv/checks/isel/vector.tir
@@ -12,6 +12,9 @@ module {
   module_end
 }
 
+// The vector.add reads VCSR::vl implicitly, so selection introduces its definer
+// vsetivli (lane count 4 as the immediate AVL) ahead of the vadd.vv.
 // CHECK: asm.symbol {name = "vadd"
+// CHECK: riscv.vsetivli {rd = x0, avl = 4}
 // CHECK: riscv.vadd.vv {vd = %virt2:VR, vs2 = %virt0:VR, vs1 = %virt1:VR}
 // CHECK: riscv.vret

--- a/backends/riscv/checks/isel/vector.tir
+++ b/backends/riscv/checks/isel/vector.tir
@@ -1,0 +1,17 @@
+// RUN: tir mc --march=rv64iv --stage=isel %s | filecheck %s
+
+// A target-independent vector.add lowers to the RVV vadd.vv: both the dialect op
+// and the instruction's behavior produce the same map-over-lanes semantic DAG, so
+// instruction selection matches them structurally.
+
+module {
+  func @vadd(%0: !vector.vec<4xi32>, %1: !vector.vec<4xi32>) -> !vector.vec<4xi32> {
+    %2 = vector.add %0, %1 : !vector.vec<4xi32>
+    return %2
+  }
+  module_end
+}
+
+// CHECK: asm.symbol {name = "vadd"
+// CHECK: riscv.vadd.vv {vd = %virt2:VR, vs2 = %virt0:VR, vs1 = %virt1:VR}
+// CHECK: riscv.vret

--- a/backends/riscv/checks/obj/vector.S
+++ b/backends/riscv/checks/obj/vector.S
@@ -1,0 +1,15 @@
+# RUN: tir mc --march=rv64iv --filetype=obj-ascii %s | filecheck %s --check-prefix=BYTES
+
+# A small slice of the RVV vector-vector arithmetic (OPIVV) instructions. The
+# encodings match the RISC-V Vector spec bit for bit, e.g. `vadd.vv v1, v2, v3`
+# is 0x022180d7.
+.global vtest
+vtest:
+    vadd.vv v1, v2, v3
+    vsub.vv v4, v5, v6
+    vmul.vv v7, v8, v9
+
+# BYTES: vtest:
+# BYTES-NEXT: [0xD7, 0x80, 0x21, 0x02]
+# BYTES-NEXT: [0x57, 0x02, 0x53, 0x0A]
+# BYTES-NEXT: [0xD7, 0x83, 0x84, 0x96]

--- a/backends/riscv/defs/vector.tmdl
+++ b/backends/riscv/defs/vector.tmdl
@@ -1,19 +1,39 @@
-// A small slice of the RISC-V Vector extension (RVV). To stay within what the
-// loop-aware behavior language can express without a dynamic vtype CSR, these
-// instructions model a fixed 32-bit element width over a VLEN-bit vector
-// register: a VLEN=128 register therefore holds four 32-bit lanes. The lane loop
-// is written with the Rust-style `for` accumulator form, which lowers to the
-// IR's first-class `Loop` node.
+// A slice of the RISC-V Vector extension (RVV). The vector unit's shape is
+// architectural state, not spec-time constants: `vtype` holds the selected
+// element width (SEW) and register-group multiplier (LMUL), `vl` holds the
+// active element count, and `vlenb` exposes the implementation's VLEN (the
+// physical width of a vector register, in bytes). Instruction behavior reads
+// these control registers rather than baking VLEN/SEW in, so an OPIVV op is
+// genuinely parametric over the configured element width and length.
 
-isa RVV requires [RV32I | RV64I] {
-    param VLEN: Integer = 128;
-    param SEW: Integer = 32;
+isa RVV requires [RV32I | RV64I] {}
+
+// Vector control and status registers (addressed by their architectural CSR
+// numbers). `vlenb` is read-only and reports VLEN/8; `vtype`/`vl`/`vstart` are
+// written by `vsetvl{i}` and the vector unit.
+register_class VCSR for [RVV] {
+    param ENCODING_LEN: Integer = 12;
+    param WIDTH: Integer = self.XLEN;
+
+    registers {
+        vstart => { index = 0x008 },
+        vl     => { index = 0xC20 },
+        vtype  => { index = 0xC21 },
+        vlenb  => { index = 0xC22 },
+    }
 }
 
-// The 32 architectural vector registers v0..v31, each VLEN bits wide.
+// The 32 architectural vector registers v0..v31. Their physical width is the
+// implementation's VLEN, the same fixed quantity `vlenb` reports; how those bits
+// are partitioned into elements is governed dynamically by `vtype`.
 register_class VR for [RVV] {
     param ENCODING_LEN: Integer = 5;
-    param WIDTH: Integer = self.VLEN;
+    // Dynamically sized: a vector register's width is the implementation's VLEN,
+    // not a compile-time constant. It is reported at runtime by `vlenb`, so the
+    // operand type is `bits<?>` — bits of unknown width. How those bits split
+    // into elements is decided by each instruction's behavior (via `vtype`), not
+    // by the register, the same way one physical file is reused across SEWs.
+    param WIDTH: Integer = VCSR::vlenb;
 
     registers {
         v0..v31 => { traits = [vector] },
@@ -51,18 +71,20 @@ template VArithVV for [RVV] {
     schedule { units = [WriteIALU]; }
 }
 
-// Each instruction's behavior is a vector map over the VLEN/SEW lanes: the
-// value-producing `for` loop lowers to a first-class `VectorMap` whose lane
-// expression reads operand lanes with the `lane` builtin. This is the same
-// map/lane shape the target-independent `vector` dialect ops produce, so
-// instruction selection can match a `vector.add` against `vadd.vv`.
+// Each OPIVV instruction maps over the `vl` active elements: the value-producing
+// `for` loop lowers to a first-class `VectorMap` whose lane count is the dynamic
+// `vl` read, and whose lane expression reads operand elements with `lane`. The
+// element width is not named here; it is whatever `vtype` selects, so the same
+// description serves every SEW. This is the same map/lane shape the
+// target-independent `vector` dialect ops produce, so instruction selection can
+// match a `vector.add` against `vadd.vv`.
 
 instruction VAdd for [RVV] : VArithVV {
     param MNEMONIC: String = "vadd.vv";
     param FUNCT6: bits<6> = 0b000000;
 
     behavior {
-        vd = for i in 0..(self.VLEN / self.SEW) {
+        vd = for i in 0..VCSR::vl {
             lane(vs2, i) + lane(vs1, i)
         };
     }
@@ -73,7 +95,7 @@ instruction VSub for [RVV] : VArithVV {
     param FUNCT6: bits<6> = 0b000010;
 
     behavior {
-        vd = for i in 0..(self.VLEN / self.SEW) {
+        vd = for i in 0..VCSR::vl {
             lane(vs2, i) - lane(vs1, i)
         };
     }
@@ -84,7 +106,7 @@ instruction VMul for [RVV] : VArithVV {
     param FUNCT6: bits<6> = 0b100101;
 
     behavior {
-        vd = for i in 0..(self.VLEN / self.SEW) {
+        vd = for i in 0..VCSR::vl {
             lane(vs2, i) * lane(vs1, i)
         };
     }

--- a/backends/riscv/defs/vector.tmdl
+++ b/backends/riscv/defs/vector.tmdl
@@ -40,6 +40,80 @@ register_class VR for [RVV] {
     }
 }
 
+// `vset{i}vli` define `VCSR::vl`, the active element count every OPIVV
+// instruction reads in its behavior. They are never selected by value matching —
+// their behavior assigns only `VCSR::vl`, not an encoded result operand, so
+// rustgen emits no matching rule. Instead instruction selection honors the OPIVV
+// ops' implicit read of `VCSR::vl` by introducing the definer ahead of them, with
+// `rd` hardwired to `x0` (the granted `vl` is discarded). The element width is
+// `total / vl` in this functional model, so no SEW operand is needed; the packed
+// `vtype` encoding is a fixed placeholder, left as a follow-up.
+//
+// `vsetvli` takes the requested length (AVL) from a register; `vsetivli` from a
+// 5-bit immediate. Selection picks between them by whether the lane count is a
+// constant (fixed vector) or a value (scalable vector).
+instruction VSetVli for [RVV] {
+    param MNEMONIC: String = "vsetvli";
+    param OPCODE: bits<7> = 0b1010111;
+    param FUNCT3: bits<3> = 0b111;
+    param VTYPEI: bits<11> = 0;
+
+    operands {
+        rd: GPR,
+        avl: GPR,
+    }
+
+    encoding {
+        0..6 => OPCODE,
+        7..11 => rd,
+        12..14 => FUNCT3,
+        15..19 => avl,
+        20..30 => VTYPEI,
+        31 => 0b0,
+    }
+
+    asm {
+        "{self.MNEMONIC} {rd}, {avl}"
+    }
+
+    behavior {
+        VCSR::vl = avl;
+    }
+
+    schedule { units = [WriteIALU]; }
+}
+
+instruction VSetIVli for [RVV] {
+    param MNEMONIC: String = "vsetivli";
+    param OPCODE: bits<7> = 0b1010111;
+    param FUNCT3: bits<3> = 0b111;
+    param VTYPEI: bits<10> = 0;
+
+    operands {
+        rd: GPR,
+        avl: bits<5>,
+    }
+
+    encoding {
+        0..6 => OPCODE,
+        7..11 => rd,
+        12..14 => FUNCT3,
+        15..19 => avl,
+        20..29 => VTYPEI,
+        30..31 => 0b11,
+    }
+
+    asm {
+        "{self.MNEMONIC} {rd}, {avl}"
+    }
+
+    behavior {
+        VCSR::vl = zext(avl, self.XLEN);
+    }
+
+    schedule { units = [WriteIALU]; }
+}
+
 // OP-V, vector-vector (OPIVV) form: `op.vv vd, vs2, vs1`.
 template VArithVV for [RVV] {
     param MNEMONIC: String;
@@ -71,22 +145,21 @@ template VArithVV for [RVV] {
     schedule { units = [WriteIALU]; }
 }
 
-// Each OPIVV instruction maps over the `vl` active elements: the value-producing
-// `for` loop lowers to a first-class `VectorMap` whose lane count is the dynamic
-// `vl` read, and whose lane expression reads operand elements with `lane`. The
-// element width is not named here; it is whatever `vtype` selects, so the same
-// description serves every SEW. This is the same map/lane shape the
+// Each OPIVV instruction maps over the `vl` active elements: it splits each
+// source register into `VCSR::vl` lanes, pairs them, applies the elementwise
+// operation, and concatenates the results back into the destination register.
+// The lane width is not named here; it is whatever `vtype` selects, so the same
+// description serves every SEW. This is the same split/map/concat shape the
 // target-independent `vector` dialect ops produce, so instruction selection can
-// match a `vector.add` against `vadd.vv`.
+// match a `vector.add` against `vadd.vv`, the `VCSR::vl` read binding to the
+// dialect op's `vl` operand.
 
 instruction VAdd for [RVV] : VArithVV {
     param MNEMONIC: String = "vadd.vv";
     param FUNCT6: bits<6> = 0b000000;
 
     behavior {
-        vd = for i in 0..VCSR::vl {
-            lane(vs2, i) + lane(vs1, i)
-        };
+        vd = concat(map(zip(split(vs2, VCSR::vl), split(vs1, VCSR::vl)), |a, b| a + b));
     }
 }
 
@@ -95,9 +168,7 @@ instruction VSub for [RVV] : VArithVV {
     param FUNCT6: bits<6> = 0b000010;
 
     behavior {
-        vd = for i in 0..VCSR::vl {
-            lane(vs2, i) - lane(vs1, i)
-        };
+        vd = concat(map(zip(split(vs2, VCSR::vl), split(vs1, VCSR::vl)), |a, b| a - b));
     }
 }
 
@@ -106,8 +177,6 @@ instruction VMul for [RVV] : VArithVV {
     param FUNCT6: bits<6> = 0b100101;
 
     behavior {
-        vd = for i in 0..VCSR::vl {
-            lane(vs2, i) * lane(vs1, i)
-        };
+        vd = concat(map(zip(split(vs2, VCSR::vl), split(vs1, VCSR::vl)), |a, b| a * b));
     }
 }

--- a/backends/riscv/defs/vector.tmdl
+++ b/backends/riscv/defs/vector.tmdl
@@ -1,0 +1,102 @@
+// A small slice of the RISC-V Vector extension (RVV). To stay within what the
+// loop-aware behavior language can express without a dynamic vtype CSR, these
+// instructions model a fixed 32-bit element width over a VLEN-bit vector
+// register: a VLEN=128 register therefore holds four 32-bit lanes. The lane loop
+// is written with the Rust-style `for` accumulator form, which lowers to the
+// IR's first-class `Loop` node.
+
+isa RVV requires [RV32I | RV64I] {
+    param VLEN: Integer = 128;
+    param SEW: Integer = 32;
+}
+
+// The 32 architectural vector registers v0..v31, each VLEN bits wide.
+register_class VR for [RVV] {
+    param ENCODING_LEN: Integer = 5;
+    param WIDTH: Integer = self.VLEN;
+
+    registers {
+        v0..v31 => { traits = [vector] },
+    }
+}
+
+// OP-V, vector-vector (OPIVV) form: `op.vv vd, vs2, vs1`.
+template VArithVV for [RVV] {
+    param MNEMONIC: String;
+    param FUNCT6: bits<6>;
+    param FUNCT3: bits<3> = 0b000;
+    param VM: bits<1> = 0b1;
+    param OPCODE: bits<7> = 0b1010111;
+
+    operands {
+        vd: VR,
+        vs2: VR,
+        vs1: VR,
+    }
+
+    encoding {
+        0..6 => OPCODE,
+        7..11 => vd,
+        12..14 => FUNCT3,
+        15..19 => vs1,
+        20..24 => vs2,
+        25 => VM,
+        26..31 => FUNCT6,
+    }
+
+    asm {
+        "{self.MNEMONIC} {vd}, {vs2}, {vs1}"
+    }
+
+    schedule { units = [WriteIALU]; }
+}
+
+instruction VAdd for [RVV] : VArithVV {
+    param MNEMONIC: String = "vadd.vv";
+    param FUNCT6: bits<6> = 0b000000;
+
+    // For each lane i in [0, VLEN/SEW): vd[i] = vs2[i] + vs1[i]. Each lane sum is
+    // zero-extended to the full register width before being shifted into place.
+    behavior {
+        vd = zext(0b0, self.VLEN);
+        for i in 0..(self.VLEN / self.SEW) {
+            vd = vd | (zext(
+                extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
+                    + extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
+                self.VLEN) << (i * self.SEW));
+        }
+    }
+}
+
+instruction VSub for [RVV] : VArithVV {
+    param MNEMONIC: String = "vsub.vv";
+    param FUNCT6: bits<6> = 0b000010;
+
+    behavior {
+        vd = zext(0b0, self.VLEN);
+        for i in 0..(self.VLEN / self.SEW) {
+            vd = vd | (zext(
+                extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
+                    - extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
+                self.VLEN) << (i * self.SEW));
+        }
+    }
+}
+
+instruction VMul for [RVV] : VArithVV {
+    param MNEMONIC: String = "vmul.vv";
+    param FUNCT6: bits<6> = 0b100101;
+
+    // The low SEW bits of each lane product are kept.
+    behavior {
+        vd = zext(0b0, self.VLEN);
+        for i in 0..(self.VLEN / self.SEW) {
+            vd = vd | (zext(
+                extract(
+                    extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
+                        * extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
+                    self.SEW - 1, 0),
+                self.VLEN) << (i * self.SEW));
+        }
+    }
+}

--- a/backends/riscv/defs/vector.tmdl
+++ b/backends/riscv/defs/vector.tmdl
@@ -51,20 +51,20 @@ template VArithVV for [RVV] {
     schedule { units = [WriteIALU]; }
 }
 
+// Each instruction's behavior is a vector map over the VLEN/SEW lanes: the
+// value-producing `for` loop lowers to a first-class `VectorMap` whose lane
+// expression reads operand lanes with the `lane` builtin. This is the same
+// map/lane shape the target-independent `vector` dialect ops produce, so
+// instruction selection can match a `vector.add` against `vadd.vv`.
+
 instruction VAdd for [RVV] : VArithVV {
     param MNEMONIC: String = "vadd.vv";
     param FUNCT6: bits<6> = 0b000000;
 
-    // For each lane i in [0, VLEN/SEW): vd[i] = vs2[i] + vs1[i]. Each lane sum is
-    // zero-extended to the full register width before being shifted into place.
     behavior {
-        vd = zext(0b0, self.VLEN);
-        for i in 0..(self.VLEN / self.SEW) {
-            vd = vd | (zext(
-                extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
-                    + extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
-                self.VLEN) << (i * self.SEW));
-        }
+        vd = for i in 0..(self.VLEN / self.SEW) {
+            lane(vs2, i) + lane(vs1, i)
+        };
     }
 }
 
@@ -73,13 +73,9 @@ instruction VSub for [RVV] : VArithVV {
     param FUNCT6: bits<6> = 0b000010;
 
     behavior {
-        vd = zext(0b0, self.VLEN);
-        for i in 0..(self.VLEN / self.SEW) {
-            vd = vd | (zext(
-                extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
-                    - extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
-                self.VLEN) << (i * self.SEW));
-        }
+        vd = for i in 0..(self.VLEN / self.SEW) {
+            lane(vs2, i) - lane(vs1, i)
+        };
     }
 }
 
@@ -87,16 +83,9 @@ instruction VMul for [RVV] : VArithVV {
     param MNEMONIC: String = "vmul.vv";
     param FUNCT6: bits<6> = 0b100101;
 
-    // The low SEW bits of each lane product are kept.
     behavior {
-        vd = zext(0b0, self.VLEN);
-        for i in 0..(self.VLEN / self.SEW) {
-            vd = vd | (zext(
-                extract(
-                    extract(vs2, i * self.SEW + self.SEW - 1, i * self.SEW)
-                        * extract(vs1, i * self.SEW + self.SEW - 1, i * self.SEW),
-                    self.SEW - 1, 0),
-                self.VLEN) << (i * self.SEW));
-        }
+        vd = for i in 0..(self.VLEN / self.SEW) {
+            lane(vs2, i) * lane(vs1, i)
+        };
     }
 }

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -451,6 +451,8 @@ dialect! {
             VAddOp,
             VSubOp,
             VMulOp,
+            VSetVliOp,
+            VSetIVliOp,
             // Zicsr
             CSRReadWriteOp,
             CSRReadSetOp,
@@ -745,6 +747,7 @@ fn create_isel_pass_for(
     features: &[Feature],
 ) -> tir_be_common::isel::InstructionSelectPass {
     tir_be_common::isel::InstructionSelectPass::new(get_isel_rules(context, features))
+        .with_register_definers(get_register_definers(context, features))
         .with_op_lowering(lower_func_and_return_to_asm_symbol)
         .with_op_lowering(lower_branches)
         .with_op_lowering(lower_calls)

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -447,6 +447,10 @@ dialect! {
             // M extension (Zmmul subset)
             MulOp,
             MulHOp,
+            // V extension (vector-vector arithmetic)
+            VAddOp,
+            VSubOp,
+            VMulOp,
             // Zicsr
             CSRReadWriteOp,
             CSRReadSetOp,

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -239,10 +239,14 @@ fn parse_riscv_isa_string(march: &str) -> Result<TargetConfig, String> {
                 enable(Feature::Zmmul);
                 skip_extension_version(&mut chars);
             }
+            'v' => {
+                enable(Feature::RVV);
+                skip_extension_version(&mut chars);
+            }
             // Standard single-letter extensions TMDL does not model yet are
             // accepted so common GNU march strings (e.g. rv64gc) keep working;
             // they contribute no instructions.
-            'a' | 'f' | 'd' | 'q' | 'l' | 'c' | 'b' | 'j' | 't' | 'p' | 'v' | 'h' => {
+            'a' | 'f' | 'd' | 'q' | 'l' | 'c' | 'b' | 'j' | 't' | 'p' | 'h' => {
                 skip_extension_version(&mut chars);
             }
             'z' | 's' | 'x' => {
@@ -2315,7 +2319,13 @@ mod target_parser_tests {
         // Bare architecture names select the generic, everything-on profile.
         assert_eq!(
             features("riscv64", None),
-            vec![Feature::RV64I, Feature::Zmmul, Feature::RVM, Feature::Zicsr]
+            vec![
+                Feature::RV64I,
+                Feature::Zmmul,
+                Feature::RVM,
+                Feature::Zicsr,
+                Feature::RVV
+            ]
         );
         assert!(!features("riscv32", None).contains(&Feature::RV64I));
     }
@@ -2361,11 +2371,11 @@ mod target_parser_tests {
         );
         assert_eq!(
             crate::register_widths(&[Feature::RV32I]),
-            vec![("PC", 32), ("GPR", 32), ("CSR", 32)]
+            vec![("PC", 32), ("GPR", 32), ("CSR", 32), ("VR", 128)]
         );
         assert_eq!(
             crate::register_widths(&[Feature::RV64I]),
-            vec![("PC", 64), ("GPR", 64), ("CSR", 64)]
+            vec![("PC", 64), ("GPR", 64), ("CSR", 64), ("VR", 128)]
         );
         // Extensions alone resolve nothing; the base supplies XLEN.
         assert_eq!(crate::isa_params(&[Feature::RVM]), vec![]);

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -2373,13 +2373,15 @@ mod target_parser_tests {
             crate::isa_params(&[Feature::RV64I, Feature::RVM]),
             vec![("XLEN", 64)]
         );
+        // VR is dynamically sized (width = vlenb, an architectural runtime value),
+        // so it carries no static width here; its size is supplied by the machine.
         assert_eq!(
             crate::register_widths(&[Feature::RV32I]),
-            vec![("PC", 32), ("GPR", 32), ("CSR", 32), ("VR", 128)]
+            vec![("PC", 32), ("GPR", 32), ("CSR", 32), ("VCSR", 32)]
         );
         assert_eq!(
             crate::register_widths(&[Feature::RV64I]),
-            vec![("PC", 64), ("GPR", 64), ("CSR", 64), ("VR", 128)]
+            vec![("PC", 64), ("GPR", 64), ("CSR", 64), ("VCSR", 64)]
         );
         // Extensions alone resolve nothing; the base supplies XLEN.
         assert_eq!(crate::isa_params(&[Feature::RVM]), vec![]);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -20,6 +20,7 @@ use crate::{
     region::RegionId,
     ty::{Type, TypeParser},
     value::{Value, ValueId},
+    vector::VectorDialect,
 };
 
 /// Central hub for managing all IR entities and state.
@@ -123,6 +124,7 @@ impl Context {
         context.register_dialect::<BuiltinDialect>();
         context.register_dialect::<PtrDialect>();
         context.register_dialect::<ScfDialect>();
+        context.register_dialect::<VectorDialect>();
 
         context
     }

--- a/core/src/dialects/mod.rs
+++ b/core/src/dialects/mod.rs
@@ -1,3 +1,4 @@
 pub mod builtin;
 pub mod ptr;
 pub mod scf;
+pub mod vector;

--- a/core/src/dialects/vector/mod.rs
+++ b/core/src/dialects/vector/mod.rs
@@ -1,7 +1,8 @@
 //! The `vector` dialect: a small, target-independent vocabulary for SIMD-style
 //! arithmetic. A [`VectorType`] is either statically sized (`vec<8xi32>`) or
-//! dynamically sized (`vec<i32>`), and the elementwise arithmetic operations take
-//! an optional vector-length operand that bounds how many lanes are active.
+//! dynamically sized (`vec<i32>`); a dynamic vector's elementwise operation takes
+//! a vector-length (`vl`) operand bounding the active lanes, while a static one
+//! reads its lane count straight from the type.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -166,10 +167,9 @@ operation! {
     }
 }
 
-/// The active lane count for `$get_vlen` in the elementwise ops' semantics: the
-/// dynamic `vl` operand (index 2) when present, otherwise the static lane count
-/// of the result vector type as a constant. This is the `n` each `split` cuts the
-/// operand bits into.
+/// The active lane count for `$get_vlen`, the `n` each `split` cuts the operand
+/// bits into: a fixed vector takes it from the result type's static length (a
+/// constant); a scalable vector takes it from the dynamic `vl` operand (index 2).
 fn vlen_node(
     op: &tir::OpInstance,
     g: &mut impl tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>,
@@ -177,21 +177,20 @@ fn vlen_node(
     if op.operands.len() > 2 {
         let n = g.add_node(tir::sem_expr::ExprKind::Symbol);
         g.set_leaf_data(n, tir::sem_expr::ExprPayload::SymbolId(2));
-        n
-    } else {
-        let context = op.context.upgrade();
-        let ty = context.get_value(op.results[0]).ty();
-        let length = (context.get_type_data(ty).as_ref() as &dyn Any)
-            .downcast_ref::<VectorType>()
-            .and_then(|t| t.length())
-            .unwrap_or(0) as u64;
-        let n = g.add_node(tir::sem_expr::ExprKind::Constant);
-        g.set_leaf_data(
-            n,
-            tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, length)),
-        );
-        n
+        return n;
     }
+    let context = op.context.upgrade();
+    let ty = context.get_value(op.results[0]).ty();
+    let length = (context.get_type_data(ty).as_ref() as &dyn Any)
+        .downcast_ref::<VectorType>()
+        .and_then(|t| t.length())
+        .unwrap_or(0) as u64;
+    let n = g.add_node(tir::sem_expr::ExprKind::Constant);
+    g.set_leaf_data(
+        n,
+        tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, length)),
+    );
+    n
 }
 
 macro_rules! impl_get_vlen {

--- a/core/src/dialects/vector/mod.rs
+++ b/core/src/dialects/vector/mod.rs
@@ -1,0 +1,394 @@
+//! The `vector` dialect: a small, target-independent vocabulary for SIMD-style
+//! arithmetic. A [`VectorType`] is either statically sized (`vec<8xi32>`) or
+//! dynamically sized (`vec<i32>`), and the elementwise arithmetic operations take
+//! an optional vector-length operand that bounds how many lanes are active.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::ty::TypeConstraint;
+use crate::{Context, Error, IRFormatter, Type, TypeId, dialect, operation, parse::Span};
+
+use crate as tir;
+
+pub mod ops {
+    pub use super::{AddOp, MulOp, SubOp, add, mul, sub};
+}
+
+dialect! {
+    VectorDialect {
+        name: "vector",
+        operations: [
+            AddOp,
+            SubOp,
+            MulOp,
+        ],
+        types: [VectorType],
+    }
+}
+
+/// A vector type, written `vec<8xi32>` (static) or `vec<i32>` (dynamic). A static
+/// vector fixes its lane count; a dynamic one leaves it unknown until run time.
+pub struct VectorType {
+    element: Arc<dyn Type>,
+    length: Option<u32>,
+}
+
+impl VectorType {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(context: &Context, element: TypeId, length: Option<u32>) -> TypeId {
+        let element = context.get_type_data(element);
+        context.get_type_id(Arc::new(Self { element, length }))
+    }
+
+    /// A statically sized vector of `length` lanes.
+    pub fn fixed(context: &Context, element: TypeId, length: u32) -> TypeId {
+        Self::new(context, element, Some(length))
+    }
+
+    /// A dynamically sized vector whose lane count is unknown at compile time.
+    pub fn dynamic(context: &Context, element: TypeId) -> TypeId {
+        Self::new(context, element, None)
+    }
+
+    pub fn element(&self, context: &Context) -> TypeId {
+        context.get_type_id(self.element.clone())
+    }
+
+    pub fn length(&self) -> Option<u32> {
+        self.length
+    }
+}
+
+impl TypeConstraint for VectorType {}
+
+impl Type for VectorType {
+    fn dialect(&self) -> &'static str {
+        "vector"
+    }
+
+    fn parse_key() -> &'static str {
+        "vec"
+    }
+
+    fn parse<'src>(
+        _mnemonic: &str,
+        parser: &mut tir::parse::text::Parser<'src>,
+        context: &Context,
+    ) -> Result<TypeId, (Span, Error)> {
+        use tir::parse::common::Cursor;
+        if !parser.parse_token("<") {
+            return Err((parser.span(), Error::ExpectedToken("<")));
+        }
+        // A leading `N x` gives a static length; its absence means dynamic.
+        let length = if let Some(n) = parser.parse_number() {
+            if n < 0 || !parser.parse_token("x") {
+                return Err((parser.span(), Error::ExpectedToken("x")));
+            }
+            Some(n as u32)
+        } else {
+            None
+        };
+        let name = parser
+            .parse_ident()
+            .ok_or_else(|| (parser.span(), Error::ExpectedType))?;
+        let element = context
+            .parse_type_mnemonic("builtin", name)
+            .map_err(|err| (parser.span(), err))?;
+        if !parser.parse_token(">") {
+            return Err((parser.span(), Error::ExpectedToken(">")));
+        }
+        Ok(Self::new(context, element, length))
+    }
+
+    fn print(&self, fmt: &mut IRFormatter<'_>) -> Result<(), std::fmt::Error> {
+        fmt.write("vec<")?;
+        if let Some(length) = self.length {
+            fmt.write(format!("{length}x"))?;
+        }
+        self.element.print(fmt)?;
+        fmt.write(">")
+    }
+
+    fn eq(&self, other: &dyn Type) -> bool {
+        let Some(other) = (other as &dyn Any).downcast_ref::<VectorType>() else {
+            return false;
+        };
+        self.length == other.length && self.element.eq(other.element.as_ref())
+    }
+}
+
+operation! {
+    AddOp {
+        name: "add",
+        dialect: "vector",
+        operands: O {
+            lhs: "crate::vector::VectorType",
+            rhs: "crate::vector::VectorType",
+            vl: "?crate::builtin::IndexType",
+        },
+        results: R {
+            result: "crate::vector::VectorType",
+        },
+    }
+}
+
+operation! {
+    SubOp {
+        name: "sub",
+        dialect: "vector",
+        operands: O {
+            lhs: "crate::vector::VectorType",
+            rhs: "crate::vector::VectorType",
+            vl: "?crate::builtin::IndexType",
+        },
+        results: R {
+            result: "crate::vector::VectorType",
+        },
+    }
+}
+
+operation! {
+    MulOp {
+        name: "mul",
+        dialect: "vector",
+        operands: O {
+            lhs: "crate::vector::VectorType",
+            rhs: "crate::vector::VectorType",
+            vl: "?crate::builtin::IndexType",
+        },
+        results: R {
+            result: "crate::vector::VectorType",
+        },
+    }
+}
+
+// A test-only operation exercising the `operation!` macro's `(loop ...)` sem
+// construct: `sum_to n` folds `acc + indvar` over `[0, n)`, i.e. the sum
+// `0 + 1 + ... + (n - 1)`.
+#[cfg(test)]
+operation! {
+    SumToOp {
+        name: "sum_to",
+        dialect: "vector",
+        operands: O {
+            n: "crate::builtin::IntegerType",
+        },
+        results: R {
+            result: "crate::builtin::IntegerType",
+        },
+        sem: "(set result (loop 0 n 0 (add acc indvar)))",
+    }
+}
+
+// A constant-bound variant: `sum_eight` folds `acc + indvar` over `[0, 8)` with
+// the bound written as a literal, so the lowered `Loop` unrolls to a constant.
+#[cfg(test)]
+operation! {
+    SumEightOp {
+        name: "sum_eight",
+        dialect: "vector",
+        results: R {
+            result: "crate::builtin::IntegerType",
+        },
+        sem: "(set result (loop 0 8 0 (add acc indvar)))",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        IRBuilder, IRFormatter, Operation, ValueId,
+        builtin::{FuncOp, IndexType, IntegerType, ops as builtin_ops},
+        parse::ir::parse_ir,
+    };
+
+    /// A value that verifies as a block argument, like a function parameter.
+    fn block_arg(context: &Context, ty: TypeId) -> ValueId {
+        let value = context.create_value(ty, None);
+        let id = value.id();
+        let _block = context.create_block(vec![value]);
+        id
+    }
+
+    #[test]
+    fn static_and_dynamic_vector_roundtrip() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+
+        let fixed = VectorType::fixed(&context, i32_ty, 8);
+        assert_eq!(context.type_to_string(fixed), "!vector.vec<8xi32>");
+
+        let dynamic = VectorType::dynamic(&context, i32_ty);
+        assert_eq!(context.type_to_string(dynamic), "!vector.vec<i32>");
+
+        // A static vector remembers its lane count and element.
+        let data = context.get_type_data(fixed);
+        let vec = (data.as_ref() as &dyn Any)
+            .downcast_ref::<VectorType>()
+            .unwrap();
+        assert_eq!(vec.length(), Some(8));
+        assert_eq!(vec.element(&context), i32_ty);
+
+        // Static and dynamic vectors are distinct; identical ones are interned.
+        assert_ne!(fixed, dynamic);
+        assert_eq!(VectorType::fixed(&context, i32_ty, 8), fixed);
+        assert_ne!(VectorType::fixed(&context, i32_ty, 4), fixed);
+    }
+
+    fn parse_type_text(context: &Context, src: &str) -> TypeId {
+        let mut parser = tir::parse::text::Parser::new(src);
+        parser
+            .parse_type(context)
+            .expect("type parses")
+            .expect("type present")
+    }
+
+    #[test]
+    fn vector_type_parses_from_text() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        assert_eq!(
+            parse_type_text(&context, "!vector.vec<8xi32>"),
+            VectorType::fixed(&context, i32_ty, 8)
+        );
+        assert_eq!(
+            parse_type_text(&context, "!vector.vec<i32>"),
+            VectorType::dynamic(&context, i32_ty)
+        );
+    }
+
+    #[test]
+    fn add_without_vl_roundtrips() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let vec_ty = VectorType::fixed(&context, i32_ty, 8);
+        let lhs = block_arg(&context, vec_ty);
+        let rhs = block_arg(&context, vec_ty);
+
+        let op = ops::add(&context, lhs, rhs, tir::Operand::none(), vec_ty).build();
+        assert_eq!(op.operands().len(), 2);
+        assert!(op.verify(&context).is_ok());
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+        assert!(buf.contains("vector.add"));
+        assert!(buf.contains("!vector.vec<8xi32>"));
+
+        let parsed = parse_ir::<AddOp>(&context, &buf).expect("parse vector.add");
+        assert!(parsed.verify(&context).is_ok());
+        assert_eq!(parsed.operands().len(), 2);
+    }
+
+    #[test]
+    fn add_with_vl_roundtrips() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let vec_ty = VectorType::dynamic(&context, i32_ty);
+        let lhs = block_arg(&context, vec_ty);
+        let rhs = block_arg(&context, vec_ty);
+        let vl = block_arg(&context, IndexType::new(&context));
+
+        let op = ops::sub(&context, lhs, rhs, vl, vec_ty).build();
+        assert_eq!(op.operands().len(), 3);
+        assert!(op.verify(&context).is_ok());
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        op.print(&mut fmt).expect("print ok");
+
+        let parsed = parse_ir::<SubOp>(&context, &buf).expect("parse vector.sub");
+        assert!(parsed.verify(&context).is_ok());
+        assert_eq!(parsed.operands().len(), 3);
+    }
+
+    #[test]
+    fn mul_rejects_scalar_operand() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let vec_ty = VectorType::fixed(&context, i32_ty, 4);
+        let lhs = block_arg(&context, vec_ty);
+        let scalar = block_arg(&context, i32_ty);
+
+        let op = ops::mul(&context, lhs, scalar, tir::Operand::none(), vec_ty).build();
+        let err = op.verify(&context).expect_err("rhs must be a vector");
+        assert!(err.to_string().contains("expected constraint"));
+    }
+
+    #[test]
+    fn loop_sem_folds_over_induction_range() {
+        use crate::graph::Dag;
+        use crate::sem_expr::{AsSemExpr, ExprKind, ExprPostGraph, Value, execute, unroll_loops};
+        use crate::utils::APInt;
+
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let n = context.create_value(i32_ty, None);
+        let op = sum_to(&context, n.id(), i32_ty).build();
+
+        let mut g = ExprPostGraph::new();
+        let root = op.convert(&mut g);
+        assert_eq!(g.get_kind(root), &ExprKind::Loop);
+
+        // 0 + 1 + 2 + 3 + 4 = 10 for n = 5.
+        let result = execute(&g, &[Value::Int(APInt::new_signed(32, 5))]);
+        match result {
+            Value::Int(v) => assert_eq!(v.to_i64(), 10),
+            other => panic!("expected int, got {other:?}"),
+        }
+
+        // A literal bound lets the lowered Loop unroll away entirely, leaving the
+        // constant 0 + 1 + ... + 7 = 28.
+        let const_op = sum_eight(&context, i32_ty).build();
+        let mut cg = ExprPostGraph::new();
+        let croot = const_op.convert(&mut cg);
+        let (unrolled, new_root) = unroll_loops(&cg, croot);
+        for idx in 0..unrolled.len() {
+            let kind = *unrolled.get_node(crate::graph::NodeId::from_index(idx));
+            assert!(!matches!(
+                kind,
+                ExprKind::Loop | ExprKind::IndVar | ExprKind::Acc
+            ));
+        }
+        let _ = new_root;
+        match execute(&unrolled, &[]) {
+            Value::Int(v) => assert_eq!(v.to_i64(), 28),
+            other => panic!("expected int, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vector_ops_nest_in_function() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let vec_ty = VectorType::fixed(&context, i32_ty, 8);
+
+        let p0 = context.create_value(vec_ty, None);
+        let p1 = context.create_value(vec_ty, None);
+        let region = context.create_region();
+        let block = context.create_block(vec![p0.clone(), p1.clone()]);
+        region.add_block(block.id());
+
+        let func = builtin_ops::func(&context, "vadd", vec_ty, Some(region.id())).build();
+
+        let mut builder = IRBuilder::new(func.body());
+        let add = builder
+            .insert(ops::add(&context, p0.id(), p1.id(), tir::Operand::none(), vec_ty).build());
+        builder.insert(builtin_ops::r#return(&context, add.result()).build());
+
+        assert!(func.verify(&context).is_ok());
+
+        let mut buf = String::new();
+        let mut fmt = IRFormatter::new(&mut buf);
+        func.print(&mut fmt).expect("print ok");
+
+        let new_context = Context::with_default_dialects();
+        let new_func = parse_ir::<FuncOp>(&new_context, &buf).expect("parse func");
+        let mut new_buf = String::new();
+        let mut fmt = IRFormatter::new(&mut new_buf);
+        new_func.print(&mut fmt).expect("print ok");
+        assert_eq!(buf, new_buf);
+    }
+}

--- a/core/src/dialects/vector/mod.rs
+++ b/core/src/dialects/vector/mod.rs
@@ -130,7 +130,7 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
-        sem: "(set result (map vlen (add (lane lhs indvar) (lane rhs indvar))))",
+        sem: "(set result (concat (map (zip (split lhs $get_vlen) (split rhs $get_vlen)) (lambda (a b) (add a b)))))",
     }
 }
 
@@ -146,7 +146,7 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
-        sem: "(set result (map vlen (sub (lane lhs indvar) (lane rhs indvar))))",
+        sem: "(set result (concat (map (zip (split lhs $get_vlen) (split rhs $get_vlen)) (lambda (a b) (sub a b)))))",
     }
 }
 
@@ -162,312 +162,54 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
-        sem: "(set result (map vlen (mul (lane lhs indvar) (lane rhs indvar))))",
+        sem: "(set result (concat (map (zip (split lhs $get_vlen) (split rhs $get_vlen)) (lambda (a b) (mul a b)))))",
     }
 }
 
-// A test-only operation exercising the `operation!` macro's `(loop ...)` sem
-// construct: `sum_to n` folds `acc + indvar` over `[0, n)`, i.e. the sum
-// `0 + 1 + ... + (n - 1)`.
-#[cfg(test)]
-operation! {
-    SumToOp {
-        name: "sum_to",
-        dialect: "vector",
-        operands: O {
-            n: "crate::builtin::IntegerType",
-        },
-        results: R {
-            result: "crate::builtin::IntegerType",
-        },
-        sem: "(set result (loop 0 n 0 (add acc indvar)))",
-    }
-}
-
-// A constant-bound variant: `sum_eight` folds `acc + indvar` over `[0, 8)` with
-// the bound written as a literal, so the lowered `Loop` unrolls to a constant.
-#[cfg(test)]
-operation! {
-    SumEightOp {
-        name: "sum_eight",
-        dialect: "vector",
-        results: R {
-            result: "crate::builtin::IntegerType",
-        },
-        sem: "(set result (loop 0 8 0 (add acc indvar)))",
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        IRBuilder, IRFormatter, Operation, ValueId,
-        builtin::{FuncOp, IndexType, IntegerType, ops as builtin_ops},
-        parse::ir::parse_ir,
-    };
-
-    /// A value that verifies as a block argument, like a function parameter.
-    fn block_arg(context: &Context, ty: TypeId) -> ValueId {
-        let value = context.create_value(ty, None);
-        let id = value.id();
-        let _block = context.create_block(vec![value]);
-        id
-    }
-
-    #[test]
-    fn static_and_dynamic_vector_roundtrip() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-
-        let fixed = VectorType::fixed(&context, i32_ty, 8);
-        assert_eq!(context.type_to_string(fixed), "!vector.vec<8xi32>");
-
-        let dynamic = VectorType::dynamic(&context, i32_ty);
-        assert_eq!(context.type_to_string(dynamic), "!vector.vec<i32>");
-
-        // A static vector remembers its lane count and element.
-        let data = context.get_type_data(fixed);
-        let vec = (data.as_ref() as &dyn Any)
+/// The active lane count for `$get_vlen` in the elementwise ops' semantics: the
+/// dynamic `vl` operand (index 2) when present, otherwise the static lane count
+/// of the result vector type as a constant. This is the `n` each `split` cuts the
+/// operand bits into.
+fn vlen_node(
+    op: &tir::OpInstance,
+    g: &mut impl tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>,
+) -> tir::graph::NodeId {
+    if op.operands.len() > 2 {
+        let n = g.add_node(tir::sem_expr::ExprKind::Symbol);
+        g.set_leaf_data(n, tir::sem_expr::ExprPayload::SymbolId(2));
+        n
+    } else {
+        let context = op.context.upgrade();
+        let ty = context.get_value(op.results[0]).ty();
+        let length = (context.get_type_data(ty).as_ref() as &dyn Any)
             .downcast_ref::<VectorType>()
-            .unwrap();
-        assert_eq!(vec.length(), Some(8));
-        assert_eq!(vec.element(&context), i32_ty);
-
-        // Static and dynamic vectors are distinct; identical ones are interned.
-        assert_ne!(fixed, dynamic);
-        assert_eq!(VectorType::fixed(&context, i32_ty, 8), fixed);
-        assert_ne!(VectorType::fixed(&context, i32_ty, 4), fixed);
-    }
-
-    fn parse_type_text(context: &Context, src: &str) -> TypeId {
-        let mut parser = tir::parse::text::Parser::new(src);
-        parser
-            .parse_type(context)
-            .expect("type parses")
-            .expect("type present")
-    }
-
-    #[test]
-    fn vector_type_parses_from_text() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        assert_eq!(
-            parse_type_text(&context, "!vector.vec<8xi32>"),
-            VectorType::fixed(&context, i32_ty, 8)
+            .and_then(|t| t.length())
+            .unwrap_or(0) as u64;
+        let n = g.add_node(tir::sem_expr::ExprKind::Constant);
+        g.set_leaf_data(
+            n,
+            tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, length)),
         );
-        assert_eq!(
-            parse_type_text(&context, "!vector.vec<i32>"),
-            VectorType::dynamic(&context, i32_ty)
-        );
-    }
-
-    #[test]
-    fn add_without_vl_roundtrips() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let vec_ty = VectorType::fixed(&context, i32_ty, 8);
-        let lhs = block_arg(&context, vec_ty);
-        let rhs = block_arg(&context, vec_ty);
-
-        let op = ops::add(&context, lhs, rhs, tir::Operand::none(), vec_ty).build();
-        assert_eq!(op.operands().len(), 2);
-        assert!(op.verify(&context).is_ok());
-
-        let mut buf = String::new();
-        let mut fmt = IRFormatter::new(&mut buf);
-        op.print(&mut fmt).expect("print ok");
-        assert!(buf.contains("vector.add"));
-        assert!(buf.contains("!vector.vec<8xi32>"));
-
-        let parsed = parse_ir::<AddOp>(&context, &buf).expect("parse vector.add");
-        assert!(parsed.verify(&context).is_ok());
-        assert_eq!(parsed.operands().len(), 2);
-    }
-
-    #[test]
-    fn add_with_vl_roundtrips() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let vec_ty = VectorType::dynamic(&context, i32_ty);
-        let lhs = block_arg(&context, vec_ty);
-        let rhs = block_arg(&context, vec_ty);
-        let vl = block_arg(&context, IndexType::new(&context));
-
-        let op = ops::sub(&context, lhs, rhs, vl, vec_ty).build();
-        assert_eq!(op.operands().len(), 3);
-        assert!(op.verify(&context).is_ok());
-
-        let mut buf = String::new();
-        let mut fmt = IRFormatter::new(&mut buf);
-        op.print(&mut fmt).expect("print ok");
-
-        let parsed = parse_ir::<SubOp>(&context, &buf).expect("parse vector.sub");
-        assert!(parsed.verify(&context).is_ok());
-        assert_eq!(parsed.operands().len(), 3);
-    }
-
-    #[test]
-    fn mul_rejects_scalar_operand() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let vec_ty = VectorType::fixed(&context, i32_ty, 4);
-        let lhs = block_arg(&context, vec_ty);
-        let scalar = block_arg(&context, i32_ty);
-
-        let op = ops::mul(&context, lhs, scalar, tir::Operand::none(), vec_ty).build();
-        let err = op.verify(&context).expect_err("rhs must be a vector");
-        assert!(err.to_string().contains("expected constraint"));
-    }
-
-    #[test]
-    fn loop_sem_folds_over_induction_range() {
-        use crate::graph::Dag;
-        use crate::sem_expr::{AsSemExpr, ExprKind, ExprPostGraph, Value, execute, unroll_loops};
-        use crate::utils::APInt;
-
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let n = context.create_value(i32_ty, None);
-        let op = sum_to(&context, n.id(), i32_ty).build();
-
-        let mut g = ExprPostGraph::new();
-        let root = op.convert(&mut g);
-        assert_eq!(g.get_kind(root), &ExprKind::Loop);
-
-        // 0 + 1 + 2 + 3 + 4 = 10 for n = 5.
-        let result = execute(&g, &[Value::Int(APInt::new_signed(32, 5))]);
-        match result {
-            Value::Int(v) => assert_eq!(v.to_i64(), 10),
-            other => panic!("expected int, got {other:?}"),
-        }
-
-        // A literal bound lets the lowered Loop unroll away entirely, leaving the
-        // constant 0 + 1 + ... + 7 = 28.
-        let const_op = sum_eight(&context, i32_ty).build();
-        let mut cg = ExprPostGraph::new();
-        let croot = const_op.convert(&mut cg);
-        let (unrolled, new_root) = unroll_loops(&cg, croot);
-        for idx in 0..unrolled.len() {
-            let kind = *unrolled.get_node(crate::graph::NodeId::from_index(idx));
-            assert!(!matches!(
-                kind,
-                ExprKind::Loop | ExprKind::IndVar | ExprKind::Acc
-            ));
-        }
-        let _ = new_root;
-        match execute(&unrolled, &[]) {
-            Value::Int(v) => assert_eq!(v.to_i64(), 28),
-            other => panic!("expected int, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vector_add_sem_is_a_lanewise_map() {
-        use crate::graph::{Dag, MutDag, NodeId};
-        use crate::sem_expr::{AsSemExpr, ExprKind, ExprPayload, ExprPostGraph, Value, execute};
-        use crate::utils::APInt;
-
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let vec_ty = VectorType::fixed(&context, i32_ty, 4);
-        let lhs = context.create_value(vec_ty, None);
-        let rhs = context.create_value(vec_ty, None);
-        let op = ops::add(&context, lhs.id(), rhs.id(), tir::Operand::none(), vec_ty).build();
-
-        // The op lowers to `(map 4 (add (lane s0 i) (lane s1 i)))`.
-        let mut g = ExprPostGraph::new();
-        let root = op.convert(&mut g);
-        assert_eq!(g.get_kind(root), &ExprKind::VectorMap);
-        let count = g.children(root).next().unwrap();
-        assert!(matches!(
-            g.get_leaf_data(count),
-            Some(ExprPayload::Int(v)) if v.to_i64() == 4
-        ));
-
-        let lanes = |xs: [i64; 4]| {
-            Value::Iterator(
-                xs.iter()
-                    .map(|&x| Value::Int(APInt::new_signed(32, x)))
-                    .collect(),
-            )
-        };
-        let a = lanes([1, 2, 3, 4]);
-        let b = lanes([10, 20, 30, 40]);
-        let Value::Iterator(out) = execute(&g, &[a.clone(), b.clone()]) else {
-            panic!("vector op must produce a vector");
-        };
-        let out: Vec<i64> = out
-            .iter()
-            .map(|v| match v {
-                Value::Int(i) => i.to_i64(),
-                other => panic!("lane must be an int, got {other:?}"),
-            })
-            .collect();
-        assert_eq!(out, vec![11, 22, 33, 44]);
-
-        // The premise behind instruction selection: a target instruction that
-        // independently lowers to the same map/lane DAG computes the same result,
-        // so it can match this op. Build that DAG by hand and compare.
-        let mut t = ExprPostGraph::new();
-        let s0 = t.add_node(ExprKind::Symbol);
-        t.set_leaf_data(s0, ExprPayload::SymbolId(0));
-        let s1 = t.add_node(ExprKind::Symbol);
-        t.set_leaf_data(s1, ExprPayload::SymbolId(1));
-        let count = t.add_node(ExprKind::Constant);
-        t.set_leaf_data(count, ExprPayload::Int(APInt::new(32, 4)));
-        let iv0 = t.add_node(ExprKind::IndVar);
-        let l0 = t.add_node(ExprKind::Lane);
-        t.add_edge(l0, s0);
-        t.add_edge(l0, iv0);
-        let iv1 = t.add_node(ExprKind::IndVar);
-        let l1 = t.add_node(ExprKind::Lane);
-        t.add_edge(l1, s1);
-        t.add_edge(l1, iv1);
-        let add = t.add_node(ExprKind::Add);
-        t.add_edge(add, l0);
-        t.add_edge(add, l1);
-        let map = t.add_node(ExprKind::VectorMap);
-        t.add_edge(map, count);
-        t.add_edge(map, add);
-        let _ = NodeId::from_index(0);
-
-        assert_eq!(
-            execute(&t, &[a, b]),
-            execute(&g, &[lanes([1, 2, 3, 4]), lanes([10, 20, 30, 40])])
-        );
-    }
-
-    #[test]
-    fn vector_ops_nest_in_function() {
-        let context = Context::with_default_dialects();
-        let i32_ty = IntegerType::new(&context, 32);
-        let vec_ty = VectorType::fixed(&context, i32_ty, 8);
-
-        let p0 = context.create_value(vec_ty, None);
-        let p1 = context.create_value(vec_ty, None);
-        let region = context.create_region();
-        let block = context.create_block(vec![p0.clone(), p1.clone()]);
-        region.add_block(block.id());
-
-        let func = builtin_ops::func(&context, "vadd", vec_ty, Some(region.id())).build();
-
-        let mut builder = IRBuilder::new(func.body());
-        let add = builder
-            .insert(ops::add(&context, p0.id(), p1.id(), tir::Operand::none(), vec_ty).build());
-        builder.insert(builtin_ops::r#return(&context, add.result()).build());
-
-        assert!(func.verify(&context).is_ok());
-
-        let mut buf = String::new();
-        let mut fmt = IRFormatter::new(&mut buf);
-        func.print(&mut fmt).expect("print ok");
-
-        let new_context = Context::with_default_dialects();
-        let new_func = parse_ir::<FuncOp>(&new_context, &buf).expect("parse func");
-        let mut new_buf = String::new();
-        let mut fmt = IRFormatter::new(&mut new_buf);
-        new_func.print(&mut fmt).expect("print ok");
-        assert_eq!(buf, new_buf);
+        n
     }
 }
+
+macro_rules! impl_get_vlen {
+    ($op:ty) => {
+        impl $op {
+            fn get_vlen(
+                &self,
+                g: &mut impl tir::graph::MutDag<
+                    Node = tir::sem_expr::ExprKind,
+                    Leaf = tir::sem_expr::ExprPayload,
+                >,
+            ) -> tir::graph::NodeId {
+                vlen_node(&self.0, g)
+            }
+        }
+    };
+}
+
+impl_get_vlen!(AddOp);
+impl_get_vlen!(SubOp);
+impl_get_vlen!(MulOp);

--- a/core/src/dialects/vector/mod.rs
+++ b/core/src/dialects/vector/mod.rs
@@ -130,6 +130,7 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
+        sem: "(set result (map vlen (add (lane lhs indvar) (lane rhs indvar))))",
     }
 }
 
@@ -145,6 +146,7 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
+        sem: "(set result (map vlen (sub (lane lhs indvar) (lane rhs indvar))))",
     }
 }
 
@@ -160,6 +162,7 @@ operation! {
         results: R {
             result: "crate::vector::VectorType",
         },
+        sem: "(set result (map vlen (mul (lane lhs indvar) (lane rhs indvar))))",
     }
 }
 
@@ -357,6 +360,82 @@ mod tests {
             Value::Int(v) => assert_eq!(v.to_i64(), 28),
             other => panic!("expected int, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn vector_add_sem_is_a_lanewise_map() {
+        use crate::graph::{Dag, MutDag, NodeId};
+        use crate::sem_expr::{AsSemExpr, ExprKind, ExprPayload, ExprPostGraph, Value, execute};
+        use crate::utils::APInt;
+
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let vec_ty = VectorType::fixed(&context, i32_ty, 4);
+        let lhs = context.create_value(vec_ty, None);
+        let rhs = context.create_value(vec_ty, None);
+        let op = ops::add(&context, lhs.id(), rhs.id(), tir::Operand::none(), vec_ty).build();
+
+        // The op lowers to `(map 4 (add (lane s0 i) (lane s1 i)))`.
+        let mut g = ExprPostGraph::new();
+        let root = op.convert(&mut g);
+        assert_eq!(g.get_kind(root), &ExprKind::VectorMap);
+        let count = g.children(root).next().unwrap();
+        assert!(matches!(
+            g.get_leaf_data(count),
+            Some(ExprPayload::Int(v)) if v.to_i64() == 4
+        ));
+
+        let lanes = |xs: [i64; 4]| {
+            Value::Vector(
+                xs.iter()
+                    .map(|&x| Value::Int(APInt::new_signed(32, x)))
+                    .collect(),
+            )
+        };
+        let a = lanes([1, 2, 3, 4]);
+        let b = lanes([10, 20, 30, 40]);
+        let Value::Vector(out) = execute(&g, &[a.clone(), b.clone()]) else {
+            panic!("vector op must produce a vector");
+        };
+        let out: Vec<i64> = out
+            .iter()
+            .map(|v| match v {
+                Value::Int(i) => i.to_i64(),
+                other => panic!("lane must be an int, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(out, vec![11, 22, 33, 44]);
+
+        // The premise behind instruction selection: a target instruction that
+        // independently lowers to the same map/lane DAG computes the same result,
+        // so it can match this op. Build that DAG by hand and compare.
+        let mut t = ExprPostGraph::new();
+        let s0 = t.add_node(ExprKind::Symbol);
+        t.set_leaf_data(s0, ExprPayload::SymbolId(0));
+        let s1 = t.add_node(ExprKind::Symbol);
+        t.set_leaf_data(s1, ExprPayload::SymbolId(1));
+        let count = t.add_node(ExprKind::Constant);
+        t.set_leaf_data(count, ExprPayload::Int(APInt::new(32, 4)));
+        let iv0 = t.add_node(ExprKind::IndVar);
+        let l0 = t.add_node(ExprKind::Lane);
+        t.add_edge(l0, s0);
+        t.add_edge(l0, iv0);
+        let iv1 = t.add_node(ExprKind::IndVar);
+        let l1 = t.add_node(ExprKind::Lane);
+        t.add_edge(l1, s1);
+        t.add_edge(l1, iv1);
+        let add = t.add_node(ExprKind::Add);
+        t.add_edge(add, l0);
+        t.add_edge(add, l1);
+        let map = t.add_node(ExprKind::VectorMap);
+        t.add_edge(map, count);
+        t.add_edge(map, add);
+        let _ = NodeId::from_index(0);
+
+        assert_eq!(
+            execute(&t, &[a, b]),
+            execute(&g, &[lanes([1, 2, 3, 4]), lanes([10, 20, 30, 40])])
+        );
     }
 
     #[test]

--- a/core/src/dialects/vector/mod.rs
+++ b/core/src/dialects/vector/mod.rs
@@ -386,7 +386,7 @@ mod tests {
         ));
 
         let lanes = |xs: [i64; 4]| {
-            Value::Vector(
+            Value::Iterator(
                 xs.iter()
                     .map(|&x| Value::Int(APInt::new_signed(32, x)))
                     .collect(),
@@ -394,7 +394,7 @@ mod tests {
         };
         let a = lanes([1, 2, 3, 4]);
         let b = lanes([10, 20, 30, 40]);
-        let Value::Vector(out) = execute(&g, &[a.clone(), b.clone()]) else {
+        let Value::Iterator(out) = execute(&g, &[a.clone(), b.clone()]) else {
             panic!("vector op must produce a vector");
         };
         let out: Vec<i64> = out

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -63,5 +63,6 @@ pub use dialects::builtin;
 pub use dialects::builtin::Integer;
 pub use dialects::ptr;
 pub use dialects::scf;
+pub use dialects::vector;
 
 pub use tir_macros::{dialect, operation};

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -83,6 +83,7 @@ macro_rules! as_int {
             Value::Int(i) => i,
             Value::Float(_) => panic!("{} requires integer operands", $op),
             Value::Iterator(_) => panic!("{} requires scalar operands", $op),
+            Value::RawBits(_) => panic!("{} requires integer operands", $op),
         }
     };
 }
@@ -93,6 +94,7 @@ macro_rules! as_float {
             Value::Float(f) => f,
             Value::Int(_) => panic!("{} requires float operands", $op),
             Value::Iterator(_) => panic!("{} requires scalar operands", $op),
+            Value::RawBits(_) => panic!("{} requires float operands", $op),
         }
     };
 }
@@ -272,7 +274,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.add(&b))
             }
             Value::Float(a) => Value::Float(a.add(&as_float!(c(1), "add"))),
-            Value::Iterator(_) => panic!("add requires scalar operands"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("add requires scalar operands"),
         },
         ExprKind::Sub => match c(0) {
             Value::Int(a) => {
@@ -280,7 +282,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sub(&b))
             }
             Value::Float(a) => Value::Float(a.sub(&as_float!(c(1), "sub"))),
-            Value::Iterator(_) => panic!("sub requires scalar operands"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("sub requires scalar operands"),
         },
         ExprKind::Mul => match c(0) {
             Value::Int(a) => {
@@ -288,7 +290,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.mul(&b))
             }
             Value::Float(a) => Value::Float(a.mul(&as_float!(c(1), "mul"))),
-            Value::Iterator(_) => panic!("mul requires scalar operands"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("mul requires scalar operands"),
         },
         ExprKind::Div => match c(0) {
             Value::Int(a) => {
@@ -296,7 +298,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sdiv(&b))
             }
             Value::Float(a) => Value::Float(a.div(&as_float!(c(1), "div"))),
-            Value::Iterator(_) => panic!("div requires scalar operands"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("div requires scalar operands"),
         },
         ExprKind::UDiv => {
             let (a, b) = coerce_ints(as_int!(c(0), "udiv"), as_int!(c(1), "udiv"));
@@ -356,7 +358,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.slt(&b))
                 }
                 Value::Float(a) => bool_result(a.lt(&as_float!(c(1), "lt"))),
-                Value::Iterator(_) => panic!("lt requires scalar operands"),
+                Value::Iterator(_) | Value::RawBits(_) => panic!("lt requires scalar operands"),
             },
         )),
         ExprKind::Gt => Value::Int(APInt::new(
@@ -367,7 +369,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sgt(&b))
                 }
                 Value::Float(a) => bool_result(a.gt(&as_float!(c(1), "gt"))),
-                Value::Iterator(_) => panic!("gt requires scalar operands"),
+                Value::Iterator(_) | Value::RawBits(_) => panic!("gt requires scalar operands"),
             },
         )),
         ExprKind::Ge => Value::Int(APInt::new(
@@ -378,7 +380,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sge(&b))
                 }
                 Value::Float(a) => bool_result(a.ge(&as_float!(c(1), "ge"))),
-                Value::Iterator(_) => panic!("ge requires scalar operands"),
+                Value::Iterator(_) | Value::RawBits(_) => panic!("ge requires scalar operands"),
             },
         )),
         ExprKind::ULt => {
@@ -403,7 +405,7 @@ fn eval_node<M: Memory>(
             let cond_zero = match c(0) {
                 Value::Int(i) => i.is_zero(),
                 Value::Float(f) => f.is_zero(),
-                Value::Iterator(_) => panic!("if condition must be scalar"),
+                Value::Iterator(_) | Value::RawBits(_) => panic!("if condition must be scalar"),
             };
             if cond_zero { c(2) } else { c(1) }
         }
@@ -441,7 +443,7 @@ fn eval_node<M: Memory>(
             Value::Float(a) => {
                 Value::Float(a.fma(&as_float!(c(1), "fma"), &as_float!(c(2), "fma")))
             }
-            Value::Iterator(_) => panic!("fma requires scalar operands"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("fma requires scalar operands"),
         },
         ExprKind::Sqrt => match c(0) {
             Value::Int(a) => {
@@ -449,7 +451,7 @@ fn eval_node<M: Memory>(
                 Value::Int(APInt::new(a.width(), (v as f64).sqrt() as u64))
             }
             Value::Float(a) => Value::Float(a.sqrt()),
-            Value::Iterator(_) => panic!("sqrt requires a scalar operand"),
+            Value::Iterator(_) | Value::RawBits(_) => panic!("sqrt requires a scalar operand"),
         },
         ExprKind::Log2Ceil => {
             let a = as_int!(c(0), "log2ceil");

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -82,7 +82,7 @@ macro_rules! as_int {
         match $v {
             Value::Int(i) => i,
             Value::Float(_) => panic!("{} requires integer operands", $op),
-            Value::Vector(_) => panic!("{} requires scalar operands", $op),
+            Value::Iterator(_) => panic!("{} requires scalar operands", $op),
         }
     };
 }
@@ -92,7 +92,7 @@ macro_rules! as_float {
         match $v {
             Value::Float(f) => f,
             Value::Int(_) => panic!("{} requires float operands", $op),
-            Value::Vector(_) => panic!("{} requires scalar operands", $op),
+            Value::Iterator(_) => panic!("{} requires scalar operands", $op),
         }
     };
 }
@@ -190,7 +190,7 @@ fn eval_vector_map<M: Memory>(
         frames.pop();
         lanes.push(lane?);
     }
-    Ok(Value::Vector(lanes))
+    Ok(Value::Iterator(lanes))
 }
 
 fn eval_node<M: Memory>(
@@ -247,7 +247,7 @@ fn eval_node<M: Memory>(
             unreachable!("VectorMap handled before child pre-evaluation")
         }
         ExprKind::Lane => {
-            let Value::Vector(lanes) = c(0) else {
+            let Value::Iterator(lanes) = c(0) else {
                 panic!("Lane requires a vector operand");
             };
             let index = as_int!(c(1), "lane").to_u64() as usize;
@@ -272,7 +272,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.add(&b))
             }
             Value::Float(a) => Value::Float(a.add(&as_float!(c(1), "add"))),
-            Value::Vector(_) => panic!("add requires scalar operands"),
+            Value::Iterator(_) => panic!("add requires scalar operands"),
         },
         ExprKind::Sub => match c(0) {
             Value::Int(a) => {
@@ -280,7 +280,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sub(&b))
             }
             Value::Float(a) => Value::Float(a.sub(&as_float!(c(1), "sub"))),
-            Value::Vector(_) => panic!("sub requires scalar operands"),
+            Value::Iterator(_) => panic!("sub requires scalar operands"),
         },
         ExprKind::Mul => match c(0) {
             Value::Int(a) => {
@@ -288,7 +288,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.mul(&b))
             }
             Value::Float(a) => Value::Float(a.mul(&as_float!(c(1), "mul"))),
-            Value::Vector(_) => panic!("mul requires scalar operands"),
+            Value::Iterator(_) => panic!("mul requires scalar operands"),
         },
         ExprKind::Div => match c(0) {
             Value::Int(a) => {
@@ -296,7 +296,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sdiv(&b))
             }
             Value::Float(a) => Value::Float(a.div(&as_float!(c(1), "div"))),
-            Value::Vector(_) => panic!("div requires scalar operands"),
+            Value::Iterator(_) => panic!("div requires scalar operands"),
         },
         ExprKind::UDiv => {
             let (a, b) = coerce_ints(as_int!(c(0), "udiv"), as_int!(c(1), "udiv"));
@@ -356,7 +356,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.slt(&b))
                 }
                 Value::Float(a) => bool_result(a.lt(&as_float!(c(1), "lt"))),
-                Value::Vector(_) => panic!("lt requires scalar operands"),
+                Value::Iterator(_) => panic!("lt requires scalar operands"),
             },
         )),
         ExprKind::Gt => Value::Int(APInt::new(
@@ -367,7 +367,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sgt(&b))
                 }
                 Value::Float(a) => bool_result(a.gt(&as_float!(c(1), "gt"))),
-                Value::Vector(_) => panic!("gt requires scalar operands"),
+                Value::Iterator(_) => panic!("gt requires scalar operands"),
             },
         )),
         ExprKind::Ge => Value::Int(APInt::new(
@@ -378,7 +378,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sge(&b))
                 }
                 Value::Float(a) => bool_result(a.ge(&as_float!(c(1), "ge"))),
-                Value::Vector(_) => panic!("ge requires scalar operands"),
+                Value::Iterator(_) => panic!("ge requires scalar operands"),
             },
         )),
         ExprKind::ULt => {
@@ -403,7 +403,7 @@ fn eval_node<M: Memory>(
             let cond_zero = match c(0) {
                 Value::Int(i) => i.is_zero(),
                 Value::Float(f) => f.is_zero(),
-                Value::Vector(_) => panic!("if condition must be scalar"),
+                Value::Iterator(_) => panic!("if condition must be scalar"),
             };
             if cond_zero { c(2) } else { c(1) }
         }
@@ -441,7 +441,7 @@ fn eval_node<M: Memory>(
             Value::Float(a) => {
                 Value::Float(a.fma(&as_float!(c(1), "fma"), &as_float!(c(2), "fma")))
             }
-            Value::Vector(_) => panic!("fma requires scalar operands"),
+            Value::Iterator(_) => panic!("fma requires scalar operands"),
         },
         ExprKind::Sqrt => match c(0) {
             Value::Int(a) => {
@@ -449,7 +449,7 @@ fn eval_node<M: Memory>(
                 Value::Int(APInt::new(a.width(), (v as f64).sqrt() as u64))
             }
             Value::Float(a) => Value::Float(a.sqrt()),
-            Value::Vector(_) => panic!("sqrt requires a scalar operand"),
+            Value::Iterator(_) => panic!("sqrt requires a scalar operand"),
         },
         ExprKind::Log2Ceil => {
             let a = as_int!(c(0), "log2ceil");
@@ -510,6 +510,8 @@ fn eval_node<M: Memory>(
             memory.write_memory(address, size, value)?;
             Value::Int(APInt::new(1, 0))
         }
+
+        ExprKind::Map | ExprKind::IterConcat | ExprKind::Zip => todo!(),
     };
 
     cache[node.index()] = Some(result.clone());
@@ -526,7 +528,7 @@ impl PartialEq for Value {
         match (self, other) {
             (Value::Int(a), Value::Int(b)) => a == b,
             (Value::Float(a), Value::Float(b)) => a == b,
-            (Value::Vector(a), Value::Vector(b)) => a == b,
+            (Value::Iterator(a), Value::Iterator(b)) => a == b,
             _ => false,
         }
     }

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -1,7 +1,7 @@
 use crate::{
     graph::{Dag, NodeId},
     sem_expr::{ExprKind, ExprPayload, Value},
-    utils::APInt,
+    utils::{APInt, RawBits},
 };
 
 /// Memory backend used by semantic expressions containing `LoadMemory` or
@@ -58,7 +58,16 @@ pub fn execute_with_memory<M: Memory>(
     let root = graph.root().expect("cannot execute empty graph");
     let mut cache = vec![None::<Value>; graph.len()];
     let mut frames: Vec<(Value, Value)> = Vec::new();
-    eval_node(graph, root, symbols, &mut cache, &mut frames, memory)
+    let mut args: Vec<Value> = Vec::new();
+    eval_node(
+        graph,
+        root,
+        symbols,
+        &mut cache,
+        &mut frames,
+        &mut args,
+        memory,
+    )
 }
 
 fn child_val(
@@ -137,14 +146,15 @@ fn eval_loop<M: Memory>(
     symbols: &[Value],
     cache: &mut Vec<Option<Value>>,
     frames: &mut Vec<(Value, Value)>,
+    args: &mut Vec<Value>,
     memory: &mut M,
 ) -> Result<Value, M::Error> {
     let children: Vec<NodeId> = graph.children(node).collect();
     let (start_n, end_n, init_n, step_n) = (children[0], children[1], children[2], children[3]);
 
-    let start = eval_node(graph, start_n, symbols, cache, frames, memory)?;
-    let end = eval_node(graph, end_n, symbols, cache, frames, memory)?;
-    let mut acc = eval_node(graph, init_n, symbols, cache, frames, memory)?;
+    let start = eval_node(graph, start_n, symbols, cache, frames, args, memory)?;
+    let end = eval_node(graph, end_n, symbols, cache, frames, args, memory)?;
+    let mut acc = eval_node(graph, init_n, symbols, cache, frames, args, memory)?;
 
     let start = as_int!(start, "loop bound").to_i64();
     let end = as_int!(end, "loop bound").to_i64();
@@ -154,8 +164,96 @@ fn eval_loop<M: Memory>(
         // `step` depends on the induction/accumulator values, which change each
         // iteration, so it cannot share the surrounding cache: evaluate it fresh.
         let mut step_cache = vec![None::<Value>; graph.len()];
-        let next = eval_node(graph, step_n, symbols, &mut step_cache, frames, memory);
+        let next = eval_node(
+            graph,
+            step_n,
+            symbols,
+            &mut step_cache,
+            frames,
+            args,
+            memory,
+        );
         frames.pop();
+        acc = next?;
+    }
+    Ok(acc)
+}
+
+/// Evaluate a `Map` node: apply `body` to each lane of `iter`, exposing the lane
+/// (or its components, for a zipped pair) through the lambda-argument stack.
+fn eval_map<M: Memory>(
+    graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
+    node: NodeId,
+    symbols: &[Value],
+    cache: &mut Vec<Option<Value>>,
+    frames: &mut Vec<(Value, Value)>,
+    args: &mut Vec<Value>,
+    memory: &mut M,
+) -> Result<Value, M::Error> {
+    let children: Vec<NodeId> = graph.children(node).collect();
+    let (iter_n, body_n) = (children[0], children[1]);
+
+    let iter = eval_node(graph, iter_n, symbols, cache, frames, args, memory)?;
+    let Value::Iterator(elems) = iter else {
+        panic!("map requires an iterator operand");
+    };
+
+    let mut out = Vec::with_capacity(elems.len());
+    for elem in elems {
+        args.push(elem);
+        // `body` reads the per-lane argument, which changes each lane, so it
+        // cannot share the surrounding cache: evaluate it fresh.
+        let mut body_cache = vec![None::<Value>; graph.len()];
+        let lane = eval_node(
+            graph,
+            body_n,
+            symbols,
+            &mut body_cache,
+            frames,
+            args,
+            memory,
+        );
+        args.pop();
+        out.push(lane?);
+    }
+    Ok(Value::Iterator(out))
+}
+
+/// Evaluate a `Reduce` node: left-fold `body` over the lanes of `iter`, binding
+/// `Arg(0)` to the accumulator and `Arg(1)` to the current lane.
+fn eval_reduce<M: Memory>(
+    graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
+    node: NodeId,
+    symbols: &[Value],
+    cache: &mut Vec<Option<Value>>,
+    frames: &mut Vec<(Value, Value)>,
+    args: &mut Vec<Value>,
+    memory: &mut M,
+) -> Result<Value, M::Error> {
+    let children: Vec<NodeId> = graph.children(node).collect();
+    let (iter_n, body_n) = (children[0], children[1]);
+
+    let iter = eval_node(graph, iter_n, symbols, cache, frames, args, memory)?;
+    let Value::Iterator(elems) = iter else {
+        panic!("reduce requires an iterator operand");
+    };
+    let mut elems = elems.into_iter();
+    let mut acc = elems.next().expect("reduce requires a non-empty iterator");
+    for elem in elems {
+        // The accumulator and lane are read via `Arg(0)`/`Arg(1)`, packed as a
+        // two-element binding on the argument stack.
+        args.push(Value::Iterator(vec![acc, elem]));
+        let mut body_cache = vec![None::<Value>; graph.len()];
+        let next = eval_node(
+            graph,
+            body_n,
+            symbols,
+            &mut body_cache,
+            frames,
+            args,
+            memory,
+        );
+        args.pop();
         acc = next?;
     }
     Ok(acc)
@@ -170,12 +268,13 @@ fn eval_vector_map<M: Memory>(
     symbols: &[Value],
     cache: &mut Vec<Option<Value>>,
     frames: &mut Vec<(Value, Value)>,
+    args: &mut Vec<Value>,
     memory: &mut M,
 ) -> Result<Value, M::Error> {
     let children: Vec<NodeId> = graph.children(node).collect();
     let (count_n, elem_n) = (children[0], children[1]);
 
-    let count = eval_node(graph, count_n, symbols, cache, frames, memory)?;
+    let count = eval_node(graph, count_n, symbols, cache, frames, args, memory)?;
     let count = as_int!(count, "vector length").to_i64();
 
     let mut lanes = Vec::with_capacity(count.max(0) as usize);
@@ -188,11 +287,54 @@ fn eval_vector_map<M: Memory>(
             Value::Int(APInt::new(1, 0)),
         ));
         let mut lane_cache = vec![None::<Value>; graph.len()];
-        let lane = eval_node(graph, elem_n, symbols, &mut lane_cache, frames, memory);
+        let lane = eval_node(
+            graph,
+            elem_n,
+            symbols,
+            &mut lane_cache,
+            frames,
+            args,
+            memory,
+        );
         frames.pop();
         lanes.push(lane?);
     }
     Ok(Value::Iterator(lanes))
+}
+
+/// Evaluate a `Split` node: cut a raw-bits value into `n` equal-width lanes, lane
+/// 0 from the low bits. Each lane is reinterpreted as an integer — the only
+/// element kind the behavior language currently produces; float lanes would read
+/// the raw lanes with [`RawBits::to_apfloat`] instead.
+fn split_bits(value: Value, n: usize) -> Value {
+    let Value::RawBits(bits) = value else {
+        panic!("split requires a raw-bits operand");
+    };
+    let lanes = bits
+        .split(n)
+        .into_iter()
+        .map(|lane| Value::Int(lane.to_apint()))
+        .collect();
+    Value::Iterator(lanes)
+}
+
+/// Evaluate an `IterConcat` node: join an iterator's lanes into one raw-bits
+/// value, lane 0 in the low bits. The inverse of `Split`; each lane is taken back
+/// to its raw bytes according to its runtime type.
+fn concat_lanes(value: Value) -> Value {
+    let Value::Iterator(lanes) = value else {
+        panic!("concat requires an iterator operand");
+    };
+    let raw: Vec<RawBits> = lanes
+        .into_iter()
+        .map(|lane| match lane {
+            Value::Int(i) => RawBits::from_apint(&i),
+            Value::Float(f) => RawBits::from_apfloat(&f),
+            Value::RawBits(b) => b,
+            Value::Iterator(_) => panic!("concat lanes must be scalar"),
+        })
+        .collect();
+    Value::RawBits(RawBits::concat(&raw))
 }
 
 fn eval_node<M: Memory>(
@@ -201,32 +343,44 @@ fn eval_node<M: Memory>(
     symbols: &[Value],
     cache: &mut Vec<Option<Value>>,
     frames: &mut Vec<(Value, Value)>,
+    args: &mut Vec<Value>,
     memory: &mut M,
 ) -> Result<Value, M::Error> {
     if let Some(ref v) = cache[node.index()] {
         return Ok(v.clone());
     }
 
-    // A `Loop` must not have its `step` child pre-evaluated: `step` depends on the
-    // per-iteration induction/accumulator values, so it is evaluated repeatedly,
-    // by hand, below. Intercept before the generic child pre-evaluation.
-    if *graph.get_kind(node) == ExprKind::Loop {
-        let result = eval_loop(graph, node, symbols, cache, frames, memory)?;
-        cache[node.index()] = Some(result.clone());
-        return Ok(result);
-    }
-
-    // A `VectorMap`, like `Loop`, evaluates its `elem` child fresh per lane with
-    // the induction value bound, so intercept it before generic child pre-eval.
-    if *graph.get_kind(node) == ExprKind::VectorMap {
-        let result = eval_vector_map(graph, node, symbols, cache, frames, memory)?;
-        cache[node.index()] = Some(result.clone());
-        return Ok(result);
+    // `Loop`, `VectorMap`, `Map` and `Reduce` re-evaluate a child once per
+    // iteration with a fresh per-iteration binding (induction value or lambda
+    // argument), so that child must not be pre-evaluated by the generic pass.
+    // Intercept each before the generic child pre-evaluation.
+    match *graph.get_kind(node) {
+        ExprKind::Loop => {
+            let result = eval_loop(graph, node, symbols, cache, frames, args, memory)?;
+            cache[node.index()] = Some(result.clone());
+            return Ok(result);
+        }
+        ExprKind::VectorMap => {
+            let result = eval_vector_map(graph, node, symbols, cache, frames, args, memory)?;
+            cache[node.index()] = Some(result.clone());
+            return Ok(result);
+        }
+        ExprKind::Map => {
+            let result = eval_map(graph, node, symbols, cache, frames, args, memory)?;
+            cache[node.index()] = Some(result.clone());
+            return Ok(result);
+        }
+        ExprKind::Reduce => {
+            let result = eval_reduce(graph, node, symbols, cache, frames, args, memory)?;
+            cache[node.index()] = Some(result.clone());
+            return Ok(result);
+        }
+        _ => {}
     }
 
     for child_id in graph.children(node) {
         if cache[child_id.index()].is_none() {
-            let v = eval_node(graph, child_id, symbols, cache, frames, memory)?;
+            let v = eval_node(graph, child_id, symbols, cache, frames, args, memory)?;
             cache[child_id.index()] = Some(v);
         }
     }
@@ -245,9 +399,43 @@ fn eval_node<M: Memory>(
             .1
             .clone(),
         ExprKind::Loop => unreachable!("Loop handled before child pre-evaluation"),
-        ExprKind::VectorMap => {
-            unreachable!("VectorMap handled before child pre-evaluation")
+        ExprKind::VectorMap | ExprKind::Map | ExprKind::Reduce => {
+            unreachable!("map/reduce handled before child pre-evaluation")
         }
+        ExprKind::Arg => {
+            let ExprPayload::Int(idx) = graph.get_leaf_data(node).unwrap() else {
+                panic!("Arg node must have Int payload");
+            };
+            let idx = idx.to_u64() as usize;
+            let binding = args.last().expect("Arg evaluated outside a lambda");
+            match binding {
+                // A pair binding (from `Zip` lanes or a `Reduce` acc/lane pack)
+                // exposes its components positionally.
+                Value::Iterator(parts) => parts[idx].clone(),
+                // A scalar binding is the single argument of a unary lambda.
+                scalar => {
+                    assert!(idx == 0, "scalar lambda argument has only index 0");
+                    scalar.clone()
+                }
+            }
+        }
+        ExprKind::Zip => {
+            let (Value::Iterator(lhs), Value::Iterator(rhs)) = (c(0), c(1)) else {
+                panic!("zip requires iterator operands");
+            };
+            assert!(
+                lhs.len() == rhs.len(),
+                "zip requires equal-length iterators"
+            );
+            Value::Iterator(
+                lhs.into_iter()
+                    .zip(rhs)
+                    .map(|(a, b)| Value::Iterator(vec![a, b]))
+                    .collect(),
+            )
+        }
+        ExprKind::Split => split_bits(c(0), as_int!(c(1), "split").to_u64() as usize),
+        ExprKind::IterConcat => concat_lanes(c(0)),
         ExprKind::Lane => {
             let Value::Iterator(lanes) = c(0) else {
                 panic!("Lane requires a vector operand");
@@ -512,8 +700,6 @@ fn eval_node<M: Memory>(
             memory.write_memory(address, size, value)?;
             Value::Int(APInt::new(1, 0))
         }
-
-        ExprKind::Map | ExprKind::IterConcat | ExprKind::Zip => todo!(),
     };
 
     cache[node.index()] = Some(result.clone());
@@ -996,5 +1182,98 @@ mod tests {
         let b = sym(&mut g, 1);
         inner(&mut g, ExprKind::Lt, &[a, b]);
         assert_eq!(as_i64(execute(&g, &[fv(3.0), fv(2.0)])), 0);
+    }
+
+    fn arg(g: &mut ExprPostGraph, k: u64) -> NodeId {
+        let node = g.add_node(ExprKind::Arg);
+        g.set_leaf_data(node, ExprPayload::Int(APInt::new(32, k)));
+        node
+    }
+    fn rb(bytes: &[u8]) -> Value {
+        Value::RawBits(crate::utils::RawBits::from_bytes(bytes.to_vec()))
+    }
+    fn raw_bytes(v: Value) -> Vec<u8> {
+        match v {
+            Value::RawBits(b) => b.bytes().to_vec(),
+            other => panic!("expected raw bits, got {other:?}"),
+        }
+    }
+    fn int_lanes(v: Value) -> Vec<i64> {
+        match v {
+            Value::Iterator(xs) => xs.into_iter().map(as_i64).collect(),
+            other => panic!("expected iterator, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_then_concat_roundtrips_raw_bits() {
+        // split a 16-bit raw value 0xBA21 into two bytes, then concat them back.
+        let mut g = ExprPostGraph::new();
+        let bits = sym(&mut g, 0);
+        let n = int_con(&mut g, 2);
+        let split = inner(&mut g, ExprKind::Split, &[bits, n]);
+
+        // The lanes are the two bytes read as integers.
+        assert_eq!(
+            int_lanes(execute(&g, &[rb(&[0x21, 0xBA])])),
+            vec![0x21, 0xBA]
+        );
+
+        inner(&mut g, ExprKind::IterConcat, &[split]);
+        assert_eq!(
+            raw_bytes(execute(&g, &[rb(&[0x21, 0xBA])])),
+            vec![0x21, 0xBA]
+        );
+    }
+
+    #[test]
+    fn map_applies_unary_lambda_per_lane() {
+        // map(split(0x0201, 2), |x| x + 1) -> [1+1, 2+1] = [2, 3].
+        let mut g = ExprPostGraph::new();
+        let bits = sym(&mut g, 0);
+        let n = int_con(&mut g, 2);
+        let iter = inner(&mut g, ExprKind::Split, &[bits, n]);
+        let x = arg(&mut g, 0);
+        let one = int_con(&mut g, 1);
+        let body = inner(&mut g, ExprKind::Add, &[x, one]);
+        inner(&mut g, ExprKind::Map, &[iter, body]);
+
+        assert_eq!(int_lanes(execute(&g, &[rb(&[0x01, 0x02])])), vec![2, 3]);
+    }
+
+    #[test]
+    fn zip_then_map_lane_wise_add_concats() {
+        // concat(map(zip(split(a, 2), split(b, 2)), |x, y| x + y)) for
+        // a=[1,2], b=[3,4] -> lanes [4, 6] -> raw bytes [0x04, 0x06].
+        let mut g = ExprPostGraph::new();
+        let a = sym(&mut g, 0);
+        let b = sym(&mut g, 1);
+        let n = int_con(&mut g, 2);
+        let split_a = inner(&mut g, ExprKind::Split, &[a, n]);
+        let split_b = inner(&mut g, ExprKind::Split, &[b, n]);
+        let zip = inner(&mut g, ExprKind::Zip, &[split_a, split_b]);
+        let x = arg(&mut g, 0);
+        let y = arg(&mut g, 1);
+        let body = inner(&mut g, ExprKind::Add, &[x, y]);
+        let map = inner(&mut g, ExprKind::Map, &[zip, body]);
+        inner(&mut g, ExprKind::IterConcat, &[map]);
+
+        let out = execute(&g, &[rb(&[0x01, 0x02]), rb(&[0x03, 0x04])]);
+        assert_eq!(raw_bytes(out), vec![0x04, 0x06]);
+    }
+
+    #[test]
+    fn reduce_folds_to_horizontal_sum() {
+        // reduce(split(0x04030201, 4), |acc, x| acc + x) -> 1+2+3+4 = 10.
+        let mut g = ExprPostGraph::new();
+        let bits = sym(&mut g, 0);
+        let n = int_con(&mut g, 4);
+        let iter = inner(&mut g, ExprKind::Split, &[bits, n]);
+        let acc = arg(&mut g, 0);
+        let x = arg(&mut g, 1);
+        let body = inner(&mut g, ExprKind::Add, &[acc, x]);
+        inner(&mut g, ExprKind::Reduce, &[iter, body]);
+
+        assert_eq!(as_i64(execute(&g, &[rb(&[0x01, 0x02, 0x03, 0x04])])), 10);
     }
 }

--- a/core/src/sem_expr/exec.rs
+++ b/core/src/sem_expr/exec.rs
@@ -82,6 +82,7 @@ macro_rules! as_int {
         match $v {
             Value::Int(i) => i,
             Value::Float(_) => panic!("{} requires integer operands", $op),
+            Value::Vector(_) => panic!("{} requires scalar operands", $op),
         }
     };
 }
@@ -91,6 +92,7 @@ macro_rules! as_float {
         match $v {
             Value::Float(f) => f,
             Value::Int(_) => panic!("{} requires float operands", $op),
+            Value::Vector(_) => panic!("{} requires scalar operands", $op),
         }
     };
 }
@@ -157,6 +159,40 @@ fn eval_loop<M: Memory>(
     Ok(acc)
 }
 
+/// Evaluate a `VectorMap` node: build a vector by evaluating `elem` over each
+/// lane index `[0, count)`, exposing the index through the frame stack the same
+/// way `Loop` exposes its induction value.
+fn eval_vector_map<M: Memory>(
+    graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
+    node: NodeId,
+    symbols: &[Value],
+    cache: &mut Vec<Option<Value>>,
+    frames: &mut Vec<(Value, Value)>,
+    memory: &mut M,
+) -> Result<Value, M::Error> {
+    let children: Vec<NodeId> = graph.children(node).collect();
+    let (count_n, elem_n) = (children[0], children[1]);
+
+    let count = eval_node(graph, count_n, symbols, cache, frames, memory)?;
+    let count = as_int!(count, "vector length").to_i64();
+
+    let mut lanes = Vec::with_capacity(count.max(0) as usize);
+    for i in 0..count {
+        // The accumulator slot is unused by a map; the induction value is read by
+        // `IndVar` and by `Lane` indices, and changes each lane, so `elem` cannot
+        // share the surrounding cache.
+        frames.push((
+            Value::Int(APInt::new_signed(64, i)),
+            Value::Int(APInt::new(1, 0)),
+        ));
+        let mut lane_cache = vec![None::<Value>; graph.len()];
+        let lane = eval_node(graph, elem_n, symbols, &mut lane_cache, frames, memory);
+        frames.pop();
+        lanes.push(lane?);
+    }
+    Ok(Value::Vector(lanes))
+}
+
 fn eval_node<M: Memory>(
     graph: &impl Dag<Node = ExprKind, Leaf = ExprPayload>,
     node: NodeId,
@@ -174,6 +210,14 @@ fn eval_node<M: Memory>(
     // by hand, below. Intercept before the generic child pre-evaluation.
     if *graph.get_kind(node) == ExprKind::Loop {
         let result = eval_loop(graph, node, symbols, cache, frames, memory)?;
+        cache[node.index()] = Some(result.clone());
+        return Ok(result);
+    }
+
+    // A `VectorMap`, like `Loop`, evaluates its `elem` child fresh per lane with
+    // the induction value bound, so intercept it before generic child pre-eval.
+    if *graph.get_kind(node) == ExprKind::VectorMap {
+        let result = eval_vector_map(graph, node, symbols, cache, frames, memory)?;
         cache[node.index()] = Some(result.clone());
         return Ok(result);
     }
@@ -199,6 +243,16 @@ fn eval_node<M: Memory>(
             .1
             .clone(),
         ExprKind::Loop => unreachable!("Loop handled before child pre-evaluation"),
+        ExprKind::VectorMap => {
+            unreachable!("VectorMap handled before child pre-evaluation")
+        }
+        ExprKind::Lane => {
+            let Value::Vector(lanes) = c(0) else {
+                panic!("Lane requires a vector operand");
+            };
+            let index = as_int!(c(1), "lane").to_u64() as usize;
+            lanes[index].clone()
+        }
         ExprKind::Symbol => {
             let ExprPayload::SymbolId(id) = graph.get_leaf_data(node).unwrap() else {
                 panic!("Symbol node must have SymbolId payload");
@@ -218,6 +272,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.add(&b))
             }
             Value::Float(a) => Value::Float(a.add(&as_float!(c(1), "add"))),
+            Value::Vector(_) => panic!("add requires scalar operands"),
         },
         ExprKind::Sub => match c(0) {
             Value::Int(a) => {
@@ -225,6 +280,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sub(&b))
             }
             Value::Float(a) => Value::Float(a.sub(&as_float!(c(1), "sub"))),
+            Value::Vector(_) => panic!("sub requires scalar operands"),
         },
         ExprKind::Mul => match c(0) {
             Value::Int(a) => {
@@ -232,6 +288,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.mul(&b))
             }
             Value::Float(a) => Value::Float(a.mul(&as_float!(c(1), "mul"))),
+            Value::Vector(_) => panic!("mul requires scalar operands"),
         },
         ExprKind::Div => match c(0) {
             Value::Int(a) => {
@@ -239,6 +296,7 @@ fn eval_node<M: Memory>(
                 Value::Int(a.sdiv(&b))
             }
             Value::Float(a) => Value::Float(a.div(&as_float!(c(1), "div"))),
+            Value::Vector(_) => panic!("div requires scalar operands"),
         },
         ExprKind::UDiv => {
             let (a, b) = coerce_ints(as_int!(c(0), "udiv"), as_int!(c(1), "udiv"));
@@ -298,6 +356,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.slt(&b))
                 }
                 Value::Float(a) => bool_result(a.lt(&as_float!(c(1), "lt"))),
+                Value::Vector(_) => panic!("lt requires scalar operands"),
             },
         )),
         ExprKind::Gt => Value::Int(APInt::new(
@@ -308,6 +367,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sgt(&b))
                 }
                 Value::Float(a) => bool_result(a.gt(&as_float!(c(1), "gt"))),
+                Value::Vector(_) => panic!("gt requires scalar operands"),
             },
         )),
         ExprKind::Ge => Value::Int(APInt::new(
@@ -318,6 +378,7 @@ fn eval_node<M: Memory>(
                     bool_result(a.sge(&b))
                 }
                 Value::Float(a) => bool_result(a.ge(&as_float!(c(1), "ge"))),
+                Value::Vector(_) => panic!("ge requires scalar operands"),
             },
         )),
         ExprKind::ULt => {
@@ -342,6 +403,7 @@ fn eval_node<M: Memory>(
             let cond_zero = match c(0) {
                 Value::Int(i) => i.is_zero(),
                 Value::Float(f) => f.is_zero(),
+                Value::Vector(_) => panic!("if condition must be scalar"),
             };
             if cond_zero { c(2) } else { c(1) }
         }
@@ -379,6 +441,7 @@ fn eval_node<M: Memory>(
             Value::Float(a) => {
                 Value::Float(a.fma(&as_float!(c(1), "fma"), &as_float!(c(2), "fma")))
             }
+            Value::Vector(_) => panic!("fma requires scalar operands"),
         },
         ExprKind::Sqrt => match c(0) {
             Value::Int(a) => {
@@ -386,6 +449,7 @@ fn eval_node<M: Memory>(
                 Value::Int(APInt::new(a.width(), (v as f64).sqrt() as u64))
             }
             Value::Float(a) => Value::Float(a.sqrt()),
+            Value::Vector(_) => panic!("sqrt requires a scalar operand"),
         },
         ExprKind::Log2Ceil => {
             let a = as_int!(c(0), "log2ceil");
@@ -462,6 +526,7 @@ impl PartialEq for Value {
         match (self, other) {
             (Value::Int(a), Value::Int(b)) => a == b,
             (Value::Float(a), Value::Float(b)) => a == b,
+            (Value::Vector(a), Value::Vector(b)) => a == b,
             _ => false,
         }
     }
@@ -544,13 +609,13 @@ mod tests {
     fn as_i64(v: Value) -> i64 {
         match v {
             Value::Int(i) => i.to_i64(),
-            Value::Float(_) => panic!(),
+            _ => panic!(),
         }
     }
     fn as_f64(v: Value) -> f64 {
         match v {
             Value::Float(f) => f.to_f64(),
-            Value::Int(_) => panic!(),
+            _ => panic!(),
         }
     }
 

--- a/core/src/sem_expr/infer.rs
+++ b/core/src/sem_expr/infer.rs
@@ -114,6 +114,9 @@ pub fn infer_widths(
             // from a lower-indexed leaf, so it stays unknown.
             ExprKind::VectorMap => child_width(1),
             ExprKind::Lane => None,
+
+            ExprKind::Map | ExprKind::Zip => None,
+            ExprKind::IterConcat => None,
         };
 
         widths[index] = width;

--- a/core/src/sem_expr/infer.rs
+++ b/core/src/sem_expr/infer.rs
@@ -116,7 +116,13 @@ pub fn infer_widths(
             ExprKind::Lane => None,
 
             ExprKind::Map | ExprKind::Zip => None,
-            ExprKind::IterConcat => None,
+            ExprKind::IterConcat | ExprKind::Split => None,
+            // A reduce is as wide as its accumulator, i.e. one input lane, whose
+            // width is the iterator's element width and not resolvable here.
+            ExprKind::Reduce => None,
+            // A lambda argument's width is its binding's, supplied at evaluation
+            // time; it cannot be resolved structurally.
+            ExprKind::Arg => None,
         };
 
         widths[index] = width;

--- a/core/src/sem_expr/infer.rs
+++ b/core/src/sem_expr/infer.rs
@@ -108,6 +108,12 @@ pub fn infer_widths(
             // can be resolved structurally from a lower-indexed leaf, so they stay
             // unknown and propagate.
             ExprKind::IndVar | ExprKind::Acc => None,
+
+            // A vector map is as wide as one lane (its `elem`); a lane read's
+            // width is the vector's element width, not resolvable structurally
+            // from a lower-indexed leaf, so it stays unknown.
+            ExprKind::VectorMap => child_width(1),
+            ExprKind::Lane => None,
         };
 
         widths[index] = width;

--- a/core/src/sem_expr/mod.rs
+++ b/core/src/sem_expr/mod.rs
@@ -87,6 +87,11 @@ pub enum ExprKind {
     Sqrt,
     #[arity = 3]
     Fma,
+    #[arity = 2]
+    Map,
+    #[arity = 2]
+    Zip,
+    IterConcat,
     /// Bounded fold/reduce, the IR's first-class loop. Arguments are
     /// `[start, end, init, step]`: the accumulator begins at `init` and, for each
     /// integer `i` in the half-open range `[start, end)`, is replaced by `step`.
@@ -146,5 +151,5 @@ pub enum Value {
     Int(APInt),
     Float(APFloat),
     /// A vector of lane values, produced by `VectorMap` and indexed by `Lane`.
-    Vector(Vec<Value>),
+    Iterator(Vec<Value>),
 }

--- a/core/src/sem_expr/mod.rs
+++ b/core/src/sem_expr/mod.rs
@@ -105,6 +105,18 @@ pub enum ExprKind {
     /// inside that loop's `step` subexpression.
     #[leaf]
     Acc,
+    /// Build a vector value by mapping over lanes. Arguments are `[count, elem]`:
+    /// `elem` is evaluated once per lane index `i` in `[0, count)` with `IndVar`
+    /// bound to `i`, and the node's value is the vector of those `count` elements.
+    /// This is the vector counterpart of `Loop` — a map rather than a fold — and
+    /// lets an elementwise vector operation and the target instruction that
+    /// implements it lower to the same DAG. `elem` reads the induction value via
+    /// `IndVar` and operand lanes via `Lane`.
+    #[arity = 2]
+    VectorMap,
+    /// Read one lane of a vector value. Arguments are `[vector, index]`.
+    #[arity = 2]
+    Lane,
 }
 
 impl ExprKind {
@@ -133,4 +145,6 @@ pub enum ExprPayload {
 pub enum Value {
     Int(APInt),
     Float(APFloat),
+    /// A vector of lane values, produced by `VectorMap` and indexed by `Lane`.
+    Vector(Vec<Value>),
 }

--- a/core/src/sem_expr/mod.rs
+++ b/core/src/sem_expr/mod.rs
@@ -87,11 +87,38 @@ pub enum ExprKind {
     Sqrt,
     #[arity = 3]
     Fma,
+    /// Apply a function to each lane of an iterator. Arguments are `[iter, body]`:
+    /// `body` is evaluated once per element with the element bound as the lambda's
+    /// argument, read via `Arg(0)` (or `Arg(0)`/`Arg(1)` when the element is a pair
+    /// produced by `Zip`). The node's value is the iterator of results.
     #[arity = 2]
     Map,
+    /// Pair two iterators lane-wise. Arguments are `[lhs, rhs]`; the value is an
+    /// iterator whose element `i` is the two-element iterator `[lhs[i], rhs[i]]`.
+    /// Feeding a `Zip` into a `Map` lets a binary lambda read both sides via
+    /// `Arg(0)`/`Arg(1)`.
     #[arity = 2]
     Zip,
+    /// Concatenate the lanes of an iterator into a single bit value, lane 0 in the
+    /// low bits. The inverse of `Split`. One argument: the iterator.
+    #[arity = 1]
     IterConcat,
+    /// Split a bit value into `n` equal-width lanes. Arguments are `[bits, n]`;
+    /// the value is an iterator of `n` elements, lane 0 taken from the low bits.
+    /// The inverse of `IterConcat`.
+    #[arity = 2]
+    Split,
+    /// Left-fold a function over an iterator's lanes. Arguments are `[iter, body]`:
+    /// the accumulator starts at lane 0 and, for each later lane, is replaced by
+    /// `body` evaluated with `Arg(0)` bound to the accumulator and `Arg(1)` to the
+    /// lane. The node's value is the final accumulator (e.g. a horizontal add).
+    #[arity = 2]
+    Reduce,
+    /// The k-th parameter of the innermost enclosing `Map`/`Reduce` lambda. A leaf
+    /// carrying its index as an `Int` payload; only meaningful inside that lambda's
+    /// `body` subexpression.
+    #[leaf]
+    Arg,
     /// Bounded fold/reduce, the IR's first-class loop. Arguments are
     /// `[start, end, init, step]`: the accumulator begins at `init` and, for each
     /// integer `i` in the half-open range `[start, end)`, is replaced by `step`.

--- a/core/src/sem_expr/mod.rs
+++ b/core/src/sem_expr/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     Operation, ValueId,
     graph::{MutDag, NodeId, PostOrderDag},
     helpers::SimpleNode,
-    utils::{APFloat, APInt},
+    utils::{APFloat, APInt, RawBits},
 };
 
 mod discover;
@@ -148,8 +148,12 @@ pub enum ExprPayload {
 /// A runtime value produced by the expression interpreter.
 #[derive(Clone, Debug)]
 pub enum Value {
+    /// Arbitrary-precision integers
     Int(APInt),
+    /// Arbitrary-precision floats
     Float(APFloat),
-    /// A vector of lane values, produced by `VectorMap` and indexed by `Lane`.
+    /// A fixed-size array of other types, like a vector
     Iterator(Vec<Value>),
+    /// An untyped bag of bits
+    RawBits(RawBits),
 }

--- a/core/src/sem_expr/unroll.rs
+++ b/core/src/sem_expr/unroll.rs
@@ -90,7 +90,17 @@ fn rebuild(
         // node to unroll it into, so keep it (and its `IndVar`/`Lane` children)
         // verbatim. The interpreter evaluates it natively; backends that cannot
         // iterate detect and reject it just like a symbolic loop.
-        ExprKind::VectorMap => copy_subtree(graph, node, out, &mut HashMap::new()),
+        // The functional iterator nodes evaluate a lambda body per element with a
+        // fresh per-element binding (read via `Arg`), like `VectorMap`'s per-lane
+        // `elem`. There is no scalar form to unroll them into, so keep them (and
+        // their bodies) verbatim; backends that cannot iterate detect and reject
+        // them.
+        ExprKind::VectorMap
+        | ExprKind::Map
+        | ExprKind::Zip
+        | ExprKind::IterConcat
+        | ExprKind::Split
+        | ExprKind::Reduce => copy_subtree(graph, node, out, &mut HashMap::new()),
         _ if children.is_empty() => {
             let new = out.add_node(kind);
             if let Some(data) = graph.get_leaf_data(node) {

--- a/core/src/sem_expr/unroll.rs
+++ b/core/src/sem_expr/unroll.rs
@@ -86,6 +86,11 @@ fn rebuild(
                 _ => copy_subtree(graph, node, out, &mut HashMap::new()),
             }
         }
+        // A `VectorMap` is a map, not a scalar fold: there is no vector-literal
+        // node to unroll it into, so keep it (and its `IndVar`/`Lane` children)
+        // verbatim. The interpreter evaluates it natively; backends that cannot
+        // iterate detect and reject it just like a symbolic loop.
+        ExprKind::VectorMap => copy_subtree(graph, node, out, &mut HashMap::new()),
         _ if children.is_empty() => {
             let new = out.add_node(kind);
             if let Some(data) = graph.get_leaf_data(node) {
@@ -181,7 +186,7 @@ mod tests {
     fn as_i64(v: Value) -> i64 {
         match v {
             Value::Int(i) => i.to_i64(),
-            Value::Float(_) => panic!(),
+            _ => panic!(),
         }
     }
 

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -1,7 +1,9 @@
 mod apfloat;
 mod apint;
+mod raw_bits;
 mod scoped_disjoint_set;
 
 pub use apfloat::*;
 pub use apint::*;
+pub use raw_bits::*;
 pub use scoped_disjoint_set::*;

--- a/core/src/utils/raw_bits.rs
+++ b/core/src/utils/raw_bits.rs
@@ -1,26 +1,151 @@
+use crate::utils::{APFloat, APInt};
+
 const BYTE_SIZE: usize = 8;
 
-#[derive(Clone, Debug)]
+/// An untyped, byte-granular sequence of bits — the raw contents of a value
+/// before it is interpreted as an integer or a float. Vector registers are
+/// represented this way: they can be wider than a machine word (so they do not
+/// fit an [`APInt`]) and the same bits may be read as integer or floating-point
+/// lanes. Bytes are stored little-endian: `storage[0]` is the least significant.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawBits {
     storage: Vec<u8>,
 }
 
 impl RawBits {
+    /// A zeroed value of `n` bits. `n` must be a whole number of bytes.
     pub fn new(n: usize) -> Self {
-        assert!(n % 8 == 0);
-        let num_bytes = n / BYTE_SIZE;
-
+        assert!(
+            n.is_multiple_of(BYTE_SIZE),
+            "RawBits width must be byte-aligned"
+        );
         RawBits {
-            storage: vec![0; num_bytes],
+            storage: vec![0; n / BYTE_SIZE],
         }
     }
 
+    /// Wrap raw little-endian bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        RawBits { storage: bytes }
+    }
+
+    /// The little-endian bytes backing this value.
+    pub fn bytes(&self) -> &[u8] {
+        &self.storage
+    }
+
+    /// The width in bits (always a multiple of 8).
     pub fn width(&self) -> usize {
         self.storage.len() * BYTE_SIZE
     }
 
-    // T is APInt or APFloat
-    pub fn split<T>(self, lanes: usize) -> Vec<T> {
-        todo!()
+    /// Reinterpret an integer as raw bits, widened to a whole number of bytes.
+    pub fn from_apint(value: &APInt) -> Self {
+        let num_bytes = value.width().div_ceil(BYTE_SIZE as u32) as usize;
+        let raw = value.to_u64();
+        let storage = (0..num_bytes)
+            .map(|i| (raw >> (i * BYTE_SIZE)) as u8)
+            .collect();
+        RawBits { storage }
+    }
+
+    /// Reinterpret these bits as an unsigned integer of the same width. The width
+    /// must fit a machine word, which holds for individual lanes.
+    pub fn to_apint(&self) -> APInt {
+        assert!(
+            self.width() <= 64,
+            "RawBits wider than 64 bits cannot be read as a single integer"
+        );
+        let mut value = 0u64;
+        for (i, byte) in self.storage.iter().enumerate() {
+            value |= u64::from(*byte) << (i * BYTE_SIZE);
+        }
+        APInt::new(self.width() as u32, value)
+    }
+
+    /// Reinterpret a float as raw bits.
+    pub fn from_apfloat(value: &APFloat) -> Self {
+        let num_bytes = value.bit_width().div_ceil(BYTE_SIZE as u32) as usize;
+        let raw = value.to_bits();
+        let storage = (0..num_bytes)
+            .map(|i| (raw >> (i * BYTE_SIZE)) as u8)
+            .collect();
+        RawBits { storage }
+    }
+
+    /// Reinterpret these bits as a float of the given IEEE-style format.
+    pub fn to_apfloat(
+        &self,
+        exp_width: u32,
+        mant_width: u32,
+        explicit_leading_bit: bool,
+    ) -> APFloat {
+        let mut bits = 0u128;
+        for (i, byte) in self.storage.iter().enumerate() {
+            bits |= u128::from(*byte) << (i * BYTE_SIZE);
+        }
+        APFloat::from_bits(exp_width, mant_width, explicit_leading_bit, bits)
+    }
+
+    /// Split into `lanes` equal-width pieces, lane 0 taken from the low bits. The
+    /// width must divide evenly into byte-aligned lanes.
+    pub fn split(&self, lanes: usize) -> Vec<RawBits> {
+        assert!(lanes > 0, "RawBits split requires a positive lane count");
+        assert!(
+            self.storage.len().is_multiple_of(lanes),
+            "RawBits of {} bits does not split into {lanes} byte-aligned lanes",
+            self.width()
+        );
+        let lane_bytes = self.storage.len() / lanes;
+        self.storage
+            .chunks(lane_bytes)
+            .map(|chunk| RawBits {
+                storage: chunk.to_vec(),
+            })
+            .collect()
+    }
+
+    /// Concatenate lanes into one value, lane 0 in the low bits. The inverse of
+    /// [`RawBits::split`].
+    pub fn concat(lanes: &[RawBits]) -> RawBits {
+        let storage = lanes
+            .iter()
+            .flat_map(|lane| lane.storage.iter().copied())
+            .collect();
+        RawBits { storage }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_and_concat_are_inverse() {
+        let raw = RawBits::from_bytes(vec![0x01, 0x02, 0x03, 0x04]);
+        let lanes = raw.split(4);
+        assert_eq!(lanes.len(), 4);
+        assert_eq!(lanes[0].bytes(), &[0x01]);
+        assert_eq!(lanes[3].bytes(), &[0x04]);
+        assert_eq!(RawBits::concat(&lanes), raw);
+    }
+
+    #[test]
+    fn integer_reinterpretation_roundtrips() {
+        let value = APInt::new(32, 0xDEAD_BEEF);
+        let raw = RawBits::from_apint(&value);
+        assert_eq!(raw.width(), 32);
+        assert_eq!(raw.to_apint(), value);
+    }
+
+    #[test]
+    fn float_reinterpretation_roundtrips() {
+        // The same bits a lane holds can be read as a float: a vector is not
+        // committed to an integer interpretation.
+        let value = APFloat::from_f32(1.5);
+        let raw = RawBits::from_apfloat(&value);
+        assert_eq!(raw.width(), 32);
+        let back = raw.to_apfloat(8, 23, false);
+        assert_eq!(back.to_f32(), 1.5);
     }
 }

--- a/core/src/utils/raw_bits.rs
+++ b/core/src/utils/raw_bits.rs
@@ -1,0 +1,26 @@
+const BYTE_SIZE: usize = 8;
+
+#[derive(Clone, Debug)]
+pub struct RawBits {
+    storage: Vec<u8>,
+}
+
+impl RawBits {
+    pub fn new(n: usize) -> Self {
+        assert!(n % 8 == 0);
+        let num_bytes = n / BYTE_SIZE;
+
+        RawBits {
+            storage: vec![0; num_bytes],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.storage.len() * BYTE_SIZE
+    }
+
+    // T is APInt or APFloat
+    pub fn split<T>(self, lanes: usize) -> Vec<T> {
+        todo!()
+    }
+}

--- a/docs/tmdl/syntax.md
+++ b/docs/tmdl/syntax.md
@@ -206,6 +206,18 @@ instruction Add for [RV32I, RV64I] : RType {
   `extract`, `clamp`, `log2Ceil`, `load`/`store` (memory), and `trap(cause)` —
   raise a synchronous exception with a constant cause code (e.g. RISC-V
   `ecall`/`ebreak`); the simulator routes it to its exception callback.
+- Functional vector builtins operate on iterators (a value split into lanes):
+  - `split(bits, n)` — cut a bit value into `n` equal-width lanes, lane 0 from
+    the low bits.
+  - `concat(iter)` — the inverse: join an iterator's lanes into one bit value.
+  - `map(iter, |x| ...)` — apply a lambda to each lane.
+  - `zip(a, b)` — pair two iterators lane-wise, so a binary `map` lambda
+    (`map(zip(a, b), |x, y| ...)`) reads both sides as separate parameters.
+  - `reduce(iter, |acc, x| ...)` — left-fold a binary lambda over the lanes
+    (e.g. a horizontal add).
+  - Lambdas use Rust syntax — `|x| body` or `|a, b| body` — and are valid only
+    as the function argument of `map`/`reduce`. A lane-wise vector add is
+    `concat(map(zip(split(vs2, n), split(vs1, n)), |a, b| a + b))`.
 - Optional `asm`/`encoding` sections can be provided or inherited.
 
 ## Encoding Section Details

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -487,12 +487,37 @@ pub enum BuiltinFunction {
     /// `trap(cause)`: raise a synchronous exception (e.g. ecall/ebreak). An
     /// effect-only builtin handled directly by codegen; it produces no value.
     Trap,
+    /// `split(bits, n)`: cut a bit value into `n` equal-width lanes (an iterator),
+    /// lane 0 from the low bits.
+    Split,
+    /// `concat(iter)`: join an iterator's lanes into one bit value, lane 0 in the
+    /// low bits. The inverse of `split`.
+    Concat,
+    /// `map(iter, |x| ...)`: apply a lambda to each lane of an iterator.
+    Map,
+    /// `reduce(iter, |acc, x| ...)`: left-fold a binary lambda over an iterator's
+    /// lanes (e.g. a horizontal add).
+    Reduce,
+    /// `zip(a, b)`: pair two iterators lane-wise so a `map` lambda can read both
+    /// sides as separate parameters.
+    Zip,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct Call {
     pub callee: Box<Expr>,
     pub arguments: Vec<Expr>,
+    #[serde(skip_serializing)]
+    pub span: Span,
+}
+
+/// A Rust-style anonymous function `|params| body`. Only valid as an argument to
+/// the `map`/`reduce` builtins; the lowering inlines its body, binding each
+/// parameter to the corresponding lambda argument.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct Lambda {
+    pub params: Vec<String>,
+    pub body: Box<Expr>,
     #[serde(skip_serializing)]
     pub span: Span,
 }
@@ -531,6 +556,7 @@ pub enum Expr {
     Slice(Slice),
     Try(TryExcept),
     BuiltinFunction(BuiltinFunction),
+    Lambda(Lambda),
     Invalid,
 }
 
@@ -616,6 +642,12 @@ fn subst_ident(expr: &mut Expr, var: &str, value: i64) {
             subst_ident(&mut t.body, var, value);
             for h in &mut t.handlers {
                 subst_ident(&mut h.body, var, value);
+            }
+        }
+        Expr::Lambda(l) => {
+            // A parameter sharing the substituted name shadows it inside the body.
+            if !l.params.iter().any(|p| p == var) {
+                subst_ident(&mut l.body, var, value);
             }
         }
     }
@@ -824,6 +856,7 @@ fn expand_loops_inplace(expr: &mut Expr, consts: &HashMap<String, i64>) {
                 expand_loops_inplace(&mut h.body, consts);
             }
         }
+        Expr::Lambda(l) => expand_loops_inplace(&mut l.body, consts),
     }
 }
 
@@ -857,6 +890,10 @@ struct SemaExprLoweringCtx<
     /// References to `dest` lower to the loop accumulator and references to the
     /// induction variable to the loop counter, so the body becomes a `Loop` node.
     loop_ctx: Option<(String, Expr)>,
+    /// Stack of `map`/`reduce` lambda parameter names, innermost last. An `Ident`
+    /// matching a parameter of the innermost lambda lowers to an `Arg` node whose
+    /// index is the parameter's position.
+    lambda_params: Vec<Vec<String>>,
 }
 
 impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>>
@@ -873,6 +910,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             variable_symbols: HashMap::new(),
             had_error: false,
             loop_ctx: None,
+            lambda_params: Vec::new(),
         }
     }
 
@@ -891,6 +929,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             variable_symbols: HashMap::new(),
             had_error: false,
             loop_ctx: None,
+            lambda_params: Vec::new(),
         }
     }
 
@@ -950,6 +989,20 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
         let id = self.alloc_variable_symbol();
         self.register_symbols.insert((class, number), id);
         id
+    }
+
+    /// Lower a `map`/`reduce` lambda's body, binding its parameters so that
+    /// references to them become `Arg` nodes. Non-lambda arguments are an error
+    /// (caught by the type checker); lowering them directly keeps the graph valid.
+    fn lower_lambda_body(&mut self, arg: &Expr) -> tir::graph::NodeId {
+        let Expr::Lambda(lambda) = arg else {
+            self.had_error = true;
+            return arg.lower_with_ctx(self);
+        };
+        self.lambda_params.push(lambda.params.clone());
+        let body = lambda.body.lower_with_ctx(self);
+        self.lambda_params.pop();
+        body
     }
 
     fn build_extract(
@@ -1068,6 +1121,17 @@ impl Expr {
             2 => return ctx.graph.add_node(tir::sem_expr::ExprKind::IndVar),
             _ => {}
         }
+        // Inside a `map`/`reduce` lambda, a reference to one of its parameters
+        // lowers to an `Arg` leaf carrying the parameter's position.
+        if let Expr::Ident(id) = self
+            && let Some(params) = ctx.lambda_params.last()
+            && let Some(idx) = params.iter().position(|p| p == &id.name)
+        {
+            return ctx.add_leaf(
+                tir::sem_expr::ExprKind::Arg,
+                tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, idx as u64)),
+            );
+        }
         match self {
             Expr::Assign(x) => x.as_sema_expr(ctx),
             Expr::Binary(x) => x.as_sema_expr(ctx),
@@ -1086,6 +1150,9 @@ impl Expr {
             // backend gives the handlers meaning.
             Expr::Try(x) => x.body.lower_with_ctx(ctx),
             Expr::BuiltinFunction(_) => panic!("builtin functions must be called"),
+            // Lambdas are lowered by the `map`/`reduce` builtins that consume them,
+            // which push their parameters and lower the body directly.
+            Expr::Lambda(_) => panic!("lambda only valid as a map/reduce argument"),
             Expr::Invalid => panic!("cannot convert invalid expression"),
         }
     }
@@ -1549,6 +1616,35 @@ impl Call {
             BuiltinFunction::Trap => {
                 ctx.had_error = true;
                 ctx.add_int_const(tir::utils::APInt::new(64, 0))
+            }
+            BuiltinFunction::Split => {
+                assert!(self.arguments.len() == 2, "split requires 2 arguments");
+                let bits = self.arguments[0].lower_with_ctx(ctx);
+                let n = self.arguments[1].lower_with_ctx(ctx);
+                ctx.add_node(tir::sem_expr::ExprKind::Split, &[bits, n])
+            }
+            BuiltinFunction::Concat => {
+                assert!(self.arguments.len() == 1, "concat requires 1 argument");
+                let iter = self.arguments[0].lower_with_ctx(ctx);
+                ctx.add_node(tir::sem_expr::ExprKind::IterConcat, &[iter])
+            }
+            BuiltinFunction::Zip => {
+                assert!(self.arguments.len() == 2, "zip requires 2 arguments");
+                let lhs = self.arguments[0].lower_with_ctx(ctx);
+                let rhs = self.arguments[1].lower_with_ctx(ctx);
+                ctx.add_node(tir::sem_expr::ExprKind::Zip, &[lhs, rhs])
+            }
+            BuiltinFunction::Map => {
+                assert!(self.arguments.len() == 2, "map requires 2 arguments");
+                let iter = self.arguments[0].lower_with_ctx(ctx);
+                let body = ctx.lower_lambda_body(&self.arguments[1]);
+                ctx.add_node(tir::sem_expr::ExprKind::Map, &[iter, body])
+            }
+            BuiltinFunction::Reduce => {
+                assert!(self.arguments.len() == 2, "reduce requires 2 arguments");
+                let iter = self.arguments[0].lower_with_ctx(ctx);
+                let body = ctx.lower_lambda_body(&self.arguments[1]);
+                ctx.add_node(tir::sem_expr::ExprKind::Reduce, &[iter, body])
             }
         }
     }

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -481,6 +481,9 @@ pub enum BuiltinFunction {
     ZExt,
     Load,
     Store,
+    /// `lane(vector, index)`: read one lane of a vector value. Used inside a
+    /// value-producing `for` loop to express elementwise vector behavior.
+    Lane,
     /// `trap(cause)`: raise a synchronous exception (e.g. ecall/ebreak). An
     /// effect-only builtin handled directly by codegen; it produces no value.
     Trap,
@@ -663,6 +666,30 @@ impl For {
         }
     }
 
+    /// If the body is a single value-producing expression (not an assignment),
+    /// the loop is a vector map: `elem` is that per-lane expression. This is the
+    /// counterpart of `accumulator`, lowering to a first-class `VectorMap` node.
+    pub(crate) fn map_elem(&self) -> Option<&Expr> {
+        let body = match &*self.body {
+            Expr::Block(b) if b.stmts.len() == 1 => &b.stmts[0],
+            other => other,
+        };
+        match body {
+            Expr::Assign(_) | Expr::Invalid => None,
+            // Effect-only statements (a bare `store`/`trap`) produce no lane value,
+            // so they are unrolled as statements rather than mapped.
+            Expr::Call(c)
+                if matches!(
+                    &*c.callee,
+                    Expr::BuiltinFunction(BuiltinFunction::Store | BuiltinFunction::Trap)
+                ) =>
+            {
+                None
+            }
+            elem => Some(elem),
+        }
+    }
+
     fn as_sema_expr<
         G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_expr::ExprPayload>,
     >(
@@ -670,8 +697,38 @@ impl For {
         ctx: &mut SemaExprLoweringCtx<'_, G>,
     ) -> tir::graph::NodeId {
         let Some((dest, step)) = self.accumulator() else {
-            // Non-accumulator loops are not first-class values: unroll constant
-            // bounds, otherwise the lowering cannot represent them.
+            // A value-producing loop is a vector map: `elem` lowered once with the
+            // loop variable bound to the induction value, building a `VectorMap`
+            // whose lane count is the (zero-based) range length.
+            if let Some(elem) = self.map_elem() {
+                // The lane count must be a compile-time constant so the lowered
+                // pattern carries a concrete vector width that instruction
+                // selection can match. The induction value ranges `0..count`, so
+                // the loop must start at zero for `IndVar` to equal the loop
+                // variable; otherwise fall back to lowering the bound expression.
+                let mut consts = ctx.params.clone();
+                for (name, value) in &ctx.isa_consts {
+                    consts.entry(name.clone()).or_insert(*value);
+                }
+                let count = match (
+                    eval_const_int(&self.start, &consts),
+                    eval_const_int(&self.end, &consts),
+                ) {
+                    (Some(0), Some(end)) if end >= 0 => {
+                        ctx.add_int_const(tir::utils::APInt::new(32, end as u64))
+                    }
+                    _ => self.end.lower_with_ctx(ctx),
+                };
+                let prev = ctx.loop_ctx.take();
+                // A non-matching dest (Invalid) means `Acc` is never produced; only
+                // the loop variable maps to the induction value.
+                ctx.loop_ctx = Some((self.var.clone(), Expr::Invalid));
+                let elem_node = elem.lower_with_ctx(ctx);
+                ctx.loop_ctx = prev;
+                return ctx.add_node(tir::sem_expr::ExprKind::VectorMap, &[count, elem_node]);
+            }
+            // Non-accumulator statement loops are not first-class values: unroll
+            // constant bounds, otherwise the lowering cannot represent them.
             return match unroll_for(self, ctx.params) {
                 Some(block) => block.lower_with_ctx(ctx),
                 None => {
@@ -716,9 +773,11 @@ fn expand_loops_inplace(expr: &mut Expr, consts: &HashMap<String, i64>) {
             expand_loops_inplace(&mut f.start, consts);
             expand_loops_inplace(&mut f.end, consts);
             expand_loops_inplace(&mut f.body, consts);
-            // Accumulator loops lower to a first-class `Loop` node, so leave them
-            // intact; only non-accumulator loops are unrolled here.
+            // Accumulator loops lower to a `Loop` node and value-producing loops to
+            // a `VectorMap`, so leave both intact; only statement loops are
+            // unrolled here.
             if f.accumulator().is_none()
+                && f.map_elem().is_none()
                 && let Some(block) = unroll_for(f, consts)
             {
                 *expr = block;
@@ -785,6 +844,11 @@ struct SemaExprLoweringCtx<
     /// still be lowered to a stable `(class, index)` slot. When absent, only PC and
     /// numbered registers (whose index is in the name, e.g. `x5`) can be resolved.
     register_indices: Option<&'a HashMap<(String, String), u32>>,
+    /// ISA parameter values (e.g. `VLEN`, `SEW`), used only to const-evaluate a
+    /// vector map's lane count. They are deliberately not consulted for general
+    /// `self.PARAM` lowering, which keeps target-dependent params like `XLEN`
+    /// symbolic in patterns.
+    isa_consts: HashMap<String, i64>,
     next_symbol_id: u32,
     register_symbols: HashMap<(String, u32), u32>,
     variable_symbols: HashMap<String, u32>,
@@ -803,6 +867,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             graph,
             params,
             register_indices: None,
+            isa_consts: HashMap::new(),
             next_symbol_id: 0,
             register_symbols: HashMap::new(),
             variable_symbols: HashMap::new(),
@@ -820,6 +885,7 @@ impl<'a, G: tir::graph::MutDag<Node = tir::sem_expr::ExprKind, Leaf = tir::sem_e
             graph,
             params,
             register_indices: Some(register_indices),
+            isa_consts: HashMap::new(),
             next_symbol_id: 0,
             register_symbols: HashMap::new(),
             variable_symbols: HashMap::new(),
@@ -1058,6 +1124,31 @@ impl Expr {
         params: &HashMap<String, i64>,
     ) -> Option<SemaLowering> {
         let mut ctx = SemaExprLoweringCtx::new(g, params);
+        let root = self.lower_with_ctx(&mut ctx);
+        if ctx.had_error {
+            return None;
+        }
+        Some(SemaLowering {
+            root,
+            variable_symbols: ctx.variable_symbols,
+            register_symbols: ctx.register_symbols,
+        })
+    }
+
+    /// Like [`Expr::lower_to_sema`], but supplies ISA parameter values used to
+    /// const-evaluate a vector map's lane count, so the lowered pattern carries a
+    /// concrete width that instruction selection can match.
+    pub fn lower_to_sema_with_isa(
+        &self,
+        g: &mut impl tir::graph::MutDag<
+            Node = tir::sem_expr::ExprKind,
+            Leaf = tir::sem_expr::ExprPayload,
+        >,
+        params: &HashMap<String, i64>,
+        isa_consts: &HashMap<String, i64>,
+    ) -> Option<SemaLowering> {
+        let mut ctx = SemaExprLoweringCtx::new(g, params);
+        ctx.isa_consts = isa_consts.clone();
         let root = self.lower_with_ctx(&mut ctx);
         if ctx.had_error {
             return None;
@@ -1412,6 +1503,12 @@ impl Call {
                 assert!(self.arguments.len() == 1, "log2Ceil requires 1 argument");
                 let input = self.arguments[0].lower_with_ctx(ctx);
                 ctx.add_node(tir::sem_expr::ExprKind::Log2Ceil, &[input])
+            }
+            BuiltinFunction::Lane => {
+                assert!(self.arguments.len() == 2, "lane requires 2 arguments");
+                let vector = self.arguments[0].lower_with_ctx(ctx);
+                let index = self.arguments[1].lower_with_ctx(ctx);
+                ctx.add_node(tir::sem_expr::ExprKind::Lane, &[vector, index])
             }
             BuiltinFunction::SExt => {
                 assert!(self.arguments.len() == 2, "sext requires 2 arguments");

--- a/tmdl/src/ast.rs
+++ b/tmdl/src/ast.rs
@@ -1213,8 +1213,9 @@ impl Expr {
         >,
         params: &HashMap<String, i64>,
         isa_consts: &HashMap<String, i64>,
+        register_indices: &HashMap<(String, String), u32>,
     ) -> Option<SemaLowering> {
-        let mut ctx = SemaExprLoweringCtx::new(g, params);
+        let mut ctx = SemaExprLoweringCtx::new_with_registers(g, params, register_indices);
         ctx.isa_consts = isa_consts.clone();
         let root = self.lower_with_ctx(&mut ctx);
         if ctx.had_error {

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -1101,6 +1101,7 @@ where
                 "clamp" => Some(BuiltinFunction::Clamp),
                 "extract" => Some(BuiltinFunction::Extract),
                 "log2Ceil" => Some(BuiltinFunction::Log2Ceil),
+                "lane" => Some(BuiltinFunction::Lane),
                 "sext" => Some(BuiltinFunction::SExt),
                 "zext" => Some(BuiltinFunction::ZExt),
                 "load" => Some(BuiltinFunction::Load),

--- a/tmdl/src/parser.rs
+++ b/tmdl/src/parser.rs
@@ -1107,6 +1107,11 @@ where
                 "load" => Some(BuiltinFunction::Load),
                 "store" => Some(BuiltinFunction::Store),
                 "trap" => Some(BuiltinFunction::Trap),
+                "split" => Some(BuiltinFunction::Split),
+                "concat" => Some(BuiltinFunction::Concat),
+                "map" => Some(BuiltinFunction::Map),
+                "reduce" => Some(BuiltinFunction::Reduce),
+                "zip" => Some(BuiltinFunction::Zip),
                 _ => None,
             }
         }
@@ -1146,7 +1151,28 @@ where
 
         let ident = select! { Token::Identifier(i) => i.to_string() };
 
-        let atom = literal_or_ident
+        // Rust-style lambda `|a, b| body`, valid only as a map/reduce argument.
+        // Parsed at atom position so a leading `|` is unambiguously a lambda
+        // (bitwise-or is infix, never starts an expression).
+        let lambda = just(Token::Pipe)
+            .ignore_then(
+                ident
+                    .separated_by(just(Token::Comma))
+                    .allow_trailing()
+                    .collect::<Vec<_>>(),
+            )
+            .then_ignore(just(Token::Pipe))
+            .then(expr.clone())
+            .map_with(|(params, body), e| {
+                Expr::Lambda(Lambda {
+                    params,
+                    body: Box::new(body),
+                    span: e.span(),
+                })
+            });
+
+        let atom = lambda
+            .or(literal_or_ident)
             .or(expr
                 .clone()
                 .delimited_by(just(Token::LParen), just(Token::RParen)))
@@ -1490,7 +1516,7 @@ mod tests {
     use chumsky::prelude::*;
 
     use crate::{
-        ast::{BinOp, Expr, UnOp},
+        ast::{BinOp, BuiltinFunction, Expr, UnOp},
         lexer::lexer,
     };
 
@@ -1670,6 +1696,74 @@ mod tests {
             has_indvar && has_acc,
             "loop body must reference IndVar and Acc"
         );
+    }
+
+    fn parse_inline(code: &str) -> Expr {
+        let (tokens, _e) = lexer().parse(code).into_output_errors();
+        let tokens = tokens.unwrap();
+        inline_expr()
+            .then(end())
+            .parse(
+                tokens
+                    .as_slice()
+                    .map((code.len()..code.len()).into(), |(t, s)| (t, s)),
+            )
+            .output()
+            .unwrap()
+            .0
+            .clone()
+    }
+
+    #[test]
+    fn expr_parses_map_with_lambda() {
+        let parsed = parse_inline("map(split(rs1, 4), |x| x + 1)");
+        let Expr::Call(call) = &parsed else {
+            panic!("expected call, got {parsed:?}");
+        };
+        assert!(matches!(
+            &*call.callee,
+            Expr::BuiltinFunction(BuiltinFunction::Map)
+        ));
+        let Expr::Lambda(lambda) = &call.arguments[1] else {
+            panic!("second argument must be a lambda");
+        };
+        assert_eq!(lambda.params, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn expr_parses_binary_lambda() {
+        let parsed = parse_inline("reduce(rs1, |acc, x| acc + x)");
+        let Expr::Call(call) = &parsed else {
+            panic!("expected call, got {parsed:?}");
+        };
+        let Expr::Lambda(lambda) = &call.arguments[1] else {
+            panic!("second argument must be a lambda");
+        };
+        assert_eq!(lambda.params, vec!["acc".to_string(), "x".to_string()]);
+    }
+
+    #[test]
+    fn functional_pipeline_lowers_and_executes() {
+        use std::collections::HashMap;
+        use tir::sem_expr::{ExprPostGraph, Value, execute};
+        use tir::utils::{APInt, RawBits};
+
+        // split a 32-bit raw value into four bytes and horizontally sum them:
+        // bytes [1, 2, 3, 4] -> 10.
+        let parsed = parse_inline("reduce(split(rs1, 4), |acc, x| acc + x)");
+        let mut graph = ExprPostGraph::new();
+        let lowering = parsed
+            .lower_to_sema(&mut graph, &HashMap::new())
+            .expect("functional pipeline lowers");
+
+        let mut symbols = vec![Value::Int(APInt::new(1, 0)); lowering.variable_symbols.len()];
+        symbols[lowering.variable_symbols["rs1"] as usize] =
+            Value::RawBits(RawBits::from_bytes(vec![1, 2, 3, 4]));
+
+        match execute(&graph, &symbols) {
+            Value::Int(v) => assert_eq!(v.to_i64(), 10),
+            other => panic!("expected scalar result, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -231,6 +231,8 @@ fn emit_instructions<'a>(
     let mut instruction_printer_map_inits: Vec<proc_macro2::TokenStream> = vec![];
     let mut isel_rule_emitters: Vec<proc_macro2::TokenStream> = vec![];
     let mut isel_rule_inits: Vec<proc_macro2::TokenStream> = vec![];
+    let mut isel_definer_emitters: Vec<proc_macro2::TokenStream> = vec![];
+    let mut isel_definer_inits: Vec<proc_macro2::TokenStream> = vec![];
     let mut machine_instruction_impls: Vec<proc_macro2::TokenStream> = vec![];
     let mut instruction_custom_format_impls: Vec<proc_macro2::TokenStream> = vec![];
     let mut as_sem_expr_impls: Vec<proc_macro2::TokenStream> = vec![];
@@ -434,6 +436,7 @@ fn emit_instructions<'a>(
                 &defined_register_operands,
                 &numeric_params,
                 &isa_param_values,
+                &register_index_map,
             )
         {
             let emit_fn_ident = format_ident!("emit_isel_{}", inst.name.to_lowercase());
@@ -589,6 +592,28 @@ fn emit_instructions<'a>(
                 }
             });
 
+            // The registers the behavior reads by path (e.g. `VCSR::vl`) are implicit
+            // uses: real dependencies not among the encoded operands. Selection
+            // introduces each one's definer ahead of this instruction.
+            let mut implicit_reads: Vec<(&(String, u32), &u32)> =
+                semantics.register_symbols.iter().collect();
+            implicit_reads.sort_by_key(|((class, index), _)| (class.clone(), *index));
+            let implicit_use_entries: Vec<proc_macro2::TokenStream> = implicit_reads
+                .iter()
+                .map(|((class, index), sym)| {
+                    let class_lit = proc_macro2::Literal::string(class);
+                    let index_lit = proc_macro2::Literal::u32_unsuffixed(*index);
+                    let sym_lit = proc_macro2::Literal::u32_unsuffixed(**sym);
+                    quote! {
+                        tir_be_common::isel::ImplicitUse {
+                            symbol: #sym_lit,
+                            register_class: #class_lit,
+                            register_index: #index_lit,
+                        }
+                    }
+                })
+                .collect();
+
             let inst_features = feature_slice(&inst.for_isas);
             isel_rule_inits.push(quote! {
                 if features_enabled(features, #inst_features) {
@@ -602,10 +627,103 @@ fn emit_instructions<'a>(
                             (#base_cost_lit).max(instruction_cost(#mnemonic_cost_lit)),
                             #emit_fn_ident,
                         )
-                        .with_operand_constraints(vec![#(#operand_constraint_entries),*]),
+                        .with_operand_constraints(vec![#(#operand_constraint_entries),*])
+                        .with_implicit_uses(vec![#(#implicit_use_entries),*]),
                     );
                 }
             });
+        }
+
+        // A pure register definer (e.g. `vsetvli`) gets no matching rule; instead it
+        // is registered as the definer of the registers its behavior writes, to be
+        // introduced ahead of instructions that read them. Its emitter hardwires the
+        // discardable destination(s) to `x0` and takes the written value from the
+        // def/use binding (symbol 0).
+        let definer_writes =
+            definer_writes(inst, &ops, &defined_register_operands, &register_index_map);
+        if !definer_writes.is_empty() {
+            let definer_emit_fn_ident = format_ident!("emit_definer_{}", inst.name.to_lowercase());
+
+            let mut definer_emit_steps = Vec::new();
+            for (op_name, op_ty) in &ops {
+                let op_name_lit = proc_macro2::Literal::string(op_name);
+                let is_value = definer_writes.iter().any(|w| &w.value_operand == op_name);
+                match op_ty {
+                    Type::Struct(class_name) => {
+                        let class_lit = proc_macro2::Literal::string(class_name);
+                        if is_value {
+                            definer_emit_steps.push(quote! {
+                                let src = m.value_binding(0)
+                                    .ok_or(tir::PassError::RewriteFailed(req.op_id()))?;
+                                builder = builder.attr(
+                                    #op_name_lit,
+                                    tir::attributes::AttributeValue::Register(
+                                        tir::attributes::RegisterAttr::Virtual {
+                                            id: src.number(),
+                                            class: Some(#class_lit.to_string()),
+                                        },
+                                    ),
+                                );
+                            });
+                        } else {
+                            // A discardable destination register, hardwired to x0.
+                            definer_emit_steps.push(quote! {
+                                builder = builder.attr(
+                                    #op_name_lit,
+                                    tir::attributes::AttributeValue::Register(
+                                        tir::attributes::RegisterAttr::Physical {
+                                            class: #class_lit.to_string(),
+                                            index: 0,
+                                        },
+                                    ),
+                                );
+                            });
+                        }
+                    }
+                    Type::Integer | Type::Bits(_) if is_value => {
+                        definer_emit_steps.push(quote! {
+                            let v = m.int_binding(0)
+                                .ok_or(tir::PassError::RewriteFailed(req.op_id()))?;
+                            builder = builder.attr(
+                                #op_name_lit,
+                                tir::attributes::AttributeValue::Int(v),
+                            );
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            isel_definer_emitters.push(quote! {
+                fn #definer_emit_fn_ident(
+                    context: &tir::Context,
+                    req: &tir_be_common::isel::EmitRequest,
+                    m: &tir_be_common::isel::RuleMatch,
+                ) -> Result<Box<dyn tir::Operation>, tir::PassError> {
+                    let _ = (req, m);
+                    let mut builder = #builder_ident::new(context);
+                    #(#definer_emit_steps)*
+                    Ok(Box::new(builder.build()))
+                }
+            });
+
+            let definer_features = feature_slice(&inst.for_isas);
+            for write in &definer_writes {
+                let class_lit = proc_macro2::Literal::string(&write.register_class);
+                let index_lit = proc_macro2::Literal::u32_unsuffixed(write.register_index);
+                let immediate = write.value_is_immediate;
+                isel_definer_inits.push(quote! {
+                    if features_enabled(features, #definer_features) {
+                        definers.push(tir_be_common::isel::RegisterDefiner {
+                            register_class: #class_lit,
+                            register_index: #index_lit,
+                            value_is_immediate: #immediate,
+                            value_symbol: 0,
+                            emit_fn: #definer_emit_fn_ident,
+                        });
+                    }
+                });
+            }
         }
 
         let encoding_arms = get_encoding_arms(inst, item_cache);
@@ -1048,6 +1166,17 @@ fn emit_instructions<'a>(
             let mut rules = Vec::new();
             #(#isel_rule_inits)*
             rules
+        }
+
+        #(#isel_definer_emitters)*
+
+        /// Instructions that define a register implicitly (e.g. `vsetvli` defining
+        /// `VCSR::vl`), introduced ahead of ops that read those registers.
+        pub fn get_register_definers(context: &tir::Context, features: &[Feature]) -> Vec<tir_be_common::isel::RegisterDefiner> {
+            let _ = (&context, &features);
+            let mut definers = Vec::new();
+            #(#isel_definer_inits)*
+            definers
         }
     })
 }
@@ -1702,6 +1831,10 @@ struct InstructionSemantics {
     base_cost: u32,
     variable_symbols: HashMap<String, u32>,
     fixed_register_by_class: HashMap<String, Option<u16>>,
+    /// `(register class, index) -> pattern symbol` for every register the behavior
+    /// reads by path (e.g. `VCSR::vl`). These are implicit reads — registers not
+    /// among the encoded operands — and become the rule's `implicit_uses`.
+    register_symbols: HashMap<(String, u32), u32>,
 }
 
 fn analyze_instruction_semantics(
@@ -1710,10 +1843,16 @@ fn analyze_instruction_semantics(
     defined_register_operands: &[String],
     numeric_params: &HashMap<String, i64>,
     isa_param_values: &HashMap<String, i64>,
+    register_index_map: &HashMap<(String, String), u32>,
 ) -> Option<InstructionSemantics> {
     let rhs = resolve_behavior_rhs(inst, operands, defined_register_operands)?;
     let mut pattern = tir::sem_expr::ExprPostGraph::new();
-    let lowering = rhs.lower_to_sema_with_isa(&mut pattern, numeric_params, isa_param_values)?;
+    let lowering = rhs.lower_to_sema_with_isa(
+        &mut pattern,
+        numeric_params,
+        isa_param_values,
+        register_index_map,
+    )?;
     let base_cost = pattern.len().try_into().unwrap_or(u32::MAX).max(1);
     let fixed_register_by_class = split_fixed_registers(&lowering.register_symbols);
 
@@ -1723,6 +1862,7 @@ fn analyze_instruction_semantics(
         base_cost,
         variable_symbols: lowering.variable_symbols,
         fixed_register_by_class,
+        register_symbols: lowering.register_symbols,
     })
 }
 
@@ -1763,6 +1903,81 @@ fn assignment_dest_name(dest: &ast::Expr) -> Option<String> {
     }
 }
 
+/// `(class, register-name)` when an assignment destination is a register path
+/// (e.g. `VCSR::vl`), or `None` for a plain identifier (an encoded operand).
+fn assignment_dest_register_path(dest: &ast::Expr) -> Option<(String, String)> {
+    match dest {
+        ast::Expr::Path(path) if path.remainder.len() == 1 => {
+            Some((path.base.clone(), path.remainder[0].clone()))
+        }
+        _ => None,
+    }
+}
+
+/// The operand names referenced anywhere in `expr`, in first-seen order. Used to
+/// find which operand feeds a register a definer instruction writes.
+fn referenced_operands(expr: &ast::Expr, operands: &HashSet<&str>) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_referenced_idents(expr, operands, &mut out);
+    out
+}
+
+fn collect_referenced_idents(expr: &ast::Expr, operands: &HashSet<&str>, out: &mut Vec<String>) {
+    match expr {
+        ast::Expr::Ident(id) => {
+            if operands.contains(id.name.as_str()) && !out.iter().any(|n| n == &id.name) {
+                out.push(id.name.clone());
+            }
+        }
+        ast::Expr::Lit(_)
+        | ast::Expr::Path(_)
+        | ast::Expr::BuiltinFunction(_)
+        | ast::Expr::Invalid => {}
+        ast::Expr::Assign(a) => {
+            collect_referenced_idents(&a.dest, operands, out);
+            collect_referenced_idents(&a.value, operands, out);
+        }
+        ast::Expr::Binary(b) => {
+            collect_referenced_idents(&b.lhs, operands, out);
+            collect_referenced_idents(&b.rhs, operands, out);
+        }
+        ast::Expr::Unary(u) => collect_referenced_idents(&u.x, operands, out),
+        ast::Expr::Block(b) => {
+            for stmt in &b.stmts {
+                collect_referenced_idents(stmt, operands, out);
+            }
+        }
+        ast::Expr::Call(c) => {
+            collect_referenced_idents(&c.callee, operands, out);
+            for arg in &c.arguments {
+                collect_referenced_idents(arg, operands, out);
+            }
+        }
+        ast::Expr::Field(f) => collect_referenced_idents(&f.base, operands, out),
+        ast::Expr::If(i) => {
+            collect_referenced_idents(&i.cond, operands, out);
+            collect_referenced_idents(&i.then, operands, out);
+            if let Some(e) = &i.else_ {
+                collect_referenced_idents(e, operands, out);
+            }
+        }
+        ast::Expr::For(f) => {
+            collect_referenced_idents(&f.start, operands, out);
+            collect_referenced_idents(&f.end, operands, out);
+            collect_referenced_idents(&f.body, operands, out);
+        }
+        ast::Expr::IndexAccess(i) => collect_referenced_idents(&i.base, operands, out),
+        ast::Expr::Slice(s) => collect_referenced_idents(&s.base, operands, out),
+        ast::Expr::Try(t) => {
+            collect_referenced_idents(&t.body, operands, out);
+            for h in &t.handlers {
+                collect_referenced_idents(&h.body, operands, out);
+            }
+        }
+        ast::Expr::Lambda(l) => collect_referenced_idents(&l.body, operands, out),
+    }
+}
+
 fn collect_behavior_assignments<'a>(expr: &'a ast::Expr, out: &mut Vec<(String, &'a ast::Expr)>) {
     match expr {
         ast::Expr::Assign(a) => {
@@ -1786,6 +2001,90 @@ fn collect_behavior_assignments<'a>(expr: &'a ast::Expr, out: &mut Vec<(String, 
         ast::Expr::For(f) => collect_behavior_assignments(&f.body, out),
         _ => {}
     }
+}
+
+/// Like [`collect_behavior_assignments`] but keeps the destination expression, so
+/// a register-path write (`VCSR::vl = …`) can be resolved to its `(class, name)`.
+fn collect_behavior_assignment_exprs<'a>(
+    expr: &'a ast::Expr,
+    out: &mut Vec<(&'a ast::Expr, &'a ast::Expr)>,
+) {
+    match expr {
+        ast::Expr::Assign(a) => out.push((a.dest.as_ref(), a.value.as_ref())),
+        ast::Expr::Block(b) => {
+            for stmt in &b.stmts {
+                collect_behavior_assignment_exprs(stmt, out);
+            }
+        }
+        ast::Expr::If(i) => {
+            collect_behavior_assignment_exprs(i.then.as_ref(), out);
+            if let Some(else_expr) = &i.else_ {
+                collect_behavior_assignment_exprs(else_expr.as_ref(), out);
+            }
+        }
+        ast::Expr::Try(t) => collect_behavior_assignment_exprs(&t.body, out),
+        ast::Expr::For(f) => collect_behavior_assignment_exprs(&f.body, out),
+        _ => {}
+    }
+}
+
+/// A register a definer instruction writes implicitly: `(class, index)` and the
+/// operand feeding it, with whether that operand is an immediate. Derived from an
+/// instruction whose behavior assigns fixed registers and no encoded result.
+struct DefinerWrite {
+    register_class: String,
+    register_index: u32,
+    value_operand: String,
+    value_is_immediate: bool,
+}
+
+/// The fixed-register writes that make `inst` a register definer, or empty if it
+/// is not one (it assigns an encoded result, or writes no fixed register).
+fn definer_writes(
+    inst: &ast::Instruction,
+    ops: &[(String, Type)],
+    defined_register_operands: &[String],
+    register_index_map: &HashMap<(String, String), u32>,
+) -> Vec<DefinerWrite> {
+    // A pure definer assigns no encoded result operand; an instruction that also
+    // produces a normal result (e.g. a CSR op writing `rd`) is matched by value.
+    if !defined_register_operands.is_empty() {
+        return Vec::new();
+    }
+    let operand_names: HashSet<&str> = ops.iter().map(|(name, _)| name.as_str()).collect();
+    let ops_by_name: HashMap<&str, &Type> =
+        ops.iter().map(|(name, ty)| (name.as_str(), ty)).collect();
+
+    let mut assignments = Vec::new();
+    collect_behavior_assignment_exprs(&inst.behavior, &mut assignments);
+
+    let mut writes = Vec::new();
+    for (dest, rhs) in assignments {
+        let Some((class, name)) = assignment_dest_register_path(dest) else {
+            continue;
+        };
+        if operand_names.contains(name.as_str()) {
+            continue;
+        }
+        let Some(&index) = register_index_map.get(&(class.clone(), name.clone())) else {
+            continue;
+        };
+        let referenced = referenced_operands(rhs, &operand_names);
+        let Some(value_operand) = referenced.into_iter().next() else {
+            continue;
+        };
+        let value_is_immediate = matches!(
+            ops_by_name.get(value_operand.as_str()),
+            Some(Type::Bits(_)) | Some(Type::Integer)
+        );
+        writes.push(DefinerWrite {
+            register_class: class,
+            register_index: index,
+            value_operand,
+            value_is_immediate,
+        });
+    }
+    writes
 }
 
 fn infer_defined_register_operands(

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -2378,7 +2378,7 @@ fn emit_value_eval(
             let mut __memory = __TmdlMachineMemory(machine);
             match tir::sem_expr::execute_with_memory(&__g, &__syms, &mut __memory)? {
                 tir::sem_expr::Value::Int(i) => i,
-                tir::sem_expr::Value::Float(_) => {
+                tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Vector(_) => {
                     return Err(tir_be_common::SimTrap::InvalidInstruction {
                         op: #mnemonic_lit,
                         reason: "instruction semantic expression did not evaluate to integer".to_string(),
@@ -2611,6 +2611,8 @@ fn emit_expr_kind_ts(kind: &tir::sem_expr::ExprKind) -> proc_macro2::TokenStream
         ExprKind::Loop => quote! { tir::sem_expr::ExprKind::Loop },
         ExprKind::IndVar => quote! { tir::sem_expr::ExprKind::IndVar },
         ExprKind::Acc => quote! { tir::sem_expr::ExprKind::Acc },
+        ExprKind::VectorMap => quote! { tir::sem_expr::ExprKind::VectorMap },
+        ExprKind::Lane => quote! { tir::sem_expr::ExprKind::Lane },
     }
 }
 

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -2380,7 +2380,7 @@ fn emit_value_eval(
             let mut __memory = __TmdlMachineMemory(machine);
             match tir::sem_expr::execute_with_memory(&__g, &__syms, &mut __memory)? {
                 tir::sem_expr::Value::Int(i) => i,
-                tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Iterator(_) => {
+                tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Iterator(_) | tir::sem_expr::Value::RawBits(_) => {
                     return Err(tir_be_common::SimTrap::InvalidInstruction {
                         op: #mnemonic_lit,
                         reason: "instruction semantic expression did not evaluate to integer".to_string(),

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -433,6 +433,7 @@ fn emit_instructions<'a>(
                 &ops,
                 &defined_register_operands,
                 &numeric_params,
+                &isa_param_values,
             )
         {
             let emit_fn_ident = format_ident!("emit_isel_{}", inst.name.to_lowercase());
@@ -1708,10 +1709,11 @@ fn analyze_instruction_semantics(
     operands: &[(String, Type)],
     defined_register_operands: &[String],
     numeric_params: &HashMap<String, i64>,
+    isa_param_values: &HashMap<String, i64>,
 ) -> Option<InstructionSemantics> {
     let rhs = resolve_behavior_rhs(inst, operands, defined_register_operands)?;
     let mut pattern = tir::sem_expr::ExprPostGraph::new();
-    let lowering = rhs.lower_to_sema(&mut pattern, numeric_params)?;
+    let lowering = rhs.lower_to_sema_with_isa(&mut pattern, numeric_params, isa_param_values)?;
     let base_cost = pattern.len().try_into().unwrap_or(u32::MAX).max(1);
     let fixed_register_by_class = split_fixed_registers(&lowering.register_symbols);
 

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -2615,9 +2615,12 @@ fn emit_expr_kind_ts(kind: &tir::sem_expr::ExprKind) -> proc_macro2::TokenStream
         ExprKind::Acc => quote! { tir::sem_expr::ExprKind::Acc },
         ExprKind::VectorMap => quote! { tir::sem_expr::ExprKind::VectorMap },
         ExprKind::Lane => quote! { tir::sem_expr::ExprKind::Lane },
-        ExprKind::Map => todo!(),
-        ExprKind::Zip => todo!(),
-        ExprKind::IterConcat => todo!(),
+        ExprKind::Map => quote! { tir::sem_expr::ExprKind::Map },
+        ExprKind::Zip => quote! { tir::sem_expr::ExprKind::Zip },
+        ExprKind::IterConcat => quote! { tir::sem_expr::ExprKind::IterConcat },
+        ExprKind::Split => quote! { tir::sem_expr::ExprKind::Split },
+        ExprKind::Reduce => quote! { tir::sem_expr::ExprKind::Reduce },
+        ExprKind::Arg => quote! { tir::sem_expr::ExprKind::Arg },
     }
 }
 

--- a/tmdl/src/rustgen.rs
+++ b/tmdl/src/rustgen.rs
@@ -2380,7 +2380,7 @@ fn emit_value_eval(
             let mut __memory = __TmdlMachineMemory(machine);
             match tir::sem_expr::execute_with_memory(&__g, &__syms, &mut __memory)? {
                 tir::sem_expr::Value::Int(i) => i,
-                tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Vector(_) => {
+                tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Iterator(_) => {
                     return Err(tir_be_common::SimTrap::InvalidInstruction {
                         op: #mnemonic_lit,
                         reason: "instruction semantic expression did not evaluate to integer".to_string(),
@@ -2615,6 +2615,9 @@ fn emit_expr_kind_ts(kind: &tir::sem_expr::ExprKind) -> proc_macro2::TokenStream
         ExprKind::Acc => quote! { tir::sem_expr::ExprKind::Acc },
         ExprKind::VectorMap => quote! { tir::sem_expr::ExprKind::VectorMap },
         ExprKind::Lane => quote! { tir::sem_expr::ExprKind::Lane },
+        ExprKind::Map => todo!(),
+        ExprKind::Zip => todo!(),
+        ExprKind::IterConcat => todo!(),
     }
 }
 

--- a/tmdl/src/sema.rs
+++ b/tmdl/src/sema.rs
@@ -839,6 +839,7 @@ fn check_behavior(
                     walk_paths(&handler.body, out);
                 }
             }
+            ast::Expr::Lambda(l) => walk_paths(&l.body, out),
             ast::Expr::Ident(_)
             | ast::Expr::Lit(_)
             | ast::Expr::BuiltinFunction(_)

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1004,6 +1004,9 @@ fn emit_sem_expr(
         // Loops are eliminated by `unroll_loops` before emission; a surviving one
         // has symbolic bounds, which SMT-LIB cannot express, so it is unsupported.
         ExprKind::Loop | ExprKind::IndVar | ExprKind::Acc => None,
+        // Vector values have no scalar SMT-LIB encoding, so a vector map or lane
+        // read is unsupported by the bit-vector backend.
+        ExprKind::VectorMap | ExprKind::Lane => None,
     }
 }
 

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1008,6 +1008,7 @@ fn emit_sem_expr(
         // read is unsupported by the bit-vector backend.
         ExprKind::VectorMap | ExprKind::Lane => None,
         ExprKind::Map | ExprKind::Zip | ExprKind::IterConcat => None,
+        ExprKind::Split | ExprKind::Reduce | ExprKind::Arg => None,
     }
 }
 
@@ -1076,6 +1077,7 @@ fn collect_mem_ops<'a>(e: &'a ast::Expr, out: &mut Vec<MemOp<'a>>) -> Option<()>
             collect_mem_ops(&f.end, out)?;
             collect_mem_ops(&f.body, out)?;
         }
+        ast::Expr::Lambda(l) => collect_mem_ops(&l.body, out)?,
         ast::Expr::Try(_)
         | ast::Expr::Ident(_)
         | ast::Expr::Path(_)

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -1007,6 +1007,7 @@ fn emit_sem_expr(
         // Vector values have no scalar SMT-LIB encoding, so a vector map or lane
         // read is unsupported by the bit-vector backend.
         ExprKind::VectorMap | ExprKind::Lane => None,
+        ExprKind::Map | ExprKind::Zip | ExprKind::IterConcat => None,
     }
 }
 

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -331,6 +331,14 @@ fn infer<'a>(
                 }
                 Type::Integer
             }
+            // `lane(vector, index)` reads one element; its width is the vector's
+            // element width, which is not tracked, so it stays a free variable.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Lane) => {
+                for arg in &call.arguments {
+                    infer(arg, env, tvg, subst, cache, diags, file_name);
+                }
+                Type::Var(tvg.fresh())
+            }
             ast::Expr::BuiltinFunction(ast::BuiltinFunction::SExt)
             | ast::Expr::BuiltinFunction(ast::BuiltinFunction::ZExt)
             | ast::Expr::BuiltinFunction(ast::BuiltinFunction::Load) => {
@@ -440,7 +448,10 @@ fn infer<'a>(
             let mut body_env = env.clone();
             body_env.bind(f.var.clone(), TypeScheme::mono(Type::Integer));
             infer(&f.body, &body_env, tvg, subst, cache, diags, file_name);
-            Type::Integer
+            // A value-producing (map) loop yields a vector assigned to a register,
+            // so its type must unify with `bits<N>` as well as the integer the
+            // statement and accumulator forms produce; a free variable does both.
+            Type::Var(tvg.fresh())
         }
 
         ast::Expr::BuiltinFunction(_) | ast::Expr::Invalid => Type::Var(tvg.fresh()),

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -637,6 +637,35 @@ fn map_param_tys(
     }
 }
 
+/// Infer a `map`/`reduce` lambda's body with its parameters bound to `param_tys`,
+/// returning the body's (result) type and recording the lambda's `fn` type.
+#[allow(clippy::too_many_arguments)]
+fn infer_lambda<'a>(
+    lambda_arg: &'a ast::Expr,
+    param_tys: &[Type],
+    env: &TypeEnv,
+    tvg: &mut TypeVarGen,
+    subst: &mut Substitution,
+    cache: &mut TypeCache<'a>,
+    diags: &mut Vec<(String, Diag)>,
+    file_name: &str,
+) -> Type {
+    let ast::Expr::Lambda(lambda) = lambda_arg else {
+        // Not a lambda where one is required; infer generically so the body is
+        // still checked. The lowering reports the misuse.
+        return infer(lambda_arg, env, tvg, subst, cache, diags, file_name);
+    };
+    let mut body_env = env.clone();
+    for (name, ty) in lambda.params.iter().zip(param_tys) {
+        body_env.bind(name.clone(), TypeScheme::mono(ty.clone()));
+    }
+    let ret = infer(&lambda.body, &body_env, tvg, subst, cache, diags, file_name);
+    let mut fields: Vec<Type> = param_tys.to_vec();
+    fields.push(ret.clone());
+    cache.insert(lambda_arg, Type::Con("fn".into(), fields));
+    ret
+}
+
 #[cfg(test)]
 mod tests {
     use super::check;
@@ -694,33 +723,4 @@ mod tests {
         );
         assert!(type_check_source(&src).is_empty());
     }
-}
-
-/// Infer a `map`/`reduce` lambda's body with its parameters bound to `param_tys`,
-/// returning the body's (result) type and recording the lambda's `fn` type.
-#[allow(clippy::too_many_arguments)]
-fn infer_lambda<'a>(
-    lambda_arg: &'a ast::Expr,
-    param_tys: &[Type],
-    env: &TypeEnv,
-    tvg: &mut TypeVarGen,
-    subst: &mut Substitution,
-    cache: &mut TypeCache<'a>,
-    diags: &mut Vec<(String, Diag)>,
-    file_name: &str,
-) -> Type {
-    let ast::Expr::Lambda(lambda) = lambda_arg else {
-        // Not a lambda where one is required; infer generically so the body is
-        // still checked. The lowering reports the misuse.
-        return infer(lambda_arg, env, tvg, subst, cache, diags, file_name);
-    };
-    let mut body_env = env.clone();
-    for (name, ty) in lambda.params.iter().zip(param_tys) {
-        body_env.bind(name.clone(), TypeScheme::mono(ty.clone()));
-    }
-    let ret = infer(&lambda.body, &body_env, tvg, subst, cache, diags, file_name);
-    let mut fields: Vec<Type> = param_tys.to_vec();
-    fields.push(ret.clone());
-    cache.insert(lambda_arg, Type::Con("fn".into(), fields));
-    ret
 }

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -23,7 +23,7 @@ pub fn check<'a>(files: &'a [ast::File]) -> (TypeCache<'a>, Vec<(String, Diag)>)
     let mut cache = TypeCache::new();
 
     let isa_param_vars = build_isa_param_vars(files, &mut tvg);
-    let synonyms = build_synonym_table(files, &isa_param_vars);
+    let synonyms = build_synonym_table(files, &isa_param_vars, &mut tvg);
 
     let item_cache: HashMap<&str, &ast::Item> = files
         .iter()
@@ -98,24 +98,37 @@ fn build_isa_param_vars(files: &[ast::File], tvg: &mut TypeVarGen) -> HashMap<St
     vars
 }
 
-fn reg_class_type(rc: &ast::RegisterClass, isa_param_vars: &HashMap<String, TypeVar>) -> Type {
+fn reg_class_type(
+    rc: &ast::RegisterClass,
+    isa_param_vars: &HashMap<String, TypeVar>,
+    tvg: &mut TypeVarGen,
+) -> Type {
+    // A static-width class fixes its width to an ISA parameter (e.g. `XLEN`); the
+    // operand is `bits<XLEN>`. A class whose `WIDTH` is any other expression is
+    // dynamically sized: its width is an architectural quantity not known at
+    // spec time (RVV's `VLEN`, reported at runtime by `vlenb`), so the operand is
+    // `bits<?>` — a bitvector of unknown width. The element structure such a
+    // register carries is imposed by the instructions that read it, not by the
+    // register type, matching hardware where one physical file is reused across
+    // element widths.
     if let Some((_ty, Some(default))) = rc.parameters.get("WIDTH")
         && let ast::Expr::Field(field) = default
         && let Some(&tv) = isa_param_vars.get(&field.member)
     {
         return Type::Con("bits".into(), vec![Type::Var(tv)]);
     }
-    unreachable!("All register classes must have WIDTH parameter")
+    Type::Con("bits".into(), vec![Type::Var(tvg.fresh())])
 }
 
 fn build_synonym_table(
     files: &[ast::File],
     isa_param_vars: &HashMap<String, TypeVar>,
+    tvg: &mut TypeVarGen,
 ) -> SynonymTable {
     let mut synonyms = SynonymTable::new();
     for file in files {
         for rc in file.register_classes() {
-            synonyms.insert(rc.name.clone(), reg_class_type(rc, isa_param_vars));
+            synonyms.insert(rc.name.clone(), reg_class_type(rc, isa_param_vars, tvg));
         }
     }
     synonyms

--- a/tmdl/src/typeck.rs
+++ b/tmdl/src/typeck.rs
@@ -354,6 +354,114 @@ fn infer<'a>(
                 }
                 Type::Integer
             }
+            // `split(bits, n)` -> vec<bits<_>>: the input is some bitvector; each
+            // lane is a bitvector whose width (input / n) is not tracked here.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Split) => {
+                let bits_ty = infer(&call.arguments[0], env, tvg, subst, cache, diags, file_name);
+                for arg in &call.arguments[1..] {
+                    infer(arg, env, tvg, subst, cache, diags, file_name);
+                }
+                constrain(
+                    &bits_ty,
+                    &Type::Con("bits".into(), vec![Type::Var(tvg.fresh())]),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                vec_ty(Type::Con("bits".into(), vec![Type::Var(tvg.fresh())]))
+            }
+            // `concat(iter)` -> bits<_>: joins an iterator's lanes into a bitvector
+            // whose width is the sum of the lane widths, not tracked here.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Concat) => {
+                let iter_ty = infer(&call.arguments[0], env, tvg, subst, cache, diags, file_name);
+                constrain(
+                    &iter_ty,
+                    &vec_ty(Type::Var(tvg.fresh())),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                Type::Con("bits".into(), vec![Type::Var(tvg.fresh())])
+            }
+            // `zip(a, b)` -> vec<pair<A, B>>: pairs two iterators lane-wise.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Zip) => {
+                let lhs_ty = infer(&call.arguments[0], env, tvg, subst, cache, diags, file_name);
+                let rhs_ty = infer(&call.arguments[1], env, tvg, subst, cache, diags, file_name);
+                let a = Type::Var(tvg.fresh());
+                let b = Type::Var(tvg.fresh());
+                constrain(
+                    &lhs_ty,
+                    &vec_ty(a.clone()),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                constrain(
+                    &rhs_ty,
+                    &vec_ty(b.clone()),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                vec_ty(Type::Con("pair".into(), vec![a, b]))
+            }
+            // `map(iter, |x| ...)` -> vec<R>: applies the lambda to each lane. A
+            // two-parameter lambda destructures a zipped pair element.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Map) => {
+                let iter_ty = infer(&call.arguments[0], env, tvg, subst, cache, diags, file_name);
+                let elem = Type::Var(tvg.fresh());
+                constrain(
+                    &iter_ty,
+                    &vec_ty(elem.clone()),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                let param_tys = map_param_tys(&elem.apply(subst), &call.arguments[1], tvg, subst);
+                let ret = infer_lambda(
+                    &call.arguments[1],
+                    &param_tys,
+                    env,
+                    tvg,
+                    subst,
+                    cache,
+                    diags,
+                    file_name,
+                );
+                vec_ty(ret)
+            }
+            // `reduce(iter, |acc, x| ...)` -> R: left-folds the lambda over the
+            // lanes; the accumulator, each lane and the result share one type.
+            ast::Expr::BuiltinFunction(ast::BuiltinFunction::Reduce) => {
+                let iter_ty = infer(&call.arguments[0], env, tvg, subst, cache, diags, file_name);
+                let elem = Type::Var(tvg.fresh());
+                constrain(
+                    &iter_ty,
+                    &vec_ty(elem.clone()),
+                    subst,
+                    call.span,
+                    diags,
+                    file_name,
+                );
+                let elem = elem.apply(subst);
+                let ret = infer_lambda(
+                    &call.arguments[1],
+                    &[elem.clone(), elem.clone()],
+                    env,
+                    tvg,
+                    subst,
+                    cache,
+                    diags,
+                    file_name,
+                );
+                constrain(&ret, &elem, subst, call.span, diags, file_name);
+                elem.apply(subst)
+            }
             callee => {
                 let callee_ty = infer(callee, env, tvg, subst, cache, diags, file_name);
                 for arg in &call.arguments {
@@ -454,9 +562,152 @@ fn infer<'a>(
             Type::Var(tvg.fresh())
         }
 
+        // A bare lambda outside `map`/`reduce` is invalid, but inferring it (with
+        // fresh parameter types) keeps the checker total and reports no spurious
+        // error; the lowering rejects it.
+        ast::Expr::Lambda(lambda) => {
+            let param_tys: Vec<Type> = lambda
+                .params
+                .iter()
+                .map(|_| Type::Var(tvg.fresh()))
+                .collect();
+            let ret = infer_lambda(expr, &param_tys, env, tvg, subst, cache, diags, file_name);
+            let mut fields = param_tys;
+            fields.push(ret);
+            Type::Con("fn".into(), fields)
+        }
+
         ast::Expr::BuiltinFunction(_) | ast::Expr::Invalid => Type::Var(tvg.fresh()),
     };
 
     cache.insert(expr, ty.clone());
     ty
+}
+
+/// An iterator (vector) type carrying elements of `elem`.
+fn vec_ty(elem: Type) -> Type {
+    Type::Con("vec".into(), vec![elem])
+}
+
+/// Parameter types for a `map` lambda over elements of type `elem`. A unary
+/// lambda takes the element; a binary lambda destructures a zipped `pair`
+/// element into its two components (best-effort, leaving them free if `elem` is
+/// not yet known to be a pair).
+fn map_param_tys(
+    elem: &Type,
+    lambda_arg: &ast::Expr,
+    tvg: &mut TypeVarGen,
+    subst: &mut Substitution,
+) -> Vec<Type> {
+    let arity = match lambda_arg {
+        ast::Expr::Lambda(l) => l.params.len(),
+        _ => 1,
+    };
+    match arity {
+        2 => {
+            let a = Type::Var(tvg.fresh());
+            let b = Type::Var(tvg.fresh());
+            let pair = Type::Con("pair".into(), vec![a.clone(), b.clone()]);
+            if let Ok(s) = unify(&elem.apply(subst), &pair) {
+                let old = mem::take(subst);
+                *subst = old.compose(&s);
+                vec![a.apply(subst), b.apply(subst)]
+            } else {
+                vec![a, b]
+            }
+        }
+        n => {
+            let mut tys = vec![elem.clone()];
+            tys.extend((1..n).map(|_| Type::Var(tvg.fresh())));
+            tys
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check;
+
+    fn type_check_source(src: &str) -> Vec<(String, String)> {
+        let (tokens, _lex_errs) = crate::lexer::lex(src);
+        let (file, parse_errs) = crate::parser::parse(src, &tokens, "test.tmdl");
+        assert!(parse_errs.is_empty(), "parse errors: {parse_errs:?}");
+        let files = vec![file.expect("file parses")];
+        let (_cache, diags) = check(&files);
+        diags.into_iter().map(|(f, d)| (f, d.to_string())).collect()
+    }
+
+    const VECTOR_PRELUDE: &str = "
+        isa RV32I { param XLEN: Integer = 32; }
+        isa RVV requires [RV32I] {
+            param VLEN: Integer = 128;
+            param SEW: Integer = 32;
+        }
+        register_class VR for [RVV] {
+            param ENCODING_LEN: Integer = 5;
+            param WIDTH: Integer = self.VLEN;
+            registers { v0..v31 => { traits = [vector] }, }
+        }
+        template VArithVV for [RVV] {
+            param MNEMONIC: String;
+            operands { vd: VR, vs2: VR, vs1: VR, }
+        }
+    ";
+
+    #[test]
+    fn functional_vector_add_type_checks() {
+        let src = format!(
+            "{VECTOR_PRELUDE}
+            instruction VAdd for [RVV] : VArithVV {{
+                param MNEMONIC: String = \"vadd.vv\";
+                behavior {{
+                    vd = concat(map(zip(split(vs2, 4), split(vs1, 4)), |a, b| a + b));
+                }}
+            }}"
+        );
+        assert!(type_check_source(&src).is_empty());
+    }
+
+    #[test]
+    fn functional_reduce_type_checks() {
+        let src = format!(
+            "{VECTOR_PRELUDE}
+            instruction VRedSum for [RVV] : VArithVV {{
+                param MNEMONIC: String = \"vredsum.vs\";
+                behavior {{
+                    vd = reduce(split(vs2, 4), |acc, x| acc + x);
+                }}
+            }}"
+        );
+        assert!(type_check_source(&src).is_empty());
+    }
+}
+
+/// Infer a `map`/`reduce` lambda's body with its parameters bound to `param_tys`,
+/// returning the body's (result) type and recording the lambda's `fn` type.
+#[allow(clippy::too_many_arguments)]
+fn infer_lambda<'a>(
+    lambda_arg: &'a ast::Expr,
+    param_tys: &[Type],
+    env: &TypeEnv,
+    tvg: &mut TypeVarGen,
+    subst: &mut Substitution,
+    cache: &mut TypeCache<'a>,
+    diags: &mut Vec<(String, Diag)>,
+    file_name: &str,
+) -> Type {
+    let ast::Expr::Lambda(lambda) = lambda_arg else {
+        // Not a lambda where one is required; infer generically so the body is
+        // still checked. The lowering reports the misuse.
+        return infer(lambda_arg, env, tvg, subst, cache, diags, file_name);
+    };
+    let mut body_env = env.clone();
+    for (name, ty) in lambda.params.iter().zip(param_tys) {
+        body_env.bind(name.clone(), TypeScheme::mono(ty.clone()));
+    }
+    let ret = infer(&lambda.body, &body_env, tvg, subst, cache, diags, file_name);
+    let mut fields: Vec<Type> = param_tys.to_vec();
+    fields.push(ret.clone());
+    cache.insert(lambda_arg, Type::Con("fn".into(), fields));
+    ret
 }

--- a/tmdl/src/utils.rs
+++ b/tmdl/src/utils.rs
@@ -98,7 +98,7 @@ pub fn eval_bits_width(expr: &ast::Expr, params: &HashMap<String, i64>) -> Optio
     }
     match tir::sem_expr::execute(&graph, &[]) {
         tir::sem_expr::Value::Int(v) => u16::try_from(v.to_u64()).ok(),
-        tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Vector(_) => None,
+        tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Iterator(_) => None,
     }
 }
 

--- a/tmdl/src/utils.rs
+++ b/tmdl/src/utils.rs
@@ -98,7 +98,9 @@ pub fn eval_bits_width(expr: &ast::Expr, params: &HashMap<String, i64>) -> Optio
     }
     match tir::sem_expr::execute(&graph, &[]) {
         tir::sem_expr::Value::Int(v) => u16::try_from(v.to_u64()).ok(),
-        tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Iterator(_) => None,
+        tir::sem_expr::Value::Float(_)
+        | tir::sem_expr::Value::Iterator(_)
+        | tir::sem_expr::Value::RawBits(_) => None,
     }
 }
 

--- a/tmdl/src/utils.rs
+++ b/tmdl/src/utils.rs
@@ -98,7 +98,7 @@ pub fn eval_bits_width(expr: &ast::Expr, params: &HashMap<String, i64>) -> Optio
     }
     match tir::sem_expr::execute(&graph, &[]) {
         tir::sem_expr::Value::Int(v) => u16::try_from(v.to_u64()).ok(),
-        tir::sem_expr::Value::Float(_) => None,
+        tir::sem_expr::Value::Float(_) | tir::sem_expr::Value::Vector(_) => None,
     }
 }
 

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1194,6 +1194,17 @@ fn sem_node_to_dag_stmts(
                     g.set_leaf_data(#var, tir::sem_expr::ExprPayload::SymbolId(#idx_lit));
                 };
                 Some((vec![stmt], var))
+            } else if name == "acc" || name == "indvar" {
+                // The accumulator and induction value of the innermost `(loop ...)`.
+                let kind = if name == "acc" {
+                    quote! { tir::sem_expr::ExprKind::Acc }
+                } else {
+                    quote! { tir::sem_expr::ExprKind::IndVar }
+                };
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                let stmt = quote! { let #var = g.add_node(#kind); };
+                Some((vec![stmt], var))
             } else if let Ok(i) = name.parse::<i64>() {
                 let var = format_ident!("__sem_node_{}", *counter);
                 *counter += 1;
@@ -1268,6 +1279,35 @@ fn sem_node_to_dag_stmts(
                         g.add_edge(#var, #low_var);
                     });
                 }
+                return Some((stmts, var));
+            }
+
+            // `(loop start end init step)` lowers to the IR's first-class `Loop`
+            // node: `init` is the accumulator at entry, `step` is folded over the
+            // half-open range `[start, end)`, reading `acc`/`indvar` for the running
+            // accumulator and induction value.
+            if let [SemNode::Atom(op), start, end, init, step] = items.as_slice()
+                && op == "loop"
+            {
+                let (mut stmts, start_var) =
+                    sem_node_to_dag_stmts(start, operand_symbols, counter)?;
+                let (end_stmts, end_var) = sem_node_to_dag_stmts(end, operand_symbols, counter)?;
+                let (init_stmts, init_var) =
+                    sem_node_to_dag_stmts(init, operand_symbols, counter)?;
+                let (step_stmts, step_var) =
+                    sem_node_to_dag_stmts(step, operand_symbols, counter)?;
+                stmts.extend(end_stmts);
+                stmts.extend(init_stmts);
+                stmts.extend(step_stmts);
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                stmts.push(quote! {
+                    let #var = g.add_node(tir::sem_expr::ExprKind::Loop);
+                    g.add_edge(#var, #start_var);
+                    g.add_edge(#var, #end_var);
+                    g.add_edge(#var, #init_var);
+                    g.add_edge(#var, #step_var);
+                });
                 return Some((stmts, var));
             }
 

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1205,6 +1205,28 @@ fn sem_node_to_dag_stmts(
                 *counter += 1;
                 let stmt = quote! { let #var = g.add_node(#kind); };
                 Some((vec![stmt], var))
+            } else if name == "vlen" {
+                // The lane count of the op's result vector type, read from the
+                // owning context at convert time — the `(map vlen ...)` counterpart
+                // of how the ext ops read their result width.
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                let stmt = quote! {
+                    let __tir_vlen = {
+                        let __ctx = self.0.context.upgrade();
+                        let __ty = __ctx.get_value(self.0.results[0]).ty();
+                        (__ctx.get_type_data(__ty).as_ref() as &dyn std::any::Any)
+                            .downcast_ref::<tir::vector::VectorType>()
+                            .and_then(|t| t.length())
+                            .unwrap_or(0) as u64
+                    };
+                    let #var = g.add_node(tir::sem_expr::ExprKind::Constant);
+                    g.set_leaf_data(
+                        #var,
+                        tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, __tir_vlen)),
+                    );
+                };
+                Some((vec![stmt], var))
             } else if let Ok(i) = name.parse::<i64>() {
                 let var = format_ident!("__sem_node_{}", *counter);
                 *counter += 1;
@@ -1323,6 +1345,10 @@ fn sem_node_to_dag_stmts(
                 "shl" => quote! { tir::sem_expr::ExprKind::ShiftLeft },
                 "lshr" => quote! { tir::sem_expr::ExprKind::ShiftRightLogic },
                 "ashr" => quote! { tir::sem_expr::ExprKind::ShiftRightArithmetic },
+                // `(map count elem)` builds a vector lane-by-lane; `(lane vec i)`
+                // reads one lane. Both are two-child nodes like the binary ops.
+                "map" => quote! { tir::sem_expr::ExprKind::VectorMap },
+                "lane" => quote! { tir::sem_expr::ExprKind::Lane },
                 _ => return None,
             };
             let (mut stmts, lhs_var) = sem_node_to_dag_stmts(lhs, operand_symbols, counter)?;

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1292,10 +1292,8 @@ fn sem_node_to_dag_stmts(
                 let (mut stmts, start_var) =
                     sem_node_to_dag_stmts(start, operand_symbols, counter)?;
                 let (end_stmts, end_var) = sem_node_to_dag_stmts(end, operand_symbols, counter)?;
-                let (init_stmts, init_var) =
-                    sem_node_to_dag_stmts(init, operand_symbols, counter)?;
-                let (step_stmts, step_var) =
-                    sem_node_to_dag_stmts(step, operand_symbols, counter)?;
+                let (init_stmts, init_var) = sem_node_to_dag_stmts(init, operand_symbols, counter)?;
+                let (step_stmts, step_var) = sem_node_to_dag_stmts(step, operand_symbols, counter)?;
                 stmts.extend(end_stmts);
                 stmts.extend(init_stmts);
                 stmts.extend(step_stmts);

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1181,11 +1181,37 @@ fn parse_sem_expr(input: &str) -> Option<SemNode> {
 fn sem_node_to_dag_stmts(
     node: &SemNode,
     operand_symbols: &std::collections::HashMap<String, u32>,
+    lambda_params: &mut Vec<Vec<String>>,
     counter: &mut u32,
 ) -> Option<(Vec<proc_macro2::TokenStream>, proc_macro2::Ident)> {
     match node {
         SemNode::Atom(name) => {
-            if let Some(&idx) = operand_symbols.get(name) {
+            if let Some(method) = name.strip_prefix('$') {
+                // `$name` calls the op's inherent `name(&self, g)` method and
+                // splices the subexpression it builds into the graph, letting an op
+                // compute a value (e.g. its vector length) in Rust rather than in
+                // the s-expr.
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                let method = format_ident!("{}", method);
+                let stmt = quote! { let #var = self.#method(g); };
+                Some((vec![stmt], var))
+            } else if let Some(idx) = lambda_params
+                .last()
+                .and_then(|ps| ps.iter().position(|p| p == name))
+            {
+                // Inside a `map`/`reduce` lambda, a parameter reference lowers to an
+                // `Arg` leaf carrying its position; only the innermost lambda's
+                // parameters are in scope.
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                let idx_lit = proc_macro2::Literal::u64_unsuffixed(idx as u64);
+                let stmt = quote! {
+                    let #var = g.add_node(tir::sem_expr::ExprKind::Arg);
+                    g.set_leaf_data(#var, tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, #idx_lit)));
+                };
+                Some((vec![stmt], var))
+            } else if let Some(&idx) = operand_symbols.get(name) {
                 let var = format_ident!("__sem_node_{}", *counter);
                 *counter += 1;
                 let idx_lit = proc_macro2::Literal::u32_unsuffixed(idx);
@@ -1205,28 +1231,6 @@ fn sem_node_to_dag_stmts(
                 *counter += 1;
                 let stmt = quote! { let #var = g.add_node(#kind); };
                 Some((vec![stmt], var))
-            } else if name == "vlen" {
-                // The lane count of the op's result vector type, read from the
-                // owning context at convert time — the `(map vlen ...)` counterpart
-                // of how the ext ops read their result width.
-                let var = format_ident!("__sem_node_{}", *counter);
-                *counter += 1;
-                let stmt = quote! {
-                    let __tir_vlen = {
-                        let __ctx = self.0.context.upgrade();
-                        let __ty = __ctx.get_value(self.0.results[0]).ty();
-                        (__ctx.get_type_data(__ty).as_ref() as &dyn std::any::Any)
-                            .downcast_ref::<tir::vector::VectorType>()
-                            .and_then(|t| t.length())
-                            .unwrap_or(0) as u64
-                    };
-                    let #var = g.add_node(tir::sem_expr::ExprKind::Constant);
-                    g.set_leaf_data(
-                        #var,
-                        tir::sem_expr::ExprPayload::Int(tir::utils::APInt::new(32, __tir_vlen)),
-                    );
-                };
-                Some((vec![stmt], var))
             } else if let Ok(i) = name.parse::<i64>() {
                 let var = format_ident!("__sem_node_{}", *counter);
                 *counter += 1;
@@ -1241,6 +1245,23 @@ fn sem_node_to_dag_stmts(
             }
         }
         SemNode::List(items) => {
+            // `(concat iter)` joins an iterator's lanes into one bit value; its
+            // single-operand shape would otherwise be mistaken for a width-changing
+            // op below, so handle it first.
+            if let [SemNode::Atom(op), arg] = items.as_slice()
+                && op == "concat"
+            {
+                let (mut stmts, arg_var) =
+                    sem_node_to_dag_stmts(arg, operand_symbols, lambda_params, counter)?;
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                stmts.push(quote! {
+                    let #var = g.add_node(tir::sem_expr::ExprKind::IterConcat);
+                    g.add_edge(#var, #arg_var);
+                });
+                return Some((stmts, var));
+            }
+
             // Unary width-changing ops take the result width from the op's result
             // type (read through the context the generated body already holds), so
             // `(sext x)`/`(zext x)`/`(trunc x)` need no explicit width operand.
@@ -1251,7 +1272,8 @@ fn sem_node_to_dag_stmts(
                     "trunc" => None,
                     _ => return None,
                 };
-                let (mut stmts, arg_var) = sem_node_to_dag_stmts(arg, operand_symbols, counter)?;
+                let (mut stmts, arg_var) =
+                    sem_node_to_dag_stmts(arg, operand_symbols, lambda_params, counter)?;
                 let width_var = format_ident!("__sem_node_{}", *counter);
                 *counter += 1;
                 stmts.push(quote! {
@@ -1312,10 +1334,13 @@ fn sem_node_to_dag_stmts(
                 && op == "loop"
             {
                 let (mut stmts, start_var) =
-                    sem_node_to_dag_stmts(start, operand_symbols, counter)?;
-                let (end_stmts, end_var) = sem_node_to_dag_stmts(end, operand_symbols, counter)?;
-                let (init_stmts, init_var) = sem_node_to_dag_stmts(init, operand_symbols, counter)?;
-                let (step_stmts, step_var) = sem_node_to_dag_stmts(step, operand_symbols, counter)?;
+                    sem_node_to_dag_stmts(start, operand_symbols, lambda_params, counter)?;
+                let (end_stmts, end_var) =
+                    sem_node_to_dag_stmts(end, operand_symbols, lambda_params, counter)?;
+                let (init_stmts, init_var) =
+                    sem_node_to_dag_stmts(init, operand_symbols, lambda_params, counter)?;
+                let (step_stmts, step_var) =
+                    sem_node_to_dag_stmts(step, operand_symbols, lambda_params, counter)?;
                 stmts.extend(end_stmts);
                 stmts.extend(init_stmts);
                 stmts.extend(step_stmts);
@@ -1327,6 +1352,53 @@ fn sem_node_to_dag_stmts(
                     g.add_edge(#var, #end_var);
                     g.add_edge(#var, #init_var);
                     g.add_edge(#var, #step_var);
+                });
+                return Some((stmts, var));
+            }
+
+            // `(map iter (lambda (x) body))` / `(reduce iter (lambda (acc x) body))`
+            // apply a lambda over an iterator's lanes. The lambda's parameters are
+            // pushed so references to them inside `body` lower to `Arg` leaves.
+            if let [SemNode::Atom(op), iter, lambda] = items.as_slice()
+                && (op == "map" || op == "reduce")
+            {
+                let SemNode::List(parts) = lambda else {
+                    return None;
+                };
+                let [SemNode::Atom(lam_kw), SemNode::List(param_nodes), body] = parts.as_slice()
+                else {
+                    return None;
+                };
+                if lam_kw != "lambda" {
+                    return None;
+                }
+                let mut params = Vec::with_capacity(param_nodes.len());
+                for p in param_nodes {
+                    let SemNode::Atom(p) = p else {
+                        return None;
+                    };
+                    params.push(p.clone());
+                }
+
+                let (mut stmts, iter_var) =
+                    sem_node_to_dag_stmts(iter, operand_symbols, lambda_params, counter)?;
+                lambda_params.push(params);
+                let body = sem_node_to_dag_stmts(body, operand_symbols, lambda_params, counter);
+                lambda_params.pop();
+                let (body_stmts, body_var) = body?;
+                stmts.extend(body_stmts);
+
+                let kind = if op == "map" {
+                    quote! { tir::sem_expr::ExprKind::Map }
+                } else {
+                    quote! { tir::sem_expr::ExprKind::Reduce }
+                };
+                let var = format_ident!("__sem_node_{}", *counter);
+                *counter += 1;
+                stmts.push(quote! {
+                    let #var = g.add_node(#kind);
+                    g.add_edge(#var, #iter_var);
+                    g.add_edge(#var, #body_var);
                 });
                 return Some((stmts, var));
             }
@@ -1345,14 +1417,17 @@ fn sem_node_to_dag_stmts(
                 "shl" => quote! { tir::sem_expr::ExprKind::ShiftLeft },
                 "lshr" => quote! { tir::sem_expr::ExprKind::ShiftRightLogic },
                 "ashr" => quote! { tir::sem_expr::ExprKind::ShiftRightArithmetic },
-                // `(map count elem)` builds a vector lane-by-lane; `(lane vec i)`
-                // reads one lane. Both are two-child nodes like the binary ops.
-                "map" => quote! { tir::sem_expr::ExprKind::VectorMap },
-                "lane" => quote! { tir::sem_expr::ExprKind::Lane },
+                // `(zip a b)` pairs two iterators lane-wise; `(split bits n)` cuts a
+                // bit value into `n` lanes. Both are two-child nodes like the binary
+                // arithmetic ops.
+                "zip" => quote! { tir::sem_expr::ExprKind::Zip },
+                "split" => quote! { tir::sem_expr::ExprKind::Split },
                 _ => return None,
             };
-            let (mut stmts, lhs_var) = sem_node_to_dag_stmts(lhs, operand_symbols, counter)?;
-            let (rhs_stmts, rhs_var) = sem_node_to_dag_stmts(rhs, operand_symbols, counter)?;
+            let (mut stmts, lhs_var) =
+                sem_node_to_dag_stmts(lhs, operand_symbols, lambda_params, counter)?;
+            let (rhs_stmts, rhs_var) =
+                sem_node_to_dag_stmts(rhs, operand_symbols, lambda_params, counter)?;
             stmts.extend(rhs_stmts);
             let var = format_ident!("__sem_node_{}", *counter);
             *counter += 1;
@@ -1395,7 +1470,8 @@ fn expr_as_sem_expr_body(expr: &Expr, operands: &[ValueSpec]) -> Option<proc_mac
     }
 
     let mut counter = 0u32;
-    let (stmts, root_var) = sem_node_to_dag_stmts(rhs, &symbols, &mut counter)?;
+    let mut lambda_params: Vec<Vec<String>> = Vec::new();
+    let (stmts, root_var) = sem_node_to_dag_stmts(rhs, &symbols, &mut lambda_params, &mut counter)?;
     Some(quote! {
         #(#stmts)*
         #root_var


### PR DESCRIPTION
Add a target-independent vector dialect with a VectorType (static vec<8xi32>
or dynamic vec<i32>) and elementwise add/sub/mul ops carrying an optional
vector-length operand. Extend the operation! macro s-expr parser with a
(loop start end init step) form plus acc/indvar leaves, lowering to the IR's
first-class Loop node.