### PR TITLE
feat(fcc): parse C89/C99 control flow and richer expressions

### DIFF
--- a/fcc/checks/Ast/calls.c
+++ b/fcc/checks/Ast/calls.c
@@ -1,0 +1,16 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/calls.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "apply" -> Int
+// CHECK-NEXT:     Param "x": Int
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Add
+// CHECK-NEXT:         Call "gcd"
+// CHECK-NEXT:           Mul
+// CHECK-NEXT:             Var "x"
+// CHECK-NEXT:             Int 2
+// CHECK-NEXT:           Int 48
+// CHECK-NEXT:         Call "sum_to"
+// CHECK-NEXT:           Var "x"

--- a/fcc/checks/Ast/control_flow.c
+++ b/fcc/checks/Ast/control_flow.c
@@ -1,0 +1,29 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/control_flow.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "classify" -> Int
+// CHECK-NEXT:     Param "n": Int
+// CHECK-NEXT:     Decl "sign": Int
+// CHECK-NEXT:       Int 0
+// CHECK-NEXT:     If
+// CHECK-NEXT:       Lt
+// CHECK-NEXT:         Var "n"
+// CHECK-NEXT:         Int 0
+// CHECK-NEXT:       Block
+// CHECK-NEXT:         Assign "sign"
+// CHECK-NEXT:           Neg
+// CHECK-NEXT:             Int 1
+// CHECK-NEXT:       If
+// CHECK-NEXT:         Eq
+// CHECK-NEXT:           Var "n"
+// CHECK-NEXT:           Int 0
+// CHECK-NEXT:         Block
+// CHECK-NEXT:           Assign "sign"
+// CHECK-NEXT:             Int 0
+// CHECK-NEXT:         Block
+// CHECK-NEXT:           Assign "sign"
+// CHECK-NEXT:             Int 1
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Var "sign"

--- a/fcc/checks/Ast/do_while.c
+++ b/fcc/checks/Ast/do_while.c
@@ -1,0 +1,25 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/do_while.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "countdown" -> Int
+// CHECK-NEXT:     Param "n": Int
+// CHECK-NEXT:     Decl "i": Int
+// CHECK-NEXT:       Int 0
+// CHECK-NEXT:     DoWhile
+// CHECK-NEXT:       Block
+// CHECK-NEXT:         Assign "i"
+// CHECK-NEXT:           Add
+// CHECK-NEXT:             Var "i"
+// CHECK-NEXT:             Int 1
+// CHECK-NEXT:         If
+// CHECK-NEXT:           Eq
+// CHECK-NEXT:             Var "i"
+// CHECK-NEXT:             Int 3
+// CHECK-NEXT:           Continue
+// CHECK-NEXT:       Lt
+// CHECK-NEXT:         Var "i"
+// CHECK-NEXT:         Var "n"
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Var "i"

--- a/fcc/checks/Ast/for_loop.c
+++ b/fcc/checks/Ast/for_loop.c
@@ -1,0 +1,32 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/for_loop.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "sum_to" -> Int
+// CHECK-NEXT:     Param "n": Int
+// CHECK-NEXT:     Decl "total": Int
+// CHECK-NEXT:       Int 0
+// CHECK-NEXT:     Decl "i": Int
+// CHECK-NEXT:     For
+// CHECK-NEXT:       Assign "i"
+// CHECK-NEXT:         Int 1
+// CHECK-NEXT:       Le
+// CHECK-NEXT:         Var "i"
+// CHECK-NEXT:         Var "n"
+// CHECK-NEXT:       Assign "i"
+// CHECK-NEXT:         Add
+// CHECK-NEXT:           Var "i"
+// CHECK-NEXT:           Int 1
+// CHECK-NEXT:       Block
+// CHECK-NEXT:         Assign "total"
+// CHECK-NEXT:           Add
+// CHECK-NEXT:             Var "total"
+// CHECK-NEXT:             Var "i"
+// CHECK-NEXT:         If
+// CHECK-NEXT:           Gt
+// CHECK-NEXT:             Var "total"
+// CHECK-NEXT:             Int 100
+// CHECK-NEXT:           Break
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Var "total"

