### PR TITLE
refactor(fcc): store AST in core's post-order DAG

### DIFF
--- a/core/src/graph/postorder.rs
+++ b/core/src/graph/postorder.rs
@@ -38,11 +38,6 @@ impl<N, L> PostOrderDag<N, L> {
         bits[idx / 64] |= 1u64 << (idx % 64);
     }
 
-    fn contains_reachable(&self, root: NodeId, target: NodeId) -> bool {
-        let idx = target.index();
-        (self.descendants[root.index()][idx / 64] & (1u64 << (idx % 64))) != 0
-    }
-
     fn merge_descendants(&mut self, into: NodeId, from: NodeId) -> bool {
         let src = self.descendants[from.index()].clone();
         self.merge_bits(into, &src)
@@ -70,32 +65,6 @@ impl<N, L> PostOrderDag<N, L> {
         }
     }
 
-    /// Post-order traversal of the subtree reachable from `root`, like
-    /// [`Dag::postorder`] but starting the scan at `root`'s lowest-indexed
-    /// descendant instead of node 0. For a tree (every node has one parent) a
-    /// subtree occupies a contiguous index range, so this visits exactly the
-    /// subtree — `O(subtree)` rather than `O(root index)`.
-    pub fn postorder_from(&self, root: NodeId) -> PostOrderDagIter<'_, N, L> {
-        PostOrderDagIter {
-            dag: self,
-            root,
-            next_index: self.first_descendant(root),
-            end_index: root.index(),
-        }
-    }
-
-    /// The smallest index reachable from `root`. `root` always marks itself, so
-    /// the result never exceeds `root.index()`.
-    fn first_descendant(&self, root: NodeId) -> usize {
-        let bits = &self.descendants[root.index()];
-        for (word, &mask) in bits.iter().enumerate() {
-            if mask != 0 {
-                return word * 64 + mask.trailing_zeros() as usize;
-            }
-        }
-        root.index()
-    }
-
     fn nth_preorder(&self, node: NodeId, remaining: &mut usize) -> Option<NodeId> {
         if *remaining == 0 {
             return Some(node);
@@ -119,27 +88,38 @@ impl<N, L> Default for PostOrderDag<N, L> {
     }
 }
 
-pub struct PostOrderDagIter<'a, N, L> {
-    dag: &'a PostOrderDag<N, L>,
-    root: NodeId,
-    next_index: usize,
-    end_index: usize,
+/// Yields a root's reachable set — its post-order traversal, since nodes are
+/// stored in post order — by walking the descendant bitmask directly: it scans
+/// only set bits (skipping empty words) instead of testing every index.
+pub struct PostOrderDagIter<'a> {
+    bits: &'a [u64],
+    word: usize,
+    current: u64,
 }
 
-impl<N, L> Iterator for PostOrderDagIter<'_, N, L> {
+impl<'a> PostOrderDagIter<'a> {
+    fn new(bits: &'a [u64]) -> Self {
+        Self {
+            bits,
+            word: 0,
+            current: bits.first().copied().unwrap_or(0),
+        }
+    }
+}
+
+impl Iterator for PostOrderDagIter<'_> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.next_index <= self.end_index {
-            let candidate = NodeId::from_index(self.next_index);
-            self.next_index += 1;
-
-            if self.dag.contains_reachable(self.root, candidate) {
-                return Some(candidate);
+        loop {
+            if self.current != 0 {
+                let bit = self.current.trailing_zeros() as usize;
+                self.current &= self.current - 1;
+                return Some(NodeId::from_index(self.word * 64 + bit));
             }
+            self.word += 1;
+            self.current = *self.bits.get(self.word)?;
         }
-
-        None
     }
 }
 