--- a/fcc/checks/Ast/precedence.c
+++ b/fcc/checks/Ast/precedence.c
@@ -1,0 +1,30 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/precedence.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "prec" -> Int
+// CHECK-NEXT:     Param "a": Int
+// CHECK-NEXT:     Param "b": Int
+// CHECK-NEXT:     Param "c": Int
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       LogOr
+// CHECK-NEXT:         LogAnd
+// CHECK-NEXT:           Lt
+// CHECK-NEXT:             Sub
+// CHECK-NEXT:               Add
+// CHECK-NEXT:                 Var "a"
+// CHECK-NEXT:                 Mul
+// CHECK-NEXT:                   Var "b"
+// CHECK-NEXT:                   Int 2
+// CHECK-NEXT:               Mod
+// CHECK-NEXT:                 Div
+// CHECK-NEXT:                   Int 6
+// CHECK-NEXT:                   Int 3
+// CHECK-NEXT:                 Int 2
+// CHECK-NEXT:             Var "c"
+// CHECK-NEXT:           Not
+// CHECK-NEXT:             Var "a"
+// CHECK-NEXT:         Eq
+// CHECK-NEXT:           Var "b"
+// CHECK-NEXT:           Var "c"

--- a/fcc/checks/Ast/while_loop.c
+++ b/fcc/checks/Ast/while_loop.c
@@ -1,0 +1,23 @@
+// This file was generated with ./utils/scripts/update_checks.py. Do not modify CHECKs manually.
+
+// RUN: fcc compile --stage ast -o - %S/../Inputs/while_loop.c | filecheck %s
+
+// CHECK: TranslationUnit
+// CHECK-NEXT:   Function "gcd" -> Int
+// CHECK-NEXT:     Param "a": Int
+// CHECK-NEXT:     Param "b": Int
+// CHECK-NEXT:     While
+// CHECK-NEXT:       Ne
+// CHECK-NEXT:         Var "b"
+// CHECK-NEXT:         Int 0
+// CHECK-NEXT:       Block
+// CHECK-NEXT:         Decl "t": Int
+// CHECK-NEXT:           Mod
+// CHECK-NEXT:             Var "a"
+// CHECK-NEXT:             Var "b"
+// CHECK-NEXT:         Assign "a"
+// CHECK-NEXT:           Var "b"
+// CHECK-NEXT:         Assign "b"
+// CHECK-NEXT:           Var "t"
+// CHECK-NEXT:     Return
+// CHECK-NEXT:       Var "a"

--- a/fcc/checks/Inputs/calls.c
+++ b/fcc/checks/Inputs/calls.c
@@ -1,0 +1,3 @@
+int apply(int x) {
+    return gcd(x * 2, 48) + sum_to(x);
+}

--- a/fcc/checks/Inputs/control_flow.c
+++ b/fcc/checks/Inputs/control_flow.c
@@ -1,0 +1,11 @@
+int classify(int n) {
+    int sign = 0;
+    if (n < 0) {
+        sign = -1;
+    } else if (n == 0) {
+        sign = 0;
+    } else {
+        sign = 1;
+    }
+    return sign;
+}

--- a/fcc/checks/Inputs/do_while.c
+++ b/fcc/checks/Inputs/do_while.c
@@ -1,0 +1,8 @@
+int countdown(int n) {
+    int i = 0;
+    do {
+        i = i + 1;
+        if (i == 3) continue;
+    } while (i < n);
+    return i;
+}

--- a/fcc/checks/Inputs/for_loop.c
+++ b/fcc/checks/Inputs/for_loop.c
@@ -1,0 +1,9 @@
+int sum_to(int n) {
+    int total = 0;
+    int i;
+    for (i = 1; i <= n; i = i + 1) {
+        total = total + i;
+        if (total > 100) break;
+    }
+    return total;
+}

--- a/fcc/checks/Inputs/precedence.c
+++ b/fcc/checks/Inputs/precedence.c
@@ -1,0 +1,3 @@
+int prec(int a, int b, int c) {
+    return a + b * 2 - 6 / 3 % 2 < c && !a || b == c;
+}

--- a/fcc/checks/Inputs/while_loop.c
+++ b/fcc/checks/Inputs/while_loop.c
@@ -1,0 +1,8 @@
+int gcd(int a, int b) {
+    while (b != 0) {
+        int t = a % b;
+        a = b;
+        b = t;
+    }
+    return a;
+}

--- a/fcc/src/ast.rs
+++ b/fcc/src/ast.rs
@@ -1,7 +1,10 @@
-//! A tiny C abstract syntax tree — only the constructs needed to drive a
-//! simple integer function (parameters, local `int` variables, arithmetic and
-//! `return`) down to IR. There are no types beyond `int`/`void`, no control
-//! flow, and no pointers at the source level.
+//! A small C abstract syntax tree covering a C89/C99 subset: `int`/`void`
+//! functions, local `int` variables, control flow (`if`/`else`, `while`,
+//! `do`/`while`, `for`, `break`, `continue`), compound blocks, the usual
+//! arithmetic/relational/logical operators and function calls. There are no
+//! types beyond `int`/`void` and no pointers at the source level. Codegen
+//! currently lowers only the original arithmetic subset; the rest is parsed
+//! and stubbed.
 //!
 //! The tree is stored in core's [`PostOrderDag`], the same cache-friendly,
 //! post-order layout the semantic-expression graph uses: node *kinds* live in a
@@ -34,10 +37,41 @@ pub enum AstKind {
     Assign,
     /// Child: the optional returned expression.
     Return,
+    /// Children: the block's statements.
+    Block,
+    /// Child: the wrapped expression (an expression used as a statement).
+    ExprStmt,
+    /// Children: condition, then-branch, and an optional else-branch.
+    If,
+    /// Children: condition, body.
+    While,
+    /// Children: body, condition.
+    DoWhile,
+    /// Children: init, condition, step, body. Omitted clauses are [`AstKind::Empty`].
+    For,
+    Break,
+    Continue,
+    /// A placeholder for an omitted `for` clause or a null statement.
+    Empty,
     /// Children: left-hand side, right-hand side.
     Add,
     Sub,
     Mul,
+    Div,
+    Mod,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+    Eq,
+    Ne,
+    LogAnd,
+    LogOr,
+    /// Child: the single operand.
+    Neg,
+    Not,
+    /// Children: the argument expressions. Callee name lives in [`AstLeaf::Call`].
+    Call,
     Var,
     Int,
 }
@@ -51,6 +85,7 @@ pub enum AstLeaf {
     Param { name: String, ty: CType },
     Decl { name: String, ty: CType },
     Assign(String),
+    Call(String),
     Var(String),
     Int(i64),
 }
@@ -86,9 +121,34 @@ fn render_node(ast: &Ast, id: NodeId, depth: usize, out: &mut String) {
             _ => unreachable!(),
         },
         AstKind::Return => "Return".to_string(),
+        AstKind::Block => "Block".to_string(),
+        AstKind::ExprStmt => "ExprStmt".to_string(),
+        AstKind::If => "If".to_string(),
+        AstKind::While => "While".to_string(),
+        AstKind::DoWhile => "DoWhile".to_string(),
+        AstKind::For => "For".to_string(),
+        AstKind::Break => "Break".to_string(),
+        AstKind::Continue => "Continue".to_string(),
+        AstKind::Empty => "Empty".to_string(),
         AstKind::Add => "Add".to_string(),
         AstKind::Sub => "Sub".to_string(),
         AstKind::Mul => "Mul".to_string(),