@@ -198,12 +178,7 @@ impl<N, L> Dag for PostOrderDag<N, L> {
     }
 
     fn postorder(&self, start: NodeId) -> impl Iterator<Item = NodeId> {
-        PostOrderDagIter {
-            dag: self,
-            root: start,
-            next_index: 0,
-            end_index: start.index(),
-        }
+        PostOrderDagIter::new(&self.descendants[start.index()])
     }
 
     fn preorder(&self, start: NodeId) -> impl Iterator<Item = NodeId> {
@@ -285,20 +260,19 @@ mod tests {
     }
 
     #[test]
-    fn postorder_from_matches_global_postorder_at_root() {
+    fn postorder_at_root_visits_every_node_in_order() {
         let (dag, root) = sample();
-        let global: Vec<_> = dag.postorder(root).collect();
-        let from: Vec<_> = dag.postorder_from(root).collect();
-        assert_eq!(global, from);
-        assert_eq!(from.len(), dag.len());
+        let nodes: Vec<_> = dag.postorder(root).collect();
+        let expected: Vec<_> = (0..dag.len()).map(NodeId::from_index).collect();
+        assert_eq!(nodes, expected);
     }
 
     #[test]
-    fn postorder_from_visits_only_the_subtree() {
+    fn postorder_visits_only_the_subtree() {
         let (dag, _root) = sample();
         // The right `Add` is node 5; its subtree is nodes 3, 4, 5.
         let right = NodeId::from_index(5);
-        let nodes: Vec<_> = dag.postorder_from(right).collect();
+        let nodes: Vec<_> = dag.postorder(right).collect();
         assert_eq!(
             nodes,
             vec![

--- a/core/src/graph/postorder.rs
+++ b/core/src/graph/postorder.rs
@@ -70,6 +70,32 @@ impl<N, L> PostOrderDag<N, L> {
         }
     }
 
+    /// Post-order traversal of the subtree reachable from `root`, like
+    /// [`Dag::postorder`] but starting the scan at `root`'s lowest-indexed
+    /// descendant instead of node 0. For a tree (every node has one parent) a
+    /// subtree occupies a contiguous index range, so this visits exactly the
+    /// subtree — `O(subtree)` rather than `O(root index)`.
+    pub fn postorder_from(&self, root: NodeId) -> PostOrderDagIter<'_, N, L> {
+        PostOrderDagIter {
+            dag: self,
+            root,
+            next_index: self.first_descendant(root),
+            end_index: root.index(),
+        }
+    }
+
+    /// The smallest index reachable from `root`. `root` always marks itself, so
+    /// the result never exceeds `root.index()`.
+    fn first_descendant(&self, root: NodeId) -> usize {
+        let bits = &self.descendants[root.index()];
+        for (word, &mask) in bits.iter().enumerate() {
+            if mask != 0 {
+                return word * 64 + mask.trailing_zeros() as usize;
+            }
+        }
+        root.index()
+    }
+
     fn nth_preorder(&self, node: NodeId, remaining: &mut usize) -> Option<NodeId> {
         if *remaining == 0 {
             return Some(node);
@@ -230,5 +256,56 @@ impl<N, L> MutDag for PostOrderDag<N, L> {
 
     fn set_actual_type(&mut self, n: NodeId, ty: TypeId) {
         self.actual_types.insert(n, ty);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Dag;
+
+    /// Build the tree `(0+1) + (3+4)` laid out in post order: leaves first, then
+    /// each `Add`, then the root. Returns the dag and its root.
+    fn sample() -> (PostOrderDag<&'static str, ()>, NodeId) {
+        let mut dag = PostOrderDag::new();
+        let a = dag.add_node("0");
+        let b = dag.add_node("1");
+        let left = dag.add_node("+");
+        dag.add_edge(left, a);
+        dag.add_edge(left, b);
+        let c = dag.add_node("3");
+        let d = dag.add_node("4");
+        let right = dag.add_node("+");
+        dag.add_edge(right, c);
+        dag.add_edge(right, d);
+        let root = dag.add_node("+");
+        dag.add_edge(root, left);
+        dag.add_edge(root, right);
+        (dag, root)
+    }
+
+    #[test]
+    fn postorder_from_matches_global_postorder_at_root() {
+        let (dag, root) = sample();
+        let global: Vec<_> = dag.postorder(root).collect();
+        let from: Vec<_> = dag.postorder_from(root).collect();
+        assert_eq!(global, from);
+        assert_eq!(from.len(), dag.len());
+    }
+
+    #[test]
+    fn postorder_from_visits_only_the_subtree() {
+        let (dag, _root) = sample();
+        // The right `Add` is node 5; its subtree is nodes 3, 4, 5.
+        let right = NodeId::from_index(5);
+        let nodes: Vec<_> = dag.postorder_from(right).collect();
+        assert_eq!(
+            nodes,
+            vec![
+                NodeId::from_index(3),
+                NodeId::from_index(4),
+                NodeId::from_index(5),
+            ]
+        );
     }
 }

--- a/fcc/Cargo.toml
+++ b/fcc/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 
 [dev-dependencies]
 tir-lit = { path = "../utils/lit" }
+criterion = { workspace = true }
 
 [[bin]]
 name = "fcc"
@@ -20,4 +21,8 @@ path = "bin.rs"
 
 [[test]]
 name = "lit"
+harness = false
+
+[[bench]]
+name = "codegen"
 harness = false

--- a/fcc/benches/codegen.rs
+++ b/fcc/benches/codegen.rs
@@ -1,0 +1,67 @@
+//! End-to-end codegen benchmark for the `fcc` C frontend: it lowers a
+//! synthetic translation unit (many functions, each a chain of local
+//! declarations over deep arithmetic) down to TIR. `codegen` measures the
+//! AST → IR step in isolation; `pipeline` includes tokenizing and parsing.
+
+use std::fmt::Write;
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use logos::Logos;
+
+use fcc::ast::Ast;
+use fcc::codegen::codegen;
+use fcc::lexer::Token;
+use fcc::parser::parse;
+use tir::Context;
+
+/// Build a translation unit with `funcs` functions, each declaring `stmts`
+/// locals over progressively deeper expressions before returning one.
+fn gen_source(funcs: usize, stmts: usize) -> String {
+    let mut src = String::new();
+    for f in 0..funcs {
+        write!(src, "int f{f}(int a, int b, int c) {{ ").unwrap();
+        src.push_str("int t0 = a * b + c; ");
+        for s in 1..stmts {
+            write!(src, "int t{s} = t{} * a - b + t{} * c; ", s - 1, s / 2).unwrap();
+        }
+        write!(src, "return t{} + t0 * a; }}\n", stmts - 1).unwrap();
+    }
+    src
+}
+
+fn parse_src(src: &str) -> Ast {
+    let tokens: Vec<Token> = Token::lexer(src).map(|r| r.unwrap()).collect();
+    parse(&tokens).expect("parse")
+}
+
+fn bench_codegen(c: &mut Criterion) {
+    let src = gen_source(50, 40);
+    let ast = parse_src(&src);
+
+    let mut group = c.benchmark_group("fcc/codegen");
+    group.bench_function("ast_to_ir", |b| {
+        b.iter(|| {
+            let ctx = Context::with_default_dialects();
+            black_box(codegen(&ctx, &ast).unwrap());
+        });
+    });
+    group.finish();
+}
+
+fn bench_pipeline(c: &mut Criterion) {
+    let src = gen_source(50, 40);
+
+    let mut group = c.benchmark_group("fcc/pipeline");
+    group.bench_function("source_to_ir", |b| {
+        b.iter(|| {
+            let ast = parse_src(&src);
+            let ctx = Context::with_default_dialects();
+            black_box(codegen(&ctx, &ast).unwrap());
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_codegen, bench_pipeline);
+criterion_main!(benches);

--- a/fcc/benches/codegen.rs
+++ b/fcc/benches/codegen.rs
@@ -30,6 +30,33 @@ fn gen_source(funcs: usize, stmts: usize) -> String {
     src
 }
 
+/// A fully-parenthesized balanced expression of the given depth (`2^depth`
+/// leaves), rotating through the parameters and operators.
+fn build_expr(depth: usize, n: &mut usize) -> String {
+    if depth == 0 {
+        let v = ["a", "b", "c"][*n % 3];
+        *n += 1;
+        return v.to_string();
+    }
+    let lhs = build_expr(depth - 1, n);
+    let op = ["+", "-", "*"][*n % 3];
+    let rhs = build_expr(depth - 1, n);
+    format!("({lhs} {op} {rhs})")
+}
+
+/// Expression-dominated translation unit: a handful of functions, each a single
+/// `return` over one huge arithmetic tree, so codegen time is almost entirely
+/// expression lowering.
+fn gen_expr_heavy(funcs: usize, depth: usize) -> String {
+    let mut src = String::new();
+    for f in 0..funcs {
+        let mut n = f;
+        let expr = build_expr(depth, &mut n);
+        writeln!(src, "int g{f}(int a, int b, int c) {{ return {expr}; }}").unwrap();
+    }
+    src
+}
+
 fn parse_src(src: &str) -> Ast {
     let tokens: Vec<Token> = Token::lexer(src).map(|r| r.unwrap()).collect();
     parse(&tokens).expect("parse")
@@ -40,6 +67,20 @@ fn bench_codegen(c: &mut Criterion) {
     let ast = parse_src(&src);
 
     let mut group = c.benchmark_group("fcc/codegen");
+    group.bench_function("ast_to_ir", |b| {
+        b.iter(|| {
+            let ctx = Context::with_default_dialects();
+            black_box(codegen(&ctx, &ast).unwrap());
+        });
+    });
+    group.finish();
+}
+
+fn bench_codegen_expr_heavy(c: &mut Criterion) {
+    let src = gen_expr_heavy(20, 12);
+    let ast = parse_src(&src);
+
+    let mut group = c.benchmark_group("fcc/codegen_expr_heavy");
     group.bench_function("ast_to_ir", |b| {
         b.iter(|| {
             let ctx = Context::with_default_dialects();
@@ -63,5 +104,10 @@ fn bench_pipeline(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_codegen, bench_pipeline);
+criterion_group!(
+    benches,
+    bench_codegen,
+    bench_codegen_expr_heavy,
+    bench_pipeline
+);
 criterion_main!(benches);

--- a/fcc/benches/codegen.rs
+++ b/fcc/benches/codegen.rs
@@ -25,7 +25,7 @@ fn gen_source(funcs: usize, stmts: usize) -> String {
         for s in 1..stmts {
             write!(src, "int t{s} = t{} * a - b + t{} * c; ", s - 1, s / 2).unwrap();
         }
-        write!(src, "return t{} + t0 * a; }}\n", stmts - 1).unwrap();
+        writeln!(src, "return t{} + t0 * a; }}", stmts - 1).unwrap();
     }
     src
 }

--- a/fcc/checks/Ast/sum.c
+++ b/fcc/checks/Ast/sum.c
@@ -2,36 +2,11 @@
 
 // RUN: fcc compile --stage ast -o - %S/../Inputs/sum.c | filecheck %s
 
-// CHECK: TranslationUnit {
-// CHECK-NEXT:     functions: [
-// CHECK-NEXT:         Function {
-// CHECK-NEXT:             name: "sum",
-// CHECK-NEXT:             ret: Int,
-// CHECK-NEXT:             params: [
-// CHECK-NEXT:                 Param {
-// CHECK-NEXT:                     name: "a",
-// CHECK-NEXT:                     ty: Int,
-// CHECK-NEXT:                 },
-// CHECK-NEXT:                 Param {
-// CHECK-NEXT:                     name: "b",
-// CHECK-NEXT:                     ty: Int,
-// CHECK-NEXT:                 },
-// CHECK-NEXT:             ],
-// CHECK-NEXT:             body: [
-// CHECK-NEXT:                 Return(
-// CHECK-NEXT:                     Some(
-// CHECK-NEXT:                         Binary {
-// CHECK-NEXT:                             op: Add,
-// CHECK-NEXT:                             lhs: Var(
-// CHECK-NEXT:                                 "a",
-// CHECK-NEXT:                             ),
-// CHECK-NEXT:                             rhs: Var(
-// CHECK-NEXT:                                 "b",
-// CHECK-NEXT:                             ),
-// CHECK-NEXT:                         },
-// CHECK-NEXT:                     ),
-// CHECK-NEXT:                 ),
-// CHECK-NEXT:             ],
-// CHECK-NEXT:         },
-// CHECK-NEXT:     ],
-// CHECK-NEXT: }
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "sum" -> Int
+// CHECK-NEXT:     Param "a": Int
+// CHECK-NEXT:     Param "b": Int
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Add
+// CHECK-NEXT:         Var "a"
+// CHECK-NEXT:         Var "b"

--- a/fcc/src/ast.rs
+++ b/fcc/src/ast.rs
@@ -2,60 +2,105 @@
 //! simple integer function (parameters, local `int` variables, arithmetic and
 //! `return`) down to IR. There are no types beyond `int`/`void`, no control
 //! flow, and no pointers at the source level.
+//!
+//! The tree is stored in core's [`PostOrderDag`], the same cache-friendly,
+//! post-order layout the semantic-expression graph uses: node *kinds* live in a
+//! flat vector while the variable-sized payload (names, literals, types) sits in
+//! a sparse side table keyed by node id. Children always precede their parent,
+//! so the root is the last node.
 
-#[derive(Debug, Clone, PartialEq)]
+use tir::graph::{Dag, NodeId, PostOrderDag};
+
+pub type Ast = PostOrderDag<AstKind, AstLeaf>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CType {
     Int,
     Void,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct TranslationUnit {
-    pub functions: Vec<Function>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Function {
-    pub name: String,
-    pub ret: CType,
-    pub params: Vec<Param>,
-    pub body: Vec<Stmt>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Param {
-    pub name: String,
-    pub ty: CType,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum Stmt {
-    /// `int name = init;` or `int name;`
-    Decl {
-        name: String,
-        ty: CType,
-        init: Option<Expr>,
-    },
-    /// `name = value;`
-    Assign { name: String, value: Expr },
-    /// `return expr;` or `return;`
-    Return(Option<Expr>),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum Expr {
-    Int(i64),
-    Var(String),
-    Binary {
-        op: BinOp,
-        lhs: Box<Expr>,
-        rhs: Box<Expr>,
-    },
-}
-
+/// The structural kind of an AST node. How its children are interpreted depends
+/// solely on the kind; payload data lives in the matching [`AstLeaf`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BinOp {
+pub enum AstKind {
+    /// Children: the translation unit's functions.
+    TranslationUnit,
+    /// Children: parameters, then body statements.
+    Function,
+    Param,
+    /// Child: the optional initializer expression.
+    Decl,
+    /// Child: the assigned value expression.
+    Assign,
+    /// Child: the optional returned expression.
+    Return,
+    /// Children: left-hand side, right-hand side.
     Add,
     Sub,
     Mul,
+    Var,
+    Int,
+}
+
+/// Payload for the nodes that carry one. Indexed by node id through
+/// [`Dag::get_leaf_data`]; structural nodes ([`AstKind::TranslationUnit`],
+/// [`AstKind::Return`], the binary operators) have none.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AstLeaf {
+    Function { name: String, ret: CType },
+    Param { name: String, ty: CType },
+    Decl { name: String, ty: CType },
+    Assign(String),
+    Var(String),
+    Int(i64),
+}
+
+/// Render the tree as an indented outline, used by the `--stage ast` output.
+pub fn render(ast: &Ast) -> String {
+    let mut out = String::new();
+    if let Some(root) = ast.root() {
+        render_node(ast, root, 0, &mut out);
+    }
+    out
+}
+
+fn render_node(ast: &Ast, id: NodeId, depth: usize, out: &mut String) {
+    use std::fmt::Write;
+
+    let label = match ast.get_node(id) {
+        AstKind::TranslationUnit => "TranslationUnit".to_string(),
+        AstKind::Function => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Function { name, ret }) => format!("Function {name:?} -> {ret:?}"),
+            _ => unreachable!(),
+        },
+        AstKind::Param => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Param { name, ty }) => format!("Param {name:?}: {ty:?}"),
+            _ => unreachable!(),
+        },
+        AstKind::Decl => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Decl { name, ty }) => format!("Decl {name:?}: {ty:?}"),
+            _ => unreachable!(),
+        },
+        AstKind::Assign => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Assign(name)) => format!("Assign {name:?}"),
+            _ => unreachable!(),
+        },
+        AstKind::Return => "Return".to_string(),
+        AstKind::Add => "Add".to_string(),
+        AstKind::Sub => "Sub".to_string(),
+        AstKind::Mul => "Mul".to_string(),
+        AstKind::Var => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Var(name)) => format!("Var {name:?}"),
+            _ => unreachable!(),
+        },
+        AstKind::Int => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Int(value)) => format!("Int {value}"),
+            _ => unreachable!(),
+        },
+    };
+
+    writeln!(out, "{:indent$}{label}", "", indent = depth * 2).unwrap();
+    for child in ast.children(id) {
+        render_node(ast, child, depth + 1, out);
+    }
 }

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use tir::builtin::{IntegerType, ModuleOp, UnitType, ops as b};
+use tir::graph::{Dag, NodeId};
 use tir::ptr::{PtrType, ops as p};
 use tir::{Context, IRBuilder, Operand, Operation, TypeId, ValueId};
 
@@ -23,17 +24,19 @@ struct Slot {
 
 struct FnCodegen<'a> {
     context: &'a Context,
+    ast: &'a Ast,
     builder: IRBuilder,
     locals: HashMap<String, Slot>,
 }
 
 /// Lower a translation unit into a `builtin.module` in `context`.
-pub fn codegen(context: &Context, unit: &TranslationUnit) -> Result<ModuleOp, String> {
+pub fn codegen(context: &Context, ast: &Ast) -> Result<ModuleOp, String> {
     let module = b::module(context, None).build();
     let mut module_builder = IRBuilder::new(module.body());
 
-    for func in &unit.functions {
-        let func_op = lower_function(context, func)?;
+    let root = ast.root().ok_or("empty translation unit")?;
+    for func in ast.children(root) {
+        let func_op = lower_function(context, ast, func)?;
         module_builder.insert(func_op);
     }
     module_builder.insert(b::module_end(context).build());
@@ -47,14 +50,24 @@ fn lower_ctype(context: &Context, ty: &CType) -> TypeId {
     }
 }
 
-fn lower_function(context: &Context, func: &Function) -> Result<impl Operation, String> {
-    let ret_ty = lower_ctype(context, &func.ret);
+fn lower_function(context: &Context, ast: &Ast, func: NodeId) -> Result<impl Operation, String> {
+    let AstLeaf::Function { name, ret } = ast.get_leaf_data(func).unwrap() else {
+        unreachable!("function node carries a function payload");
+    };
+    let ret_ty = lower_ctype(context, ret);
+
+    let params: Vec<NodeId> = ast
+        .children(func)
+        .take_while(|&c| matches!(ast.get_node(c), AstKind::Param))
+        .collect();
 
     // Entry block arguments carry the incoming parameter values.
     let mut param_values = Vec::new();
-    for param in &func.params {
-        let ty = lower_ctype(context, &param.ty);
-        param_values.push(context.create_value(ty, None));
+    for &param in &params {
+        let AstLeaf::Param { ty, .. } = ast.get_leaf_data(param).unwrap() else {
+            unreachable!("param node carries a param payload");
+        };
+        param_values.push(context.create_value(lower_ctype(context, ty), None));
     }
     let param_ids: Vec<ValueId> = param_values.iter().map(|v| v.id()).collect();
 
@@ -62,24 +75,28 @@ fn lower_function(context: &Context, func: &Function) -> Result<impl Operation, 
     let block = context.create_block(param_values);
     region.add_block(block.id());
 
-    let func_op = b::func(context, func.name.as_str(), ret_ty, Some(region.id())).build();
+    let func_op = b::func(context, name.as_str(), ret_ty, Some(region.id())).build();
 
     let mut cg = FnCodegen {
         context,
+        ast,
         builder: IRBuilder::new(func_op.body()),
         locals: HashMap::new(),
     };
 
     // Spill each parameter into its own stack slot, mirroring -O0 codegen.
-    for (param, value) in func.params.iter().zip(param_ids) {
-        let elem = lower_ctype(context, &param.ty);
+    for (&param, value) in params.iter().zip(param_ids) {
+        let AstLeaf::Param { name, ty } = ast.get_leaf_data(param).unwrap() else {
+            unreachable!("param node carries a param payload");
+        };
+        let elem = lower_ctype(context, ty);
         let slot = cg.alloca(elem);
         cg.builder
             .insert(p::store(context, value, slot.ptr).build());
-        cg.locals.insert(param.name.clone(), slot);
+        cg.locals.insert(name.clone(), slot);
     }
 
-    for stmt in &func.body {
+    for stmt in ast.children(func).skip(params.len()) {
         cg.lower_stmt(stmt)?;
     }
 
@@ -96,31 +113,39 @@ impl FnCodegen<'_> {
         }
     }
 
-    fn lower_stmt(&mut self, stmt: &Stmt) -> Result<(), String> {
-        match stmt {
-            Stmt::Decl { name, ty, init } => {
+    fn lower_stmt(&mut self, stmt: NodeId) -> Result<(), String> {
+        let ast = self.ast;
+        match ast.get_node(stmt) {
+            AstKind::Decl => {
+                let AstLeaf::Decl { name, ty } = ast.get_leaf_data(stmt).unwrap() else {
+                    unreachable!("decl node carries a decl payload");
+                };
                 let elem = lower_ctype(self.context, ty);
                 let slot = self.alloca(elem);
-                if let Some(expr) = init {
-                    let value = self.lower_expr(expr)?;
+                if let Some(init) = ast.children(stmt).next() {
+                    let value = self.lower_expr(init)?;
                     self.builder
                         .insert(p::store(self.context, value, slot.ptr).build());
                 }
                 self.locals.insert(name.clone(), slot);
                 Ok(())
             }
-            Stmt::Assign { name, value } => {
+            AstKind::Assign => {
+                let AstLeaf::Assign(name) = ast.get_leaf_data(stmt).unwrap() else {
+                    unreachable!("assign node carries an assign payload");
+                };
                 let slot = *self
                     .locals
                     .get(name)
                     .ok_or_else(|| format!("assignment to unknown variable '{name}'"))?;
+                let value = ast.children(stmt).next().unwrap();
                 let v = self.lower_expr(value)?;
                 self.builder
                     .insert(p::store(self.context, v, slot.ptr).build());
                 Ok(())
             }
-            Stmt::Return(expr) => {
-                let operand = match expr {
+            AstKind::Return => {
+                let operand = match ast.children(stmt).next() {
                     Some(e) => Operand::from(self.lower_expr(e)?),
                     None => Operand::none(),
                 };
@@ -128,19 +153,27 @@ impl FnCodegen<'_> {
                     .insert(b::r#return(self.context, operand).build());
                 Ok(())
             }
+            kind => unreachable!("not a statement: {kind:?}"),
         }
     }
 
-    fn lower_expr(&mut self, expr: &Expr) -> Result<ValueId, String> {
+    fn lower_expr(&mut self, expr: NodeId) -> Result<ValueId, String> {
+        let ast = self.ast;
         let i32_ty = IntegerType::new(self.context, 32);
-        match expr {
-            Expr::Int(n) => {
+        match ast.get_node(expr) {
+            AstKind::Int => {
+                let AstLeaf::Int(n) = ast.get_leaf_data(expr).unwrap() else {
+                    unreachable!("int node carries an int payload");
+                };
                 let op = self
                     .builder
                     .insert(b::constant(self.context, *n, i32_ty).build());
                 Ok(op.result())
             }
-            Expr::Var(name) => {
+            AstKind::Var => {
+                let AstLeaf::Var(name) = ast.get_leaf_data(expr).unwrap() else {
+                    unreachable!("var node carries a var payload");
+                };
                 let slot = *self
                     .locals
                     .get(name)
@@ -150,25 +183,30 @@ impl FnCodegen<'_> {
                     .insert(p::load(self.context, slot.ptr, slot.elem).build());
                 Ok(op.result())
             }
-            Expr::Binary { op, lhs, rhs } => {
+            kind @ (AstKind::Add | AstKind::Sub | AstKind::Mul) => {
+                let kind = *kind;
+                let mut children = ast.children(expr);
+                let lhs = children.next().unwrap();
+                let rhs = children.next().unwrap();
                 let l = self.lower_expr(lhs)?;
                 let r = self.lower_expr(rhs)?;
-                let result = match op {
-                    BinOp::Add => self
+                let result = match kind {
+                    AstKind::Add => self
                         .builder
                         .insert(b::addi(self.context, l, r, i32_ty).build())
                         .result(),
-                    BinOp::Sub => self
+                    AstKind::Sub => self
                         .builder
                         .insert(b::subi(self.context, l, r, i32_ty).build())
                         .result(),
-                    BinOp::Mul => self
+                    _ => self
                         .builder
                         .insert(b::muli(self.context, l, r, i32_ty).build())
                         .result(),
                 };
                 Ok(result)
             }
+            kind => unreachable!("not an expression: {kind:?}"),
         }
     }
 }

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -186,7 +186,7 @@ impl FnCodegen<'_> {
         self.values.clear();
         let mut base = root.index();
 
-        for node in ast.postorder_from(root) {
+        for node in ast.postorder(root) {
             if self.values.is_empty() {
                 base = node.index();
             }

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -27,6 +27,10 @@ struct FnCodegen<'a> {
     ast: &'a Ast,
     builder: IRBuilder,
     locals: HashMap<String, Slot>,
+    /// Scratch holding the lowered SSA value of each node in the expression
+    /// subtree currently being lowered, indexed by `node.index() - base`. Reused
+    /// across expressions to avoid reallocating.
+    values: Vec<ValueId>,
 }
 
 /// Lower a translation unit into a `builtin.module` in `context`.
@@ -56,14 +60,13 @@ fn lower_function(context: &Context, ast: &Ast, func: NodeId) -> Result<impl Ope
     };
     let ret_ty = lower_ctype(context, ret);
 
-    let params: Vec<NodeId> = ast
+    // Entry block arguments carry the incoming parameter values; parameters are
+    // the function node's leading children.
+    let mut param_values = Vec::new();
+    for param in ast
         .children(func)
         .take_while(|&c| matches!(ast.get_node(c), AstKind::Param))
-        .collect();
-
-    // Entry block arguments carry the incoming parameter values.
-    let mut param_values = Vec::new();
-    for &param in &params {
+    {
         let AstLeaf::Param { ty, .. } = ast.get_leaf_data(param).unwrap() else {
             unreachable!("param node carries a param payload");
         };
@@ -82,23 +85,9 @@ fn lower_function(context: &Context, ast: &Ast, func: NodeId) -> Result<impl Ope
         ast,
         builder: IRBuilder::new(func_op.body()),
         locals: HashMap::new(),
+        values: Vec::new(),
     };
-
-    // Spill each parameter into its own stack slot, mirroring -O0 codegen.
-    for (&param, value) in params.iter().zip(param_ids) {
-        let AstLeaf::Param { name, ty } = ast.get_leaf_data(param).unwrap() else {
-            unreachable!("param node carries a param payload");
-        };
-        let elem = lower_ctype(context, ty);
-        let slot = cg.alloca(elem);
-        cg.builder
-            .insert(p::store(context, value, slot.ptr).build());
-        cg.locals.insert(name.clone(), slot);
-    }
-
-    for stmt in ast.children(func).skip(params.len()) {
-        cg.lower_stmt(stmt)?;
-    }
+    cg.lower_body(func, &param_ids)?;
 
     Ok(func_op)
 }
@@ -111,6 +100,35 @@ impl FnCodegen<'_> {
             ptr: op.result(),
             elem,
         }
+    }
+
+    /// Lower a function: spill parameters into stack slots, then lower each body
+    /// statement in source order (statement order is a side-effect ordering, so it
+    /// stays top-down; only the expressions within use the post-order iterator).
+    fn lower_body(&mut self, func: NodeId, param_ids: &[ValueId]) -> Result<(), String> {
+        let ast = self.ast;
+
+        let mut idx = 0;
+        for param in ast
+            .children(func)
+            .take_while(|&c| matches!(ast.get_node(c), AstKind::Param))
+        {
+            let AstLeaf::Param { name, ty } = ast.get_leaf_data(param).unwrap() else {
+                unreachable!("param node carries a param payload");
+            };
+            let elem = lower_ctype(self.context, ty);
+            let slot = self.alloca(elem);
+            self.builder
+                .insert(p::store(self.context, param_ids[idx], slot.ptr).build());
+            idx += 1;
+            self.locals.insert(name.clone(), slot);
+        }
+
+        for stmt in ast.children(func).skip(idx) {
+            self.lower_stmt(stmt)?;
+        }
+
+        Ok(())
     }
 
     fn lower_stmt(&mut self, stmt: NodeId) -> Result<(), String> {
@@ -157,56 +175,73 @@ impl FnCodegen<'_> {
         }
     }
 
-    fn lower_expr(&mut self, expr: NodeId) -> Result<ValueId, String> {
+    /// Lower an expression subtree in one post-order pass: operands precede their
+    /// operator, so each node's value is ready when its parent is reached. The
+    /// AST is a tree, so the subtree is a contiguous index range `[base, root]`;
+    /// values are pushed in index order, letting children be read by offset
+    /// without hashing.
+    fn lower_expr(&mut self, root: NodeId) -> Result<ValueId, String> {
         let ast = self.ast;
         let i32_ty = IntegerType::new(self.context, 32);
-        match ast.get_node(expr) {
-            AstKind::Int => {
-                let AstLeaf::Int(n) = ast.get_leaf_data(expr).unwrap() else {
-                    unreachable!("int node carries an int payload");
-                };
-                let op = self
-                    .builder
-                    .insert(b::constant(self.context, *n, i32_ty).build());
-                Ok(op.result())
+        self.values.clear();
+        let mut base = root.index();
+
+        for node in ast.postorder_from(root) {
+            if self.values.is_empty() {
+                base = node.index();
             }
-            AstKind::Var => {
-                let AstLeaf::Var(name) = ast.get_leaf_data(expr).unwrap() else {
-                    unreachable!("var node carries a var payload");
-                };
-                let slot = *self
-                    .locals
-                    .get(name)
-                    .ok_or_else(|| format!("use of unknown variable '{name}'"))?;
-                let op = self
-                    .builder
-                    .insert(p::load(self.context, slot.ptr, slot.elem).build());
-                Ok(op.result())
-            }
-            kind @ (AstKind::Add | AstKind::Sub | AstKind::Mul) => {
-                let kind = *kind;
-                let mut children = ast.children(expr);
-                let lhs = children.next().unwrap();
-                let rhs = children.next().unwrap();
-                let l = self.lower_expr(lhs)?;
-                let r = self.lower_expr(rhs)?;
-                let result = match kind {
-                    AstKind::Add => self
-                        .builder
-                        .insert(b::addi(self.context, l, r, i32_ty).build())
-                        .result(),
-                    AstKind::Sub => self
-                        .builder
-                        .insert(b::subi(self.context, l, r, i32_ty).build())
-                        .result(),
-                    _ => self
-                        .builder
-                        .insert(b::muli(self.context, l, r, i32_ty).build())
-                        .result(),
-                };
-                Ok(result)
-            }
-            kind => unreachable!("not an expression: {kind:?}"),
+            debug_assert_eq!(
+                node.index(),
+                base + self.values.len(),
+                "subtree not contiguous"
+            );
+
+            let value = match ast.get_node(node) {
+                AstKind::Int => {
+                    let AstLeaf::Int(n) = ast.get_leaf_data(node).unwrap() else {
+                        unreachable!("int node carries an int payload");
+                    };
+                    self.builder
+                        .insert(b::constant(self.context, *n, i32_ty).build())
+                        .result()
+                }
+                AstKind::Var => {
+                    let AstLeaf::Var(name) = ast.get_leaf_data(node).unwrap() else {
+                        unreachable!("var node carries a var payload");
+                    };
+                    let slot = *self
+                        .locals
+                        .get(name)
+                        .ok_or_else(|| format!("use of unknown variable '{name}'"))?;
+                    self.builder
+                        .insert(p::load(self.context, slot.ptr, slot.elem).build())
+                        .result()
+                }
+                kind @ (AstKind::Add | AstKind::Sub | AstKind::Mul) => {
+                    let kind = *kind;
+                    let mut children = ast.children(node);
+                    let l = self.values[children.next().unwrap().index() - base];
+                    let r = self.values[children.next().unwrap().index() - base];
+                    match kind {
+                        AstKind::Add => self
+                            .builder
+                            .insert(b::addi(self.context, l, r, i32_ty).build())
+                            .result(),
+                        AstKind::Sub => self
+                            .builder
+                            .insert(b::subi(self.context, l, r, i32_ty).build())
+                            .result(),
+                        _ => self
+                            .builder
+                            .insert(b::muli(self.context, l, r, i32_ty).build())
+                            .result(),
+                    }
+                }
+                kind => unreachable!("not an expression: {kind:?}"),
+            };
+            self.values.push(value);
         }
+
+        Ok(*self.values.last().unwrap())
     }
 }

--- a/fcc/src/driver.rs
+++ b/fcc/src/driver.rs
@@ -118,7 +118,7 @@ fn run_compile(args: CompileArgs) {
             }
             CompileStage::Ast => {
                 let unit = parse_source(reader);
-                writeln!(out, "{unit:#?}").unwrap();
+                write!(out, "{}", crate::ast::render(&unit)).unwrap();
             }
             CompileStage::Ir => {
                 let unit = parse_source(reader);
@@ -141,10 +141,7 @@ fn run_compile(args: CompileArgs) {
     }
 }
 
-fn lower_to_ir(
-    context: &tir::Context,
-    unit: &crate::ast::TranslationUnit,
-) -> tir::builtin::ModuleOp {
+fn lower_to_ir(context: &tir::Context, unit: &crate::ast::Ast) -> tir::builtin::ModuleOp {
     crate::codegen::codegen(context, unit).unwrap_or_else(|e| {
         eprintln!("fcc: codegen error: {e}");
         std::process::exit(1);
@@ -211,7 +208,7 @@ fn emit_machine_code(args: &CompileArgs, reader: Box<dyn io::Read>) -> Vec<u8> {
     tir_be_common::binary::write_elf(&object, &format)
 }
 
-fn parse_source(reader: Box<dyn io::Read>) -> crate::ast::TranslationUnit {
+fn parse_source(reader: Box<dyn io::Read>) -> crate::ast::Ast {
     let tokens: Vec<Token> = preprocessed(reader, HashMap::new(), &[]).collect();
     crate::parser::parse(&tokens).unwrap_or_else(|errors| {
         for e in errors {

--- a/fcc/src/parser.rs
+++ b/fcc/src/parser.rs
@@ -5,9 +5,16 @@
 //! It accepts just enough C to express integer functions: `int`/`void` return
 //! types and parameters, local `int` declarations, assignments, simple
 //! arithmetic (`+`, `-`, `*`, parentheses) and `return`.
+//!
+//! Nodes are appended straight into the [`Ast`] DAG carried as parser state.
+//! Because combinators run bottom-up, every child is added before its parent,
+//! which is exactly the post-order layout the DAG requires.
 
-use chumsky::input::ValueInput;
+use chumsky::input::{MapExtra, ValueInput};
+use chumsky::inspector::SimpleState;
 use chumsky::prelude::*;
+
+use tir::graph::{MutDag, NodeId};
 
 use crate::ast::*;
 use crate::lexer::Token;
@@ -15,23 +22,24 @@ use crate::lexer::Token;
 /// Index-based span over the token slice (we parse already-lexed tokens, so
 /// byte offsets are not available — token indices are the natural span).
 type Span = SimpleSpan<usize>;
-type Extra<'src> = extra::Err<Rich<'src, Token, Span>>;
+type Extra<'src> = extra::Full<Rich<'src, Token, Span>, SimpleState<Ast>, ()>;
 
 /// Parse a token stream into a translation unit. Whitespace tokens are dropped
 /// first; on failure the collected diagnostics are returned as strings.
-pub fn parse(tokens: &[Token]) -> Result<TranslationUnit, Vec<String>> {
+pub fn parse(tokens: &[Token]) -> Result<Ast, Vec<String>> {
     let filtered: Vec<Token> = tokens
         .iter()
         .filter(|t| !matches!(t, Token::Whitespace(_)))
         .cloned()
         .collect();
 
+    let mut state = SimpleState(Ast::new());
     let (out, errors) = translation_unit()
-        .parse(filtered.as_slice())
+        .parse_with_state(filtered.as_slice(), &mut state)
         .into_output_errors();
 
     match out {
-        Some(unit) if errors.is_empty() => Ok(unit),
+        Some(_) if errors.is_empty() => Ok(state.0),
         _ => Err(errors.into_iter().map(|e| e.to_string()).collect()),
     }
 }
@@ -53,73 +61,128 @@ where
     select! { Token::Identifier(name) => name }
 }
 
-fn expr<'src, I>() -> impl Parser<'src, I, Expr, Extra<'src>> + Clone
+fn expr<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
     recursive(|expr| {
         let primary = choice((
-            select! { Token::IntegerLiteral(n) => Expr::Int(n.to_i64()) },
-            ident().map(Expr::Var),
+            select! { Token::IntegerLiteral(n) => n.to_i64() }.map_with(
+                |n, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                    let ast: &mut Ast = &mut e.state().0;
+                    let id = ast.add_node(AstKind::Int);
+                    ast.set_leaf_data(id, AstLeaf::Int(n));
+                    id
+                },
+            ),
+            ident().map_with(|name, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::Var);
+                ast.set_leaf_data(id, AstLeaf::Var(name));
+                id
+            }),
             expr.delimited_by(just(Token::LParen), just(Token::RParen)),
         ));
 
-        // `*` binds tighter than `+`/`-`; both are left-associative.
-        let product = primary.clone().foldl(
-            just(Token::Star).ignore_then(primary).repeated(),
-            |lhs, rhs| Expr::Binary {
-                op: BinOp::Mul,
-                lhs: Box::new(lhs),
-                rhs: Box::new(rhs),
-            },
-        );
+        // `*` binds tighter than `+`/`-`; both are left-associative. The operands
+        // are already in the DAG by the time the fold runs, so each operator node
+        // is appended after them.
+        let product = primary
+            .clone()
+            .then(
+                just(Token::Star)
+                    .ignore_then(primary)
+                    .repeated()
+                    .collect::<Vec<NodeId>>(),
+            )
+            .map_with(
+                |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                    let ast: &mut Ast = &mut e.state().0;
+                    rest.into_iter()
+                        .fold(first, |lhs, rhs| binary(ast, AstKind::Mul, lhs, rhs))
+                },
+            );
 
         let add_op = choice((
-            just(Token::Plus).to(BinOp::Add),
-            just(Token::Minus).to(BinOp::Sub),
+            just(Token::Plus).to(AstKind::Add),
+            just(Token::Minus).to(AstKind::Sub),
         ));
 
         product
             .clone()
-            .foldl(add_op.then(product).repeated(), |lhs, (op, rhs)| {
-                Expr::Binary {
-                    op,
-                    lhs: Box::new(lhs),
-                    rhs: Box::new(rhs),
-                }
-            })
+            .then(add_op.then(product).repeated().collect::<Vec<_>>())
+            .map_with(
+                |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                    let ast: &mut Ast = &mut e.state().0;
+                    rest.into_iter()
+                        .fold(first, |lhs, (op, rhs)| binary(ast, op, lhs, rhs))
+                },
+            )
     })
 }
 
-fn stmt<'src, I>() -> impl Parser<'src, I, Stmt, Extra<'src>> + Clone
+fn binary(ast: &mut Ast, op: AstKind, lhs: NodeId, rhs: NodeId) -> NodeId {
+    let id = ast.add_node(op);
+    ast.add_edge(id, lhs);
+    ast.add_edge(id, rhs);
+    id
+}
+
+fn stmt<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
     let ret = just(Token::KwReturn)
         .ignore_then(expr().or_not())
         .then_ignore(just(Token::Semicolon))
-        .map(Stmt::Return);
+        .map_with(|value, e| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::Return);
+            if let Some(value) = value {
+                ast.add_edge(id, value);
+            }
+            id
+        });
 
     let decl = ctype()
         .then(ident())
         .then(just(Token::Assign).ignore_then(expr()).or_not())
         .then_ignore(just(Token::Semicolon))
-        .map(|((ty, name), init)| Stmt::Decl { name, ty, init });
+        .map_with(|((ty, name), init), e| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::Decl);
+            ast.set_leaf_data(id, AstLeaf::Decl { name, ty });
+            if let Some(init) = init {
+                ast.add_edge(id, init);
+            }
+            id
+        });
 
     let assign = ident()
         .then_ignore(just(Token::Assign))
         .then(expr())
         .then_ignore(just(Token::Semicolon))
-        .map(|(name, value)| Stmt::Assign { name, value });
+        .map_with(|(name, value), e| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::Assign);
+            ast.set_leaf_data(id, AstLeaf::Assign(name));
+            ast.add_edge(id, value);
+            id
+        });
 
     choice((ret, decl, assign))
 }
 
-fn function<'src, I>() -> impl Parser<'src, I, Function, Extra<'src>> + Clone
+fn function<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
-    let param = ctype().then(ident()).map(|(ty, name)| Param { name, ty });
+    let param = ctype().then(ident()).map_with(|(ty, name), e| {
+        let ast: &mut Ast = &mut e.state().0;
+        let id = ast.add_node(AstKind::Param);
+        ast.set_leaf_data(id, AstLeaf::Param { name, ty });
+        id
+    });
 
     // `(void)` is an explicit empty parameter list; `()` is also accepted.
     let params = choice((
@@ -137,15 +200,18 @@ where
         .then(ident())
         .then(params)
         .then(body)
-        .map(|(((ret, name), params), body)| Function {
-            name,
-            ret,
-            params,
-            body,
+        .map_with(|(((ret, name), params), body), e| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::Function);
+            ast.set_leaf_data(id, AstLeaf::Function { name, ret });
+            for child in params.into_iter().chain(body) {
+                ast.add_edge(id, child);
+            }
+            id
         })
 }
 
-fn translation_unit<'src, I>() -> impl Parser<'src, I, TranslationUnit, Extra<'src>>
+fn translation_unit<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>>
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
@@ -153,5 +219,12 @@ where
         .repeated()
         .collect::<Vec<_>>()
         .then_ignore(end())
-        .map(|functions| TranslationUnit { functions })
+        .map_with(|functions, e| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::TranslationUnit);
+            for func in functions {
+                ast.add_edge(id, func);
+            }
+            id
+        })
 }


### PR DESCRIPTION
Replace the hand-rolled recursive AST enums (Box<Expr>, Vec-based
statements) with core's PostOrderDag, mirroring the sem_expr graph:
node kinds live in a flat vector and payloads (names, literals, types)
in a sparse side table. The parser appends nodes straight into the DAG
via chumsky parser state; since combinators run bottom-up, children
always precede their parent as the post-order layout requires. Codegen
walks the DAG by NodeId, and the --stage ast output is rendered as an
indented outline (golden regenerated).