+        AstKind::Div => "Div".to_string(),
+        AstKind::Mod => "Mod".to_string(),
+        AstKind::Lt => "Lt".to_string(),
+        AstKind::Gt => "Gt".to_string(),
+        AstKind::Le => "Le".to_string(),
+        AstKind::Ge => "Ge".to_string(),
+        AstKind::Eq => "Eq".to_string(),
+        AstKind::Ne => "Ne".to_string(),
+        AstKind::LogAnd => "LogAnd".to_string(),
+        AstKind::LogOr => "LogOr".to_string(),
+        AstKind::Neg => "Neg".to_string(),
+        AstKind::Not => "Not".to_string(),
+        AstKind::Call => match ast.get_leaf_data(id) {
+            Some(AstLeaf::Call(name)) => format!("Call {name:?}"),
+            _ => unreachable!(),
+        },
         AstKind::Var => match ast.get_leaf_data(id) {
             Some(AstLeaf::Var(name)) => format!("Var {name:?}"),
             _ => unreachable!(),

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -171,7 +171,11 @@ impl FnCodegen<'_> {
                     .insert(b::r#return(self.context, operand).build());
                 Ok(())
             }
-            kind => unreachable!("not a statement: {kind:?}"),
+            // Control flow and expression statements are parsed but not yet
+            // lowered; codegen for them is stubbed out for now.
+            kind => Err(format!(
+                "codegen not yet implemented for statement {kind:?}"
+            )),
         }
     }
 
@@ -237,7 +241,13 @@ impl FnCodegen<'_> {
                             .result(),
                     }
                 }
-                kind => unreachable!("not an expression: {kind:?}"),
+                // The richer operators (division, comparison, logical, unary,
+                // calls) are parsed but not yet lowered; stub them out for now.
+                kind => {
+                    return Err(format!(
+                        "codegen not yet implemented for expression {kind:?}"
+                    ));
+                }
             };
             self.values.push(value);
         }

--- a/fcc/src/lexer.rs
+++ b/fcc/src/lexer.rs
@@ -134,6 +134,28 @@ pub enum Token {
     Minus,
     #[token("*")]
     Star,
+    #[token("/")]
+    Slash,
+    #[token("%")]
+    Percent,
+    #[token("==")]
+    EqEq,
+    #[token("!=")]
+    BangEq,
+    #[token("<")]
+    Lt,
+    #[token(">")]
+    Gt,
+    #[token("<=")]
+    Le,
+    #[token(">=")]
+    Ge,
+    #[token("&&")]
+    AmpAmp,
+    #[token("||")]
+    PipePipe,
+    #[token("!")]
+    Bang,
 }
 
 impl fmt::Display for Token {
@@ -199,6 +221,17 @@ impl fmt::Display for Token {
             Token::Plus => f.write_str("+"),
             Token::Minus => f.write_str("-"),
             Token::Star => f.write_str("*"),
+            Token::Slash => f.write_str("/"),
+            Token::Percent => f.write_str("%"),
+            Token::EqEq => f.write_str("=="),
+            Token::BangEq => f.write_str("!="),
+            Token::Lt => f.write_str("<"),
+            Token::Gt => f.write_str(">"),
+            Token::Le => f.write_str("<="),
+            Token::Ge => f.write_str(">="),
+            Token::AmpAmp => f.write_str("&&"),
+            Token::PipePipe => f.write_str("||"),
+            Token::Bang => f.write_str("!"),
         }
     }
 }

--- a/fcc/src/parser.rs
+++ b/fcc/src/parser.rs
@@ -2,9 +2,11 @@
 //! same style as the TMDL compiler's parser (combinators over a token slice
 //! with `Rich` errors).
 //!
-//! It accepts just enough C to express integer functions: `int`/`void` return
-//! types and parameters, local `int` declarations, assignments, simple
-//! arithmetic (`+`, `-`, `*`, parentheses) and `return`.
+//! Types are still limited to `int`/`void`, but the statement and expression
+//! grammar covers a useful C89/C99 subset: `if`/`else`, `while`, `do`/`while`,
+//! `for`, `break`, `continue`, compound blocks and expression statements;
+//! arithmetic (`+ - * / %`), relational and equality operators, logical
+//! `&& || !`, unary minus, parentheses and function calls.
 //!
 //! Nodes are appended straight into the [`Ast`] DAG carried as parser state.
 //! Because combinators run bottom-up, every child is added before its parent,
@@ -66,59 +68,127 @@ where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
     recursive(|expr| {
-        let primary = choice((
-            select! { Token::IntegerLiteral(n) => n.to_i64() }.map_with(
-                |n, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                    let ast: &mut Ast = &mut e.state().0;
-                    let id = ast.add_node(AstKind::Int);
-                    ast.set_leaf_data(id, AstLeaf::Int(n));
-                    id
-                },
-            ),
-            ident().map_with(|name, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+        let literal = select! { Token::IntegerLiteral(n) => n.to_i64() }.map_with(
+            |n, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
                 let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::Var);
-                ast.set_leaf_data(id, AstLeaf::Var(name));
+                let id = ast.add_node(AstKind::Int);
+                ast.set_leaf_data(id, AstLeaf::Int(n));
                 id
-            }),
+            },
+        );
+
+        // A call must be tried before a bare identifier so `f(x)` is not read as
+        // the variable `f`.
+        let call = ident()
+            .then(
+                expr.clone()
+                    .separated_by(just(Token::Comma))
+                    .collect::<Vec<NodeId>>()
+                    .delimited_by(just(Token::LParen), just(Token::RParen)),
+            )
+            .map_with(|(name, args), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::Call);
+                ast.set_leaf_data(id, AstLeaf::Call(name));
+                for arg in args {
+                    ast.add_edge(id, arg);
+                }
+                id
+            });
+
+        let var = ident().map_with(|name, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+            let ast: &mut Ast = &mut e.state().0;
+            let id = ast.add_node(AstKind::Var);
+            ast.set_leaf_data(id, AstLeaf::Var(name));
+            id
+        });
+
+        let primary = choice((
+            literal,
+            call,
+            var,
             expr.delimited_by(just(Token::LParen), just(Token::RParen)),
         ));
 
-        // `*` binds tighter than `+`/`-`; both are left-associative. The operands
-        // are already in the DAG by the time the fold runs, so each operator node
-        // is appended after them.
-        let product = primary
-            .clone()
-            .then(
-                just(Token::Star)
-                    .ignore_then(primary)
-                    .repeated()
-                    .collect::<Vec<NodeId>>(),
-            )
-            .map_with(
-                |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                    let ast: &mut Ast = &mut e.state().0;
-                    rest.into_iter()
-                        .fold(first, |lhs, rhs| binary(ast, AstKind::Mul, lhs, rhs))
-                },
-            );
+        // Prefix unary operators (`-`, `!`), applied right-to-left so the
+        // innermost operator wraps the operand first.
+        let unary = choice((
+            just(Token::Minus).to(AstKind::Neg),
+            just(Token::Bang).to(AstKind::Not),
+        ))
+        .repeated()
+        .collect::<Vec<AstKind>>()
+        .then(primary)
+        .map_with(
+            |(ops, operand), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                ops.into_iter()
+                    .rev()
+                    .fold(operand, |child, op| unary(ast, op, child))
+            },
+        );
 
-        let add_op = choice((
-            just(Token::Plus).to(AstKind::Add),
-            just(Token::Minus).to(AstKind::Sub),
-        ));
-
-        product
-            .clone()
-            .then(add_op.then(product).repeated().collect::<Vec<_>>())
-            .map_with(
-                |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                    let ast: &mut Ast = &mut e.state().0;
-                    rest.into_iter()
-                        .fold(first, |lhs, (op, rhs)| binary(ast, op, lhs, rhs))
-                },
-            )
+        // Precedence ladder, tightest first. Every operator is left-associative.
+        let product = binop(
+            unary,
+            choice((
+                just(Token::Star).to(AstKind::Mul),
+                just(Token::Slash).to(AstKind::Div),
+                just(Token::Percent).to(AstKind::Mod),
+            )),
+        );
+        let sum = binop(
+            product,
+            choice((
+                just(Token::Plus).to(AstKind::Add),
+                just(Token::Minus).to(AstKind::Sub),
+            )),
+        );
+        let relational = binop(
+            sum,
+            choice((
+                just(Token::Le).to(AstKind::Le),
+                just(Token::Ge).to(AstKind::Ge),
+                just(Token::Lt).to(AstKind::Lt),
+                just(Token::Gt).to(AstKind::Gt),
+            )),
+        );
+        let equality = binop(
+            relational,
+            choice((
+                just(Token::EqEq).to(AstKind::Eq),
+                just(Token::BangEq).to(AstKind::Ne),
+            )),
+        );
+        let logical_and = binop(equality, just(Token::AmpAmp).to(AstKind::LogAnd));
+        binop(logical_and, just(Token::PipePipe).to(AstKind::LogOr))
     })
+}
+
+/// A left-associative binary-operator level: a `child` operand followed by any
+/// number of `op child` tails, folded into nested operator nodes. Operands are
+/// already in the DAG by the time the fold runs, so each operator node is
+/// appended after them.
+fn binop<'src, I, C, O>(child: C, op: O) -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+    C: Parser<'src, I, NodeId, Extra<'src>> + Clone,
+    O: Parser<'src, I, AstKind, Extra<'src>> + Clone,
+{
+    child
+        .clone()
+        .then(
+            op.then(child)
+                .repeated()
+                .collect::<Vec<(AstKind, NodeId)>>(),
+        )
+        .map_with(
+            |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                rest.into_iter()
+                    .fold(first, |lhs, (op, rhs)| binary(ast, op, lhs, rhs))
+            },
+        )
 }
 
 fn binary(ast: &mut Ast, op: AstKind, lhs: NodeId, rhs: NodeId) -> NodeId {
@@ -128,26 +198,21 @@ fn binary(ast: &mut Ast, op: AstKind, lhs: NodeId, rhs: NodeId) -> NodeId {
     id
 }
 
-fn stmt<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
+fn unary(ast: &mut Ast, op: AstKind, operand: NodeId) -> NodeId {
+    let id = ast.add_node(op);
+    ast.add_edge(id, operand);
+    id
+}
+
+/// Build an `int x = init` declaration node (without the trailing `;`, so the
+/// same body serves both a declaration statement and a `for` init clause).
+fn decl_body<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
-    let ret = just(Token::KwReturn)
-        .ignore_then(expr().or_not())
-        .then_ignore(just(Token::Semicolon))
-        .map_with(|value, e| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::Return);
-            if let Some(value) = value {
-                ast.add_edge(id, value);
-            }
-            id
-        });
-
-    let decl = ctype()
+    ctype()
         .then(ident())
         .then(just(Token::Assign).ignore_then(expr()).or_not())
-        .then_ignore(just(Token::Semicolon))
         .map_with(|((ty, name), init), e| {
             let ast: &mut Ast = &mut e.state().0;
             let id = ast.add_node(AstKind::Decl);
@@ -156,21 +221,187 @@ where
                 ast.add_edge(id, init);
             }
             id
-        });
+        })
+}
 
-    let assign = ident()
+/// Build an `x = value` assignment node (without the trailing `;`).
+fn assign_body<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    ident()
         .then_ignore(just(Token::Assign))
         .then(expr())
-        .then_ignore(just(Token::Semicolon))
         .map_with(|(name, value), e| {
             let ast: &mut Ast = &mut e.state().0;
             let id = ast.add_node(AstKind::Assign);
             ast.set_leaf_data(id, AstLeaf::Assign(name));
             ast.add_edge(id, value);
             id
-        });
+        })
+}
 
-    choice((ret, decl, assign))
+fn empty_node<'src, I>(e: &mut MapExtra<'src, '_, I, Extra<'src>>) -> NodeId
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    e.state().0.add_node(AstKind::Empty)
+}
+
+fn stmt<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    recursive(|stmt| {
+        let semi = just(Token::Semicolon);
+
+        let block = stmt
+            .clone()
+            .repeated()
+            .collect::<Vec<NodeId>>()
+            .delimited_by(just(Token::LBrace), just(Token::RBrace))
+            .map_with(|stmts, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::Block);
+                for s in stmts {
+                    ast.add_edge(id, s);
+                }
+                id
+            });
+
+        let ret = just(Token::KwReturn)
+            .ignore_then(expr().or_not())
+            .then_ignore(semi.clone())
+            .map_with(|value, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::Return);
+                if let Some(value) = value {
+                    ast.add_edge(id, value);
+                }
+                id
+            });
+
+        let decl = decl_body().then_ignore(semi.clone());
+        let assign = assign_body().then_ignore(semi.clone());
+
+        let cond = expr().delimited_by(just(Token::LParen), just(Token::RParen));
+
+        let if_stmt = just(Token::KwIf)
+            .ignore_then(cond.clone())
+            .then(stmt.clone())
+            .then(just(Token::KwElse).ignore_then(stmt.clone()).or_not())
+            .map_with(
+                |((c, then), els), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                    let ast: &mut Ast = &mut e.state().0;
+                    let id = ast.add_node(AstKind::If);
+                    ast.add_edge(id, c);
+                    ast.add_edge(id, then);
+                    if let Some(els) = els {
+                        ast.add_edge(id, els);
+                    }
+                    id
+                },
+            );
+
+        let while_stmt = just(Token::KwWhile)
+            .ignore_then(cond.clone())
+            .then(stmt.clone())
+            .map_with(|(c, body), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::While);
+                ast.add_edge(id, c);
+                ast.add_edge(id, body);
+                id
+            });
+
+        let do_while = just(Token::KwDo)
+            .ignore_then(stmt.clone())
+            .then_ignore(just(Token::KwWhile))
+            .then(cond.clone())
+            .then_ignore(semi.clone())
+            .map_with(|(body, c), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::DoWhile);
+                ast.add_edge(id, body);
+                ast.add_edge(id, c);
+                id
+            });
+
+        // Each `for` clause may be omitted; an omitted clause becomes an
+        // `Empty` node so the node always has exactly four children.
+        let for_init = choice((decl_body(), assign_body()))
+            .or_not()
+            .map_with(|c, e| c.unwrap_or_else(|| empty_node(e)));
+        let for_cond = expr()
+            .or_not()
+            .map_with(|c, e| c.unwrap_or_else(|| empty_node(e)));
+        let for_step = choice((assign_body(), expr()))
+            .or_not()
+            .map_with(|c, e| c.unwrap_or_else(|| empty_node(e)));
+
+        let for_stmt = just(Token::KwFor)
+            .ignore_then(
+                for_init
+                    .then_ignore(semi.clone())
+                    .then(for_cond)
+                    .then_ignore(semi.clone())
+                    .then(for_step)
+                    .delimited_by(just(Token::LParen), just(Token::RParen)),
+            )
+            .then(stmt.clone())
+            .map_with(
+                |(((init, c), step), body), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                    let ast: &mut Ast = &mut e.state().0;
+                    let id = ast.add_node(AstKind::For);
+                    ast.add_edge(id, init);
+                    ast.add_edge(id, c);
+                    ast.add_edge(id, step);
+                    ast.add_edge(id, body);
+                    id
+                },
+            );
+
+        let break_stmt = just(Token::KwBreak).then_ignore(semi.clone()).map_with(
+            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| e.state().0.add_node(AstKind::Break),
+        );
+        let continue_stmt = just(Token::KwContinue).then_ignore(semi.clone()).map_with(
+            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| e.state().0.add_node(AstKind::Continue),
+        );
+
+        let null_stmt = semi
+            .clone()
+            .map_with(|_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                e.state().0.add_node(AstKind::Empty)
+            });
+
+        let expr_stmt = expr().then_ignore(semi).map_with(
+            |value, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let ast: &mut Ast = &mut e.state().0;
+                let id = ast.add_node(AstKind::ExprStmt);
+                ast.add_edge(id, value);
+                id
+            },
+        );
+
+        // Declarations start with a type keyword and control flow with its own
+        // keyword, so they are unambiguous. An assignment is tried before an
+        // expression statement because the latter would also accept the left
+        // operand of an assignment on its own.
+        choice((
+            block,
+            decl,
+            ret,
+            if_stmt,
+            while_stmt,
+            do_while,
+            for_stmt,
+            break_stmt,
+            continue_stmt,
+            null_stmt,
+            assign,
+            expr_stmt,
+        ))
+    })
 }
 
 fn function<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone


### PR DESCRIPTION
Extend the parser beyond the integer-arithmetic subset:

- Statements: if/else, while, do/while, for (with omittable clauses),
  break, continue, compound blocks, expression and null statements.
- Expressions: / % == != < > <= >= && || !, unary minus, and function
  calls, with a full C precedence ladder.

Types stay int/void. Codegen returns a graceful 'not yet implemented'
error for the new node kinds; the original arithmetic subset still
lowers. New AST FileCheck tests cover each construct.