### PR TITLE
feat(fcc): numbered ariadne diagnostics with --explain

### DIFF
--- a/fcc/Cargo.toml
+++ b/fcc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 logos = "0.16.1"
 chumsky = "0.10.1"
+ariadne = { workspace = true }
 tir = { path = "../core" }
 tir-be-common.workspace = true
 tir-targets.workspace = true

--- a/fcc/benches/codegen.rs
+++ b/fcc/benches/codegen.rs
@@ -11,6 +11,7 @@ use logos::Logos;
 
 use fcc::ast::Ast;
 use fcc::codegen::codegen;
+use fcc::diagnostics::{Span, intern_file};
 use fcc::lexer::Token;
 use fcc::parser::parse;
 use tir::Context;
@@ -58,7 +59,11 @@ fn gen_expr_heavy(funcs: usize, depth: usize) -> String {
 }
 
 fn parse_src(src: &str) -> Ast {
-    let tokens: Vec<Token> = Token::lexer(src).map(|r| r.unwrap()).collect();
+    let file = intern_file("<bench>", src);
+    let tokens: Vec<_> = Token::lexer(src)
+        .spanned()
+        .map(|(r, span)| (r.unwrap(), Span::new(file, span.start)))
+        .collect();
     parse(&tokens).expect("parse")
 }
 

--- a/fcc/src/ast.rs
+++ b/fcc/src/ast.rs
@@ -14,7 +14,25 @@
 
 use tir::graph::{Dag, NodeId, PostOrderDag};
 
-pub type Ast = PostOrderDag<AstKind, AstLeaf>;
+use crate::diagnostics::Span;
+
+/// The AST: node payloads ([`AstNode`], kind + source span) live in the DAG's
+/// dense vector, while the variable-sized leaf payload sits in its side table.
+pub type Ast = PostOrderDag<AstNode, AstLeaf>;
+
+/// A node's dense payload: its structural [`AstKind`] and the source [`Span`]
+/// where the construct begins, used to point diagnostics at the offending code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AstNode {
+    pub kind: AstKind,
+    pub span: Span,
+}
+
+impl AstNode {
+    pub fn new(kind: AstKind, span: Span) -> Self {
+        AstNode { kind, span }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CType {
@@ -102,7 +120,7 @@ pub fn render(ast: &Ast) -> String {
 fn render_node(ast: &Ast, id: NodeId, depth: usize, out: &mut String) {
     use std::fmt::Write;
 
-    let label = match ast.get_node(id) {
+    let label = match ast.get_node(id).kind {
         AstKind::TranslationUnit => "TranslationUnit".to_string(),
         AstKind::Function => match ast.get_leaf_data(id) {
             Some(AstLeaf::Function { name, ret }) => format!("Function {name:?} -> {ret:?}"),

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -14,6 +14,9 @@ use tir::ptr::{PtrType, ops as p};
 use tir::{Context, IRBuilder, Operand, Operation, TypeId, ValueId};
 
 use crate::ast::*;
+use crate::diagnostics::{
+    Diagnostic, EmptyTranslationUnit, UndeclaredIdentifier, UnsupportedConstruct,
+};
 
 /// A local variable: the pointer to its stack slot and the slot's element type.
 #[derive(Clone, Copy)]
@@ -34,17 +37,28 @@ struct FnCodegen<'a> {
 }
 
 /// Lower a translation unit into a `builtin.module` in `context`.
-pub fn codegen(context: &Context, ast: &Ast) -> Result<ModuleOp, String> {
+pub fn codegen(context: &Context, ast: &Ast) -> Result<ModuleOp, Diagnostic> {
     let module = b::module(context, None).build();
     let mut module_builder = IRBuilder::new(module.body());
 
-    let root = ast.root().ok_or("empty translation unit")?;
+    let root = ast.root().ok_or(EmptyTranslationUnit)?;
     for func in ast.children(root) {
         let func_op = lower_function(context, ast, func)?;
         module_builder.insert(func_op);
     }
     module_builder.insert(b::module_end(context).build());
     Ok(module)
+}
+
+/// Use of a name with no declaration in scope. Codegen runs on a span-less AST,
+/// so these diagnostics carry no source label; the message names the identifier.
+fn undeclared(name: &str) -> Diagnostic {
+    UndeclaredIdentifier::new(name).into()
+}
+
+/// A construct the parser accepts but codegen does not lower yet.
+fn unsupported(what: String) -> Diagnostic {
+    UnsupportedConstruct::new(what).into()
 }
 
 fn lower_ctype(context: &Context, ty: &CType) -> TypeId {
@@ -54,7 +68,11 @@ fn lower_ctype(context: &Context, ty: &CType) -> TypeId {
     }
 }
 
-fn lower_function(context: &Context, ast: &Ast, func: NodeId) -> Result<impl Operation, String> {
+fn lower_function(
+    context: &Context,
+    ast: &Ast,
+    func: NodeId,
+) -> Result<impl Operation, Diagnostic> {
     let AstLeaf::Function { name, ret } = ast.get_leaf_data(func).unwrap() else {
         unreachable!("function node carries a function payload");
     };
@@ -105,7 +123,7 @@ impl FnCodegen<'_> {
     /// Lower a function: spill parameters into stack slots, then lower each body
     /// statement in source order (statement order is a side-effect ordering, so it
     /// stays top-down; only the expressions within use the post-order iterator).
-    fn lower_body(&mut self, func: NodeId, param_ids: &[ValueId]) -> Result<(), String> {
+    fn lower_body(&mut self, func: NodeId, param_ids: &[ValueId]) -> Result<(), Diagnostic> {
         let ast = self.ast;
 
         let mut idx = 0;
@@ -131,7 +149,7 @@ impl FnCodegen<'_> {
         Ok(())
     }
 
-    fn lower_stmt(&mut self, stmt: NodeId) -> Result<(), String> {
+    fn lower_stmt(&mut self, stmt: NodeId) -> Result<(), Diagnostic> {
         let ast = self.ast;
         match ast.get_node(stmt) {
             AstKind::Decl => {
@@ -152,10 +170,7 @@ impl FnCodegen<'_> {
                 let AstLeaf::Assign(name) = ast.get_leaf_data(stmt).unwrap() else {
                     unreachable!("assign node carries an assign payload");
                 };
-                let slot = *self
-                    .locals
-                    .get(name)
-                    .ok_or_else(|| format!("assignment to unknown variable '{name}'"))?;
+                let slot = *self.locals.get(name).ok_or_else(|| undeclared(name))?;
                 let value = ast.children(stmt).next().unwrap();
                 let v = self.lower_expr(value)?;
                 self.builder
@@ -173,9 +188,7 @@ impl FnCodegen<'_> {
             }
             // Control flow and expression statements are parsed but not yet
             // lowered; codegen for them is stubbed out for now.
-            kind => Err(format!(
-                "codegen not yet implemented for statement {kind:?}"
-            )),
+            kind => Err(unsupported(format!("statement {kind:?}"))),
         }
     }
 
@@ -184,7 +197,7 @@ impl FnCodegen<'_> {
     /// AST is a tree, so the subtree is a contiguous index range `[base, root]`;
     /// values are pushed in index order, letting children be read by offset
     /// without hashing.
-    fn lower_expr(&mut self, root: NodeId) -> Result<ValueId, String> {
+    fn lower_expr(&mut self, root: NodeId) -> Result<ValueId, Diagnostic> {
         let ast = self.ast;
         let i32_ty = IntegerType::new(self.context, 32);
         self.values.clear();
@@ -213,10 +226,7 @@ impl FnCodegen<'_> {
                     let AstLeaf::Var(name) = ast.get_leaf_data(node).unwrap() else {
                         unreachable!("var node carries a var payload");
                     };
-                    let slot = *self
-                        .locals
-                        .get(name)
-                        .ok_or_else(|| format!("use of unknown variable '{name}'"))?;
+                    let slot = *self.locals.get(name).ok_or_else(|| undeclared(name))?;
                     self.builder
                         .insert(p::load(self.context, slot.ptr, slot.elem).build())
                         .result()
@@ -244,9 +254,7 @@ impl FnCodegen<'_> {
                 // The richer operators (division, comparison, logical, unary,
                 // calls) are parsed but not yet lowered; stub them out for now.
                 kind => {
-                    return Err(format!(
-                        "codegen not yet implemented for expression {kind:?}"
-                    ));
+                    return Err(unsupported(format!("expression {kind:?}")));
                 }
             };
             self.values.push(value);

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -41,7 +41,7 @@ pub fn codegen(context: &Context, ast: &Ast) -> Result<ModuleOp, Diagnostic> {
     let module = b::module(context, None).build();
     let mut module_builder = IRBuilder::new(module.body());
 
-    let root = ast.root().ok_or(EmptyTranslationUnit)?;
+    let root = ast.root().ok_or_else(EmptyTranslationUnit::new)?;
     for func in ast.children(root) {
         let func_op = lower_function(context, ast, func)?;
         module_builder.insert(func_op);

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -50,15 +50,14 @@ pub fn codegen(context: &Context, ast: &Ast) -> Result<ModuleOp, Diagnostic> {
     Ok(module)
 }
 
-/// Use of a name with no declaration in scope. Codegen runs on a span-less AST,
-/// so these diagnostics carry no source label; the message names the identifier.
-fn undeclared(name: &str) -> Diagnostic {
-    UndeclaredIdentifier::new(name).into()
+/// Use of a name with no declaration in scope, spanned at the offending node.
+fn undeclared(ast: &Ast, node: NodeId, name: &str) -> Diagnostic {
+    UndeclaredIdentifier::new(ast.get_node(node).span, name).into()
 }
 
 /// A construct the parser accepts but codegen does not lower yet.
-fn unsupported(what: String) -> Diagnostic {
-    UnsupportedConstruct::new(what).into()
+fn unsupported(ast: &Ast, node: NodeId, what: String) -> Diagnostic {
+    UnsupportedConstruct::new(ast.get_node(node).span, what).into()
 }
 
 fn lower_ctype(context: &Context, ty: &CType) -> TypeId {
@@ -83,7 +82,7 @@ fn lower_function(
     let mut param_values = Vec::new();
     for param in ast
         .children(func)
-        .take_while(|&c| matches!(ast.get_node(c), AstKind::Param))
+        .take_while(|&c| matches!(ast.get_node(c).kind, AstKind::Param))
     {
         let AstLeaf::Param { ty, .. } = ast.get_leaf_data(param).unwrap() else {
             unreachable!("param node carries a param payload");
@@ -129,7 +128,7 @@ impl FnCodegen<'_> {
         let mut idx = 0;
         for param in ast
             .children(func)
-            .take_while(|&c| matches!(ast.get_node(c), AstKind::Param))
+            .take_while(|&c| matches!(ast.get_node(c).kind, AstKind::Param))
         {
             let AstLeaf::Param { name, ty } = ast.get_leaf_data(param).unwrap() else {
                 unreachable!("param node carries a param payload");
@@ -151,7 +150,7 @@ impl FnCodegen<'_> {
 
     fn lower_stmt(&mut self, stmt: NodeId) -> Result<(), Diagnostic> {
         let ast = self.ast;
-        match ast.get_node(stmt) {
+        match ast.get_node(stmt).kind {
             AstKind::Decl => {
                 let AstLeaf::Decl { name, ty } = ast.get_leaf_data(stmt).unwrap() else {
                     unreachable!("decl node carries a decl payload");
@@ -170,7 +169,10 @@ impl FnCodegen<'_> {
                 let AstLeaf::Assign(name) = ast.get_leaf_data(stmt).unwrap() else {
                     unreachable!("assign node carries an assign payload");
                 };
-                let slot = *self.locals.get(name).ok_or_else(|| undeclared(name))?;
+                let slot = *self
+                    .locals
+                    .get(name)
+                    .ok_or_else(|| undeclared(ast, stmt, name))?;
                 let value = ast.children(stmt).next().unwrap();
                 let v = self.lower_expr(value)?;
                 self.builder
@@ -188,7 +190,7 @@ impl FnCodegen<'_> {
             }
             // Control flow and expression statements are parsed but not yet
             // lowered; codegen for them is stubbed out for now.
-            kind => Err(unsupported(format!("statement {kind:?}"))),
+            kind => Err(unsupported(ast, stmt, format!("statement {kind:?}"))),
         }
     }
 
@@ -213,7 +215,7 @@ impl FnCodegen<'_> {
                 "subtree not contiguous"
             );
 
-            let value = match ast.get_node(node) {
+            let value = match ast.get_node(node).kind {
                 AstKind::Int => {
                     let AstLeaf::Int(n) = ast.get_leaf_data(node).unwrap() else {
                         unreachable!("int node carries an int payload");
@@ -226,13 +228,15 @@ impl FnCodegen<'_> {
                     let AstLeaf::Var(name) = ast.get_leaf_data(node).unwrap() else {
                         unreachable!("var node carries a var payload");
                     };
-                    let slot = *self.locals.get(name).ok_or_else(|| undeclared(name))?;
+                    let slot = *self
+                        .locals
+                        .get(name)
+                        .ok_or_else(|| undeclared(ast, node, name))?;
                     self.builder
                         .insert(p::load(self.context, slot.ptr, slot.elem).build())
                         .result()
                 }
                 kind @ (AstKind::Add | AstKind::Sub | AstKind::Mul) => {
-                    let kind = *kind;
                     let mut children = ast.children(node);
                     let l = self.values[children.next().unwrap().index() - base];
                     let r = self.values[children.next().unwrap().index() - base];
@@ -254,7 +258,7 @@ impl FnCodegen<'_> {
                 // The richer operators (division, comparison, logical, unary,
                 // calls) are parsed but not yet lowered; stub them out for now.
                 kind => {
-                    return Err(unsupported(format!("expression {kind:?}")));
+                    return Err(unsupported(ast, node, format!("expression {kind:?}")));
                 }
             };
             self.values.push(value);

--- a/fcc/src/codegen_tests.rs
+++ b/fcc/src/codegen_tests.rs
@@ -1,13 +1,18 @@
 #[cfg(test)]
 mod tests {
     use crate::codegen::codegen;
+    use crate::diagnostics::{Span, intern_file};
     use crate::parser::parse;
     use logos::Logos;
 
     use crate::lexer::Token;
 
     fn compile(src: &str) -> String {
-        let tokens: Vec<Token> = Token::lexer(src).map(|r| r.unwrap()).collect();
+        let file = intern_file("<test>", src);
+        let tokens: Vec<_> = Token::lexer(src)
+            .spanned()
+            .map(|(r, span)| (r.unwrap(), Span::new(file, span.start)))
+            .collect();
         let unit = parse(&tokens).expect("parse");
         let context = tir::Context::with_default_dialects();
         let module = codegen(&context, &unit).expect("codegen");

--- a/fcc/src/diagnostics.rs
+++ b/fcc/src/diagnostics.rs
@@ -1,0 +1,627 @@
+//! The `fcc` diagnostic system: numbered, self-describing errors and warnings
+//! rendered with [`ariadne`], in the spirit of `rustc` and the Microsoft C
+//! compiler.
+//!
+//! Every diagnostic carries a stable [`Code`] (e.g. `E0001`, `W0300`) whose
+//! title, long-form explanation and standard reference live in one catalog, so
+//! `fcc --explain E0001` and the inline report draw from the same source of
+//! truth.
+//!
+//! Source positions are [`Span`]s: a single `u64` packing an interned [`FileId`]
+//! (high 32 bits) with a byte offset (low 32 bits). Because the file is part of
+//! the span, a diagnostic raised inside an `#include`d file resolves to that
+//! file's own text — there is no need to translate offsets back to the primary
+//! translation unit. The interner ([`intern_file`]) owns each file's name and
+//! source so a [`Diagnostic`] can render itself without the caller threading
+//! that text around.
+
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use ariadne::{Color, Config, IndexType, Label, Report, ReportKind, Source};
+
+// ---------------------------------------------------------------------------
+// Source files and spans
+// ---------------------------------------------------------------------------
+
+/// Handle to an interned source file (its name and text). See [`intern_file`].
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub struct FileId(u32);
+
+/// A source position: an interned file in the high 32 bits, a byte offset into
+/// that file in the low 32 bits. One `u64` covers every position fcc reports.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Span(u64);
+
+impl Span {
+    pub fn new(file: FileId, offset: usize) -> Span {
+        Span((u64::from(file.0) << 32) | u64::from(offset as u32))
+    }
+
+    pub fn file(self) -> FileId {
+        FileId((self.0 >> 32) as u32)
+    }
+
+    pub fn offset(self) -> usize {
+        (self.0 & 0xffff_ffff) as usize
+    }
+}
+
+type FileTable = Mutex<Vec<(String, Arc<str>)>>;
+
+fn files() -> &'static FileTable {
+    static FILES: OnceLock<FileTable> = OnceLock::new();
+    FILES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Register a source file and return its handle. Each call appends a fresh
+/// entry, so a file `#include`d twice gets two ids (each with its own text),
+/// which is exactly what the renderer needs.
+pub fn intern_file(name: &str, source: &str) -> FileId {
+    let mut files = files().lock().unwrap();
+    files.push((name.to_string(), Arc::from(source)));
+    FileId((files.len() - 1) as u32)
+}
+
+pub fn file_source(file: FileId) -> Arc<str> {
+    Arc::clone(&files().lock().unwrap()[file.0 as usize].1)
+}
+
+fn file_name(file: FileId) -> String {
+    files().lock().unwrap()[file.0 as usize].0.clone()
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic catalog
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// A stable diagnostic identifier. The numeric ranges group related problems:
+/// `E0001..` syntax, `E02xx` name resolution, `E03xx`/`W03xx` preprocessor,
+/// `E09xx` constructs `fcc` does not yet implement.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Code {
+    UnexpectedToken,
+    UnexpectedEof,
+    UndeclaredIdentifier,
+    PreprocError,
+    PreprocWarning,
+    UnsupportedConstruct,
+    EmptyTranslationUnit,
+}
+
+impl Code {
+    pub fn severity(self) -> Severity {
+        match self {
+            Code::PreprocWarning => Severity::Warning,
+            _ => Severity::Error,
+        }
+    }
+
+    /// The printable identifier, e.g. `"E0001"`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Code::UnexpectedToken => "E0001",
+            Code::UnexpectedEof => "E0002",
+            Code::UndeclaredIdentifier => "E0200",
+            Code::PreprocError => "E0300",
+            Code::PreprocWarning => "W0300",
+            Code::UnsupportedConstruct => "E0900",
+            Code::EmptyTranslationUnit => "E0901",
+        }
+    }
+
+    /// The one-line summary shown as the report message.
+    pub fn title(self) -> &'static str {
+        match self {
+            Code::UnexpectedToken => "unexpected token",
+            Code::UnexpectedEof => "unexpected end of file",
+            Code::UndeclaredIdentifier => "use of undeclared identifier",
+            Code::PreprocError => "#error directive",
+            Code::PreprocWarning => "#warning directive",
+            Code::UnsupportedConstruct => "unsupported construct",
+            Code::EmptyTranslationUnit => "empty translation unit",
+        }
+    }
+
+    /// A standard reference, printed as a `note:` so the user can read the rule
+    /// the diagnostic enforces. Section numbers follow ISO/IEC 9899:2018 (C17).
+    pub fn reference(self) -> Option<&'static str> {
+        match self {
+            Code::UnexpectedToken | Code::UnexpectedEof => Some(
+                "C17 6.9: an external declaration must be a function definition or a declaration",
+            ),
+            Code::UndeclaredIdentifier => {
+                Some("C17 6.5.1: an identifier must be visibly declared before it is used")
+            }
+            Code::PreprocError => {
+                Some("C17 6.10.5: the #error directive renders the program ill-formed")
+            }
+            Code::PreprocWarning => {
+                Some("C23 6.10.6: #warning emits a diagnostic without halting translation")
+            }
+            Code::UnsupportedConstruct | Code::EmptyTranslationUnit => None,
+        }
+    }
+
+    /// The long-form text shown by `fcc --explain <CODE>`.
+    pub fn explanation(self) -> &'static str {
+        match self {
+            Code::UnexpectedToken => {
+                "\
+The parser reached a token that cannot continue the current grammar rule. This
+usually means a missing or stray token: a forgotten semicolon, an unbalanced
+brace or parenthesis, or an operator without an operand.
+
+Read the label to see what the parser expected at that point, then add the
+missing token or remove the unexpected one."
+            }
+            Code::UnexpectedEof => {
+                "\
+The source ended while the parser was still expecting more input, for example a
+closing brace for a function body or the rest of an unfinished expression.
+
+Make sure every `{`, `(` and statement is closed before the end of the file."
+            }
+            Code::UndeclaredIdentifier => {
+                "\
+A variable was read or assigned before any declaration introduced it into
+scope. C has no implicit declarations: a name must be declared with a type
+before it is used.
+
+Declare the variable before the statement that uses it, e.g. `int total = 0;`,
+and check the spelling of the identifier."
+            }
+            Code::PreprocError => {
+                "\
+The translation unit contains an active `#error` directive. The preprocessor
+emits the directive's text and the program is rejected.
+
+Remove the `#error`, or satisfy the `#if` condition that guards it (often a
+missing `-D` define or include path)."
+            }
+            Code::PreprocWarning => {
+                "\
+An active `#warning` directive emitted its message. Unlike `#error`, this does
+not stop compilation; it flags a condition the author wanted you to notice.
+
+Address the cause described by the message, or remove the directive once it no
+longer applies."
+            }
+            Code::UnsupportedConstruct => {
+                "\
+The construct is valid C but `fcc` does not lower it to IR yet. The frontend
+parses a wider language than the code generator currently supports.
+
+Rewrite the function using the supported subset, or pick an earlier `--stage`
+(such as `ast`) that does not require code generation."
+            }
+            Code::EmptyTranslationUnit => {
+                "\
+Code generation was asked to lower a translation unit that contains no
+functions. There is nothing to emit.
+
+Provide at least one function definition in the input."
+            }
+        }
+    }
+
+    pub fn from_code(code: &str) -> Option<Code> {
+        const ALL: [Code; 7] = [
+            Code::UnexpectedToken,
+            Code::UnexpectedEof,
+            Code::UndeclaredIdentifier,
+            Code::PreprocError,
+            Code::PreprocWarning,
+            Code::UnsupportedConstruct,
+            Code::EmptyTranslationUnit,
+        ];
+        ALL.into_iter()
+            .find(|c| c.as_str().eq_ignore_ascii_case(code))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic
+// ---------------------------------------------------------------------------
+
+/// The rendered form every diagnostic lowers to. It is rarely built directly:
+/// each problem has its own concrete type (see below) constructed with `new`
+/// and converted with `.into()`, so the message, label and help that belong to
+/// a [`Code`] live in one place.
+///
+/// `label` ties the message to a position in a source file; when absent
+/// (codegen has no source spans yet) the diagnostic renders as a compact header
+/// without a snippet.
+#[derive(Debug)]
+pub struct Diagnostic {
+    code: Code,
+    message: String,
+    label: Option<(Span, String)>,
+    help: Option<String>,
+}
+
+impl Diagnostic {
+    fn new(code: Code, message: impl Into<String>) -> Self {
+        Diagnostic {
+            code,
+            message: message.into(),
+            label: None,
+            help: None,
+        }
+    }
+
+    fn with_label(mut self, span: Span, message: impl Into<String>) -> Self {
+        self.label = Some((span, message.into()));
+        self
+    }
+
+    fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    pub fn code(&self) -> Code {
+        self.code
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.code.severity() == Severity::Error
+    }
+
+    /// Render to stderr with color (the interactive default).
+    pub fn eprint(&self) {
+        let _ = self.write(&mut io::stderr(), true);
+    }
+
+    /// Render to an arbitrary writer; `color` toggles ANSI styling (off for
+    /// tests and non-terminal output).
+    pub fn write(&self, w: &mut dyn Write, color: bool) -> io::Result<()> {
+        match &self.label {
+            Some((span, label)) => self.write_report(*span, label, w, color),
+            None => self.write_compact(w, color),
+        }
+    }
+
+    fn write_report(
+        &self,
+        span: Span,
+        label: &str,
+        w: &mut dyn Write,
+        color: bool,
+    ) -> io::Result<()> {
+        let name = file_name(span.file());
+        let source = file_source(span.file());
+        // Point spans carry only a start; underline the first byte so the caret
+        // has something to sit under, clamping at end of file.
+        let off = span.offset();
+        let range = off..(off + 1).min(source.len()).max(off);
+
+        let (kind, accent) = match self.code.severity() {
+            Severity::Error => (ReportKind::Error, Color::Red),
+            Severity::Warning => (ReportKind::Warning, Color::Yellow),
+        };
+        let mut report = Report::build(kind, (name.clone(), range.clone()))
+            .with_config(
+                Config::new()
+                    .with_index_type(IndexType::Byte)
+                    .with_color(color),
+            )
+            .with_code(self.code.as_str())
+            .with_message(&self.message)
+            .with_label(
+                Label::new((name.clone(), range))
+                    .with_message(label)
+                    .with_color(accent),
+            );
+        if let Some(help) = &self.help {
+            report = report.with_help(help);
+        }
+        if let Some(reference) = self.code.reference() {
+            report = report.with_note(reference);
+        }
+        report.finish().write((name, Source::from(&*source)), w)
+    }
+
+    /// Spanless rendering: `kind[CODE]: message` plus help/note lines, matching
+    /// ariadne's header style without a source frame.
+    fn write_compact(&self, w: &mut dyn Write, color: bool) -> io::Result<()> {
+        let (word, accent) = match self.code.severity() {
+            Severity::Error => ("error", "\x1b[31m"),
+            Severity::Warning => ("warning", "\x1b[33m"),
+        };
+        let (a, r) = if color { (accent, "\x1b[0m") } else { ("", "") };
+        writeln!(w, "{a}{word}[{}]{r}: {}", self.code.as_str(), self.message)?;
+        if let Some(help) = &self.help {
+            writeln!(w, "  = help: {help}")?;
+        }
+        if let Some(reference) = self.code.reference() {
+            writeln!(w, "  = note: {reference}")?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete diagnostics
+//
+// Each problem the compiler can report is its own type, built with `new` and
+// turned into a `Diagnostic` with `.into()`. This keeps the message, span label
+// and fix hint for a given `Code` next to the data they need.
+// ---------------------------------------------------------------------------
+
+/// `E0001`: the parser met a token that cannot continue the current rule.
+pub struct UnexpectedToken {
+    pub span: Span,
+    /// The parser's account of what it expected versus what it found.
+    pub reason: String,
+}
+
+impl UnexpectedToken {
+    pub fn new(span: Span, reason: impl Into<String>) -> Self {
+        UnexpectedToken {
+            span,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl From<UnexpectedToken> for Diagnostic {
+    fn from(d: UnexpectedToken) -> Diagnostic {
+        Diagnostic::new(Code::UnexpectedToken, Code::UnexpectedToken.title())
+            .with_label(d.span, d.reason)
+            .with_help("check for a missing or misplaced token near here")
+    }
+}
+
+/// `E0002`: input ended while the parser still expected more.
+pub struct UnexpectedEof {
+    pub span: Span,
+    pub reason: String,
+}
+
+impl UnexpectedEof {
+    pub fn new(span: Span, reason: impl Into<String>) -> Self {
+        UnexpectedEof {
+            span,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl From<UnexpectedEof> for Diagnostic {
+    fn from(d: UnexpectedEof) -> Diagnostic {
+        Diagnostic::new(Code::UnexpectedEof, Code::UnexpectedEof.title())
+            .with_label(d.span, d.reason)
+            .with_help("a brace, parenthesis or statement is left unclosed")
+    }
+}
+
+/// `E0200`: a name is used without any declaration in scope.
+pub struct UndeclaredIdentifier {
+    pub name: String,
+}
+
+impl UndeclaredIdentifier {
+    pub fn new(name: impl Into<String>) -> Self {
+        UndeclaredIdentifier { name: name.into() }
+    }
+}
+
+impl From<UndeclaredIdentifier> for Diagnostic {
+    fn from(d: UndeclaredIdentifier) -> Diagnostic {
+        Diagnostic::new(
+            Code::UndeclaredIdentifier,
+            format!("use of undeclared identifier '{}'", d.name),
+        )
+        .with_help(format!("declare '{}' with a type before using it", d.name))
+    }
+}
+
+/// `E0900`: valid C that the code generator does not lower yet.
+pub struct UnsupportedConstruct {
+    pub what: String,
+}
+
+impl UnsupportedConstruct {
+    pub fn new(what: impl Into<String>) -> Self {
+        UnsupportedConstruct { what: what.into() }
+    }
+}
+
+impl From<UnsupportedConstruct> for Diagnostic {
+    fn from(d: UnsupportedConstruct) -> Diagnostic {
+        Diagnostic::new(
+            Code::UnsupportedConstruct,
+            format!("codegen not yet implemented for {}", d.what),
+        )
+    }
+}
+
+/// `E0901`: code generation reached a translation unit with no functions.
+pub struct EmptyTranslationUnit;
+
+impl From<EmptyTranslationUnit> for Diagnostic {
+    fn from(_: EmptyTranslationUnit) -> Diagnostic {
+        Diagnostic::new(
+            Code::EmptyTranslationUnit,
+            "translation unit contains no functions",
+        )
+    }
+}
+
+/// `E0300`: an active `#error` directive.
+pub struct PreprocError {
+    pub span: Span,
+    /// The directive's text (empty for a bare `#error`).
+    pub text: String,
+}
+
+impl PreprocError {
+    pub fn new(span: Span, text: impl Into<String>) -> Self {
+        PreprocError {
+            span,
+            text: text.into(),
+        }
+    }
+}
+
+impl From<PreprocError> for Diagnostic {
+    fn from(d: PreprocError) -> Diagnostic {
+        let message = if d.text.is_empty() {
+            Code::PreprocError.title().to_string()
+        } else {
+            d.text
+        };
+        Diagnostic::new(Code::PreprocError, message)
+            .with_label(d.span, "#error directive encountered")
+    }
+}
+
+/// `W0300`: an active `#warning` directive.
+pub struct PreprocWarning {
+    pub span: Span,
+    pub text: String,
+}
+
+impl PreprocWarning {
+    pub fn new(span: Span, text: impl Into<String>) -> Self {
+        PreprocWarning {
+            span,
+            text: text.into(),
+        }
+    }
+}
+
+impl From<PreprocWarning> for Diagnostic {
+    fn from(d: PreprocWarning) -> Diagnostic {
+        let message = if d.text.is_empty() {
+            Code::PreprocWarning.title().to_string()
+        } else {
+            d.text
+        };
+        Diagnostic::new(Code::PreprocWarning, message)
+            .with_label(d.span, "#warning directive encountered")
+    }
+}
+
+/// The body of `fcc --explain <CODE>`: the title line followed by the long-form
+/// explanation and, where it exists, the standard reference.
+pub fn explain(code: &str) -> Option<String> {
+    let code = Code::from_code(code)?;
+    let word = match code.severity() {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    };
+    let mut out = format!(
+        "{word}[{}]: {}\n\n{}\n",
+        code.as_str(),
+        code.title(),
+        code.explanation()
+    );
+    if let Some(reference) = code.reference() {
+        out.push_str(&format!("\nReference: {reference}\n"));
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Render a diagnostic to a plain (color-free) string.
+    fn render(diag: Diagnostic) -> String {
+        let mut buf = Vec::new();
+        diag.write(&mut buf, false).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    const CODES: [Code; 7] = [
+        Code::UnexpectedToken,
+        Code::UnexpectedEof,
+        Code::UndeclaredIdentifier,
+        Code::PreprocError,
+        Code::PreprocWarning,
+        Code::UnsupportedConstruct,
+        Code::EmptyTranslationUnit,
+    ];
+
+    #[test]
+    fn codes_round_trip_and_are_unique() {
+        let mut seen = Vec::new();
+        for code in CODES {
+            assert_eq!(Code::from_code(code.as_str()), Some(code));
+            assert!(!seen.contains(&code.as_str()), "duplicate code string");
+            seen.push(code.as_str());
+        }
+        assert_eq!(Code::from_code("e0001"), Some(Code::UnexpectedToken));
+        assert_eq!(Code::from_code("E9999"), None);
+    }
+
+    #[test]
+    fn severity_follows_code_prefix() {
+        for code in CODES {
+            let expected = if code.as_str().starts_with('W') {
+                Severity::Warning
+            } else {
+                Severity::Error
+            };
+            assert_eq!(code.severity(), expected);
+        }
+    }
+
+    #[test]
+    fn span_packs_file_and_offset() {
+        let file = intern_file("<span-test>", "source");
+        let span = Span::new(file, 1234);
+        assert_eq!(span.file(), file);
+        assert_eq!(span.offset(), 1234);
+    }
+
+    #[test]
+    fn spanned_report_points_at_source() {
+        let src = "int main(void) { return; }";
+        let file = intern_file("<report-test>", src);
+        let at = src.find("return").unwrap();
+        let diag: Diagnostic = UnexpectedToken::new(Span::new(file, at), "found ';'").into();
+
+        let out = render(diag);
+        assert!(out.contains("[E0001]"), "{out}");
+        assert!(out.contains("unexpected token"), "{out}");
+        assert!(out.contains("found ';'"), "{out}");
+        assert!(out.contains("<report-test>"), "{out}");
+        // The standard reference is attached automatically from the catalog.
+        assert!(out.contains("6.9"), "{out}");
+    }
+
+    #[test]
+    fn spanless_diagnostic_renders_compact_header() {
+        let out = render(UndeclaredIdentifier::new("count").into());
+        assert!(out.starts_with("error[E0200]:"), "{out}");
+        assert!(out.contains("undeclared identifier 'count'"), "{out}");
+        assert!(out.contains("= help:"), "{out}");
+        assert!(out.contains("= note:"), "{out}");
+    }
+
+    #[test]
+    fn warning_uses_warning_severity() {
+        let file = intern_file("<warn-test>", "#warning hi");
+        let diag: Diagnostic = PreprocWarning::new(Span::new(file, 0), "hi").into();
+        assert!(!diag.is_error());
+        assert_eq!(diag.code(), Code::PreprocWarning);
+    }
+
+    #[test]
+    fn explain_known_and_unknown() {
+        let text = explain("E0300").unwrap();
+        assert!(text.contains("error[E0300]"));
+        assert!(text.contains("#error"));
+        assert!(text.contains("Reference:"));
+        assert!(explain("nope").is_none());
+    }
+}

--- a/fcc/src/diagnostics.rs
+++ b/fcc/src/diagnostics.rs
@@ -2,16 +2,17 @@
 //! rendered with [`ariadne`], in the spirit of `rustc` and the Microsoft C
 //! compiler.
 //!
-//! Every diagnostic carries a stable [`Code`] (e.g. `E0001`, `W0300`) whose
-//! title, long-form explanation and standard reference live in one catalog, so
-//! `fcc --explain E0001` and the inline report draw from the same source of
-//! truth.
+//! The whole catalog is one [`diagnostics!`] table. Each row declares a stable
+//! [`Code`] (e.g. `E0001`, `W0300`), its title, standard reference and the
+//! long-form text shown by `fcc --explain`, plus a concrete builder type
+//! (`UnexpectedToken`, `UndeclaredIdentifier`, …) constructed with `new` and
+//! converted into a [`Diagnostic`] with `.into()`. Severity is read from the
+//! code's first letter (`W` = warning).
 //!
 //! Source positions are [`Span`]s: a single `u64` packing an interned [`FileId`]
 //! (high 32 bits) with a byte offset (low 32 bits). Because the file is part of
 //! the span, a diagnostic raised inside an `#include`d file resolves to that
-//! file's own text — there is no need to translate offsets back to the primary
-//! translation unit. The interner ([`intern_file`]) owns each file's name and
+//! file's own text. The interner ([`intern_file`]) owns each file's name and
 //! source so a [`Diagnostic`] can render itself without the caller threading
 //! that text around.
 
@@ -72,7 +73,7 @@ fn file_name(file: FileId) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Diagnostic catalog
+// Catalog
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -81,148 +82,215 @@ pub enum Severity {
     Warning,
 }
 
-/// A stable diagnostic identifier. The numeric ranges group related problems:
-/// `E0001..` syntax, `E02xx` name resolution, `E03xx`/`W03xx` preprocessor,
-/// `E09xx` constructs `fcc` does not yet implement.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Code {
-    UnexpectedToken,
-    UnexpectedEof,
-    UndeclaredIdentifier,
-    PreprocError,
-    PreprocWarning,
-    UnsupportedConstruct,
-    EmptyTranslationUnit,
+/// Declare the diagnostic catalog: the [`Code`] enum with its metadata plus one
+/// builder type per row. `build` maps the type's fields (`d`) to a
+/// [`Diagnostic`]; `fields: {}` is allowed for diagnostics without payload.
+macro_rules! diagnostics {
+    ($(
+        $(#[$meta:meta])*
+        $name:ident = $code:literal {
+            title: $title:literal,
+            reference: $reference:expr,
+            explain: $explain:literal,
+            fields: { $($field:ident: $fty:ty),* $(,)? },
+            build: |$d:ident| $build:expr,
+        }
+    )*) => {
+        /// A stable diagnostic identifier. The numeric ranges group related
+        /// problems: `E0001..` syntax, `E02xx` name resolution, `E03xx`/`W03xx`
+        /// preprocessor, `E09xx` constructs `fcc` does not yet implement.
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        pub enum Code {
+            $($name),*
+        }
+
+        impl Code {
+            pub const ALL: &'static [Code] = &[$(Code::$name),*];
+
+            /// The printable identifier, e.g. `"E0001"`.
+            pub fn as_str(self) -> &'static str {
+                match self { $(Code::$name => $code),* }
+            }
+
+            /// The one-line summary shown as the report message.
+            pub fn title(self) -> &'static str {
+                match self { $(Code::$name => $title),* }
+            }
+
+            /// A standard reference, printed as a `note:`. Section numbers
+            /// follow ISO/IEC 9899:2018 (C17) unless stated otherwise.
+            pub fn reference(self) -> Option<&'static str> {
+                match self { $(Code::$name => $reference),* }
+            }
+
+            /// The long-form text shown by `fcc --explain <CODE>`.
+            pub fn explanation(self) -> &'static str {
+                match self { $(Code::$name => $explain),* }
+            }
+        }
+
+        $(
+            $(#[$meta])*
+            pub struct $name {
+                $(pub $field: $fty),*
+            }
+
+            impl $name {
+                // Payload-free diagnostics get an argument-less `new`; that is
+                // the intended constructor, not a missing `Default`.
+                #[allow(clippy::new_without_default)]
+                pub fn new($($field: impl Into<$fty>),*) -> Self {
+                    Self { $($field: $field.into()),* }
+                }
+            }
+
+            impl From<$name> for Diagnostic {
+                fn from($d: $name) -> Diagnostic {
+                    $build
+                }
+            }
+        )*
+    };
 }
 
-impl Code {
-    pub fn severity(self) -> Severity {
-        match self {
-            Code::PreprocWarning => Severity::Warning,
-            _ => Severity::Error,
-        }
-    }
-
-    /// The printable identifier, e.g. `"E0001"`.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Code::UnexpectedToken => "E0001",
-            Code::UnexpectedEof => "E0002",
-            Code::UndeclaredIdentifier => "E0200",
-            Code::PreprocError => "E0300",
-            Code::PreprocWarning => "W0300",
-            Code::UnsupportedConstruct => "E0900",
-            Code::EmptyTranslationUnit => "E0901",
-        }
-    }
-
-    /// The one-line summary shown as the report message.
-    pub fn title(self) -> &'static str {
-        match self {
-            Code::UnexpectedToken => "unexpected token",
-            Code::UnexpectedEof => "unexpected end of file",
-            Code::UndeclaredIdentifier => "use of undeclared identifier",
-            Code::PreprocError => "#error directive",
-            Code::PreprocWarning => "#warning directive",
-            Code::UnsupportedConstruct => "unsupported construct",
-            Code::EmptyTranslationUnit => "empty translation unit",
-        }
-    }
-
-    /// A standard reference, printed as a `note:` so the user can read the rule
-    /// the diagnostic enforces. Section numbers follow ISO/IEC 9899:2018 (C17).
-    pub fn reference(self) -> Option<&'static str> {
-        match self {
-            Code::UnexpectedToken | Code::UnexpectedEof => Some(
-                "C17 6.9: an external declaration must be a function definition or a declaration",
-            ),
-            Code::UndeclaredIdentifier => {
-                Some("C17 6.5.1: an identifier must be visibly declared before it is used")
-            }
-            Code::PreprocError => {
-                Some("C17 6.10.5: the #error directive renders the program ill-formed")
-            }
-            Code::PreprocWarning => {
-                Some("C23 6.10.6: #warning emits a diagnostic without halting translation")
-            }
-            Code::UnsupportedConstruct | Code::EmptyTranslationUnit => None,
-        }
-    }
-
-    /// The long-form text shown by `fcc --explain <CODE>`.
-    pub fn explanation(self) -> &'static str {
-        match self {
-            Code::UnexpectedToken => {
-                "\
+diagnostics! {
+    /// `E0001`: the parser met a token that cannot continue the current rule.
+    UnexpectedToken = "E0001" {
+        title: "unexpected token",
+        reference: Some("C17 6.9: an external declaration must be a function definition or a declaration"),
+        explain: "\
 The parser reached a token that cannot continue the current grammar rule. This
 usually means a missing or stray token: a forgotten semicolon, an unbalanced
 brace or parenthesis, or an operator without an operand.
 
 Read the label to see what the parser expected at that point, then add the
-missing token or remove the unexpected one."
-            }
-            Code::UnexpectedEof => {
-                "\
+missing token or remove the unexpected one.",
+        fields: { span: Span, reason: String },
+        build: |d| Diagnostic::of(Code::UnexpectedToken)
+            .label(d.span, d.reason)
+            .help("check for a missing or misplaced token near here"),
+    }
+
+    /// `E0002`: input ended while the parser still expected more.
+    UnexpectedEof = "E0002" {
+        title: "unexpected end of file",
+        reference: Some("C17 6.9: an external declaration must be a function definition or a declaration"),
+        explain: "\
 The source ended while the parser was still expecting more input, for example a
 closing brace for a function body or the rest of an unfinished expression.
 
-Make sure every `{`, `(` and statement is closed before the end of the file."
-            }
-            Code::UndeclaredIdentifier => {
-                "\
+Make sure every `{`, `(` and statement is closed before the end of the file.",
+        fields: { span: Span, reason: String },
+        build: |d| Diagnostic::of(Code::UnexpectedEof)
+            .label(d.span, d.reason)
+            .help("a brace, parenthesis or statement is left unclosed"),
+    }
+
+    /// `E0200`: a name is used without any declaration in scope.
+    UndeclaredIdentifier = "E0200" {
+        title: "use of undeclared identifier",
+        reference: Some("C17 6.5.1: an identifier must be visibly declared before it is used"),
+        explain: "\
 A variable was read or assigned before any declaration introduced it into
 scope. C has no implicit declarations: a name must be declared with a type
 before it is used.
 
 Declare the variable before the statement that uses it, e.g. `int total = 0;`,
-and check the spelling of the identifier."
-            }
-            Code::PreprocError => {
-                "\
+and check the spelling of the identifier.",
+        fields: { span: Span, name: String },
+        build: |d| Diagnostic::of(Code::UndeclaredIdentifier)
+            .message(format!("use of undeclared identifier '{}'", d.name))
+            .label(d.span, "not declared in this scope")
+            .help(format!("declare '{}' with a type before using it", d.name)),
+    }
+
+    /// `E0300`: an active `#error` directive.
+    PreprocError = "E0300" {
+        title: "#error directive",
+        reference: Some("C17 6.10.5: the #error directive renders the program ill-formed"),
+        explain: "\
 The translation unit contains an active `#error` directive. The preprocessor
 emits the directive's text and the program is rejected.
 
 Remove the `#error`, or satisfy the `#if` condition that guards it (often a
-missing `-D` define or include path)."
-            }
-            Code::PreprocWarning => {
-                "\
+missing `-D` define or include path).",
+        fields: { span: Span, text: String },
+        build: |d| Diagnostic::of(Code::PreprocError)
+            .message(directive_message(Code::PreprocError, d.text))
+            .label(d.span, "#error directive encountered"),
+    }
+
+    /// `W0300`: an active `#warning` directive.
+    PreprocWarning = "W0300" {
+        title: "#warning directive",
+        reference: Some("C23 6.10.6: #warning emits a diagnostic without halting translation"),
+        explain: "\
 An active `#warning` directive emitted its message. Unlike `#error`, this does
 not stop compilation; it flags a condition the author wanted you to notice.
 
 Address the cause described by the message, or remove the directive once it no
-longer applies."
-            }
-            Code::UnsupportedConstruct => {
-                "\
+longer applies.",
+        fields: { span: Span, text: String },
+        build: |d| Diagnostic::of(Code::PreprocWarning)
+            .message(directive_message(Code::PreprocWarning, d.text))
+            .label(d.span, "#warning directive encountered"),
+    }
+
+    /// `E0900`: valid C that the code generator does not lower yet.
+    UnsupportedConstruct = "E0900" {
+        title: "unsupported construct",
+        reference: None,
+        explain: "\
 The construct is valid C but `fcc` does not lower it to IR yet. The frontend
 parses a wider language than the code generator currently supports.
 
 Rewrite the function using the supported subset, or pick an earlier `--stage`
-(such as `ast`) that does not require code generation."
-            }
-            Code::EmptyTranslationUnit => {
-                "\
+(such as `ast`) that does not require code generation.",
+        fields: { span: Span, what: String },
+        build: |d| Diagnostic::of(Code::UnsupportedConstruct)
+            .message(format!("codegen not yet implemented for {}", d.what))
+            .label(d.span, "not supported by codegen yet"),
+    }
+
+    /// `E0901`: code generation reached a translation unit with no functions.
+    EmptyTranslationUnit = "E0901" {
+        title: "empty translation unit",
+        reference: None,
+        explain: "\
 Code generation was asked to lower a translation unit that contains no
 functions. There is nothing to emit.
 
-Provide at least one function definition in the input."
-            }
+Provide at least one function definition in the input.",
+        fields: {},
+        build: |_d| Diagnostic::of(Code::EmptyTranslationUnit)
+            .message("translation unit contains no functions"),
+    }
+}
+
+impl Code {
+    pub fn severity(self) -> Severity {
+        if self.as_str().as_bytes()[0] == b'W' {
+            Severity::Warning
+        } else {
+            Severity::Error
         }
     }
 
     pub fn from_code(code: &str) -> Option<Code> {
-        const ALL: [Code; 7] = [
-            Code::UnexpectedToken,
-            Code::UnexpectedEof,
-            Code::UndeclaredIdentifier,
-            Code::PreprocError,
-            Code::PreprocWarning,
-            Code::UnsupportedConstruct,
-            Code::EmptyTranslationUnit,
-        ];
-        ALL.into_iter()
+        Code::ALL
+            .iter()
+            .copied()
             .find(|c| c.as_str().eq_ignore_ascii_case(code))
+    }
+}
+
+/// Message for a `#error`/`#warning`: the directive's own text, or the code's
+/// title when the directive carried none.
+fn directive_message(code: Code, text: String) -> String {
+    if text.is_empty() {
+        code.title().to_string()
+    } else {
+        text
     }
 }
 
@@ -230,14 +298,9 @@ Provide at least one function definition in the input."
 // Diagnostic
 // ---------------------------------------------------------------------------
 
-/// The rendered form every diagnostic lowers to. It is rarely built directly:
-/// each problem has its own concrete type (see below) constructed with `new`
-/// and converted with `.into()`, so the message, label and help that belong to
-/// a [`Code`] live in one place.
-///
-/// `label` ties the message to a position in a source file; when absent
-/// (codegen has no source spans yet) the diagnostic renders as a compact header
-/// without a snippet.
+/// The rendered form every diagnostic lowers to, built by the catalog's
+/// `build` closures. `label` ties the message to a position in a source file;
+/// when absent the diagnostic renders as a compact header without a snippet.
 #[derive(Debug)]
 pub struct Diagnostic {
     code: Code,
@@ -247,21 +310,27 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-    fn new(code: Code, message: impl Into<String>) -> Self {
+    /// Start a diagnostic for `code`, defaulting the message to its title.
+    fn of(code: Code) -> Self {
         Diagnostic {
             code,
-            message: message.into(),
+            message: code.title().to_string(),
             label: None,
             help: None,
         }
     }
 
-    fn with_label(mut self, span: Span, message: impl Into<String>) -> Self {
+    fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = message.into();
+        self
+    }
+
+    fn label(mut self, span: Span, message: impl Into<String>) -> Self {
         self.label = Some((span, message.into()));
         self
     }
 
-    fn with_help(mut self, help: impl Into<String>) -> Self {
+    fn help(mut self, help: impl Into<String>) -> Self {
         self.help = Some(help.into());
         self
     }
@@ -347,179 +416,6 @@ impl Diagnostic {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Concrete diagnostics
-//
-// Each problem the compiler can report is its own type, built with `new` and
-// turned into a `Diagnostic` with `.into()`. This keeps the message, span label
-// and fix hint for a given `Code` next to the data they need.
-// ---------------------------------------------------------------------------
-
-/// `E0001`: the parser met a token that cannot continue the current rule.
-pub struct UnexpectedToken {
-    pub span: Span,
-    /// The parser's account of what it expected versus what it found.
-    pub reason: String,
-}
-
-impl UnexpectedToken {
-    pub fn new(span: Span, reason: impl Into<String>) -> Self {
-        UnexpectedToken {
-            span,
-            reason: reason.into(),
-        }
-    }
-}
-
-impl From<UnexpectedToken> for Diagnostic {
-    fn from(d: UnexpectedToken) -> Diagnostic {
-        Diagnostic::new(Code::UnexpectedToken, Code::UnexpectedToken.title())
-            .with_label(d.span, d.reason)
-            .with_help("check for a missing or misplaced token near here")
-    }
-}
-
-/// `E0002`: input ended while the parser still expected more.
-pub struct UnexpectedEof {
-    pub span: Span,
-    pub reason: String,
-}
-
-impl UnexpectedEof {
-    pub fn new(span: Span, reason: impl Into<String>) -> Self {
-        UnexpectedEof {
-            span,
-            reason: reason.into(),
-        }
-    }
-}
-
-impl From<UnexpectedEof> for Diagnostic {
-    fn from(d: UnexpectedEof) -> Diagnostic {
-        Diagnostic::new(Code::UnexpectedEof, Code::UnexpectedEof.title())
-            .with_label(d.span, d.reason)
-            .with_help("a brace, parenthesis or statement is left unclosed")
-    }
-}
-
-/// `E0200`: a name is used without any declaration in scope.
-pub struct UndeclaredIdentifier {
-    pub span: Span,
-    pub name: String,
-}
-
-impl UndeclaredIdentifier {
-    pub fn new(span: Span, name: impl Into<String>) -> Self {
-        UndeclaredIdentifier {
-            span,
-            name: name.into(),
-        }
-    }
-}
-
-impl From<UndeclaredIdentifier> for Diagnostic {
-    fn from(d: UndeclaredIdentifier) -> Diagnostic {
-        Diagnostic::new(
-            Code::UndeclaredIdentifier,
-            format!("use of undeclared identifier '{}'", d.name),
-        )
-        .with_label(d.span, "not declared in this scope")
-        .with_help(format!("declare '{}' with a type before using it", d.name))
-    }
-}
-
-/// `E0900`: valid C that the code generator does not lower yet.
-pub struct UnsupportedConstruct {
-    pub span: Span,
-    pub what: String,
-}
-
-impl UnsupportedConstruct {
-    pub fn new(span: Span, what: impl Into<String>) -> Self {
-        UnsupportedConstruct {
-            span,
-            what: what.into(),
-        }
-    }
-}
-
-impl From<UnsupportedConstruct> for Diagnostic {
-    fn from(d: UnsupportedConstruct) -> Diagnostic {
-        Diagnostic::new(
-            Code::UnsupportedConstruct,
-            format!("codegen not yet implemented for {}", d.what),
-        )
-        .with_label(d.span, "not supported by codegen yet")
-    }
-}
-
-/// `E0901`: code generation reached a translation unit with no functions.
-pub struct EmptyTranslationUnit;
-
-impl From<EmptyTranslationUnit> for Diagnostic {
-    fn from(_: EmptyTranslationUnit) -> Diagnostic {
-        Diagnostic::new(
-            Code::EmptyTranslationUnit,
-            "translation unit contains no functions",
-        )
-    }
-}
-
-/// `E0300`: an active `#error` directive.
-pub struct PreprocError {
-    pub span: Span,
-    /// The directive's text (empty for a bare `#error`).
-    pub text: String,
-}
-
-impl PreprocError {
-    pub fn new(span: Span, text: impl Into<String>) -> Self {
-        PreprocError {
-            span,
-            text: text.into(),
-        }
-    }
-}
-
-impl From<PreprocError> for Diagnostic {
-    fn from(d: PreprocError) -> Diagnostic {
-        let message = if d.text.is_empty() {
-            Code::PreprocError.title().to_string()
-        } else {
-            d.text
-        };
-        Diagnostic::new(Code::PreprocError, message)
-            .with_label(d.span, "#error directive encountered")
-    }
-}
-
-/// `W0300`: an active `#warning` directive.
-pub struct PreprocWarning {
-    pub span: Span,
-    pub text: String,
-}
-
-impl PreprocWarning {
-    pub fn new(span: Span, text: impl Into<String>) -> Self {
-        PreprocWarning {
-            span,
-            text: text.into(),
-        }
-    }
-}
-
-impl From<PreprocWarning> for Diagnostic {
-    fn from(d: PreprocWarning) -> Diagnostic {
-        let message = if d.text.is_empty() {
-            Code::PreprocWarning.title().to_string()
-        } else {
-            d.text
-        };
-        Diagnostic::new(Code::PreprocWarning, message)
-            .with_label(d.span, "#warning directive encountered")
-    }
-}
-
 /// The body of `fcc --explain <CODE>`: the title line followed by the long-form
 /// explanation and, where it exists, the standard reference.
 pub fn explain(code: &str) -> Option<String> {
@@ -551,20 +447,10 @@ mod tests {
         String::from_utf8(buf).unwrap()
     }
 
-    const CODES: [Code; 7] = [
-        Code::UnexpectedToken,
-        Code::UnexpectedEof,
-        Code::UndeclaredIdentifier,
-        Code::PreprocError,
-        Code::PreprocWarning,
-        Code::UnsupportedConstruct,
-        Code::EmptyTranslationUnit,
-    ];
-
     #[test]
     fn codes_round_trip_and_are_unique() {
         let mut seen = Vec::new();
-        for code in CODES {
+        for &code in Code::ALL {
             assert_eq!(Code::from_code(code.as_str()), Some(code));
             assert!(!seen.contains(&code.as_str()), "duplicate code string");
             seen.push(code.as_str());
@@ -575,7 +461,7 @@ mod tests {
 
     #[test]
     fn severity_follows_code_prefix() {
-        for code in CODES {
+        for &code in Code::ALL {
             let expected = if code.as_str().starts_with('W') {
                 Severity::Warning
             } else {
@@ -611,7 +497,7 @@ mod tests {
 
     #[test]
     fn spanless_diagnostic_renders_compact_header() {
-        let out = render(EmptyTranslationUnit.into());
+        let out = render(EmptyTranslationUnit::new().into());
         assert!(out.starts_with("error[E0901]:"), "{out}");
         assert!(out.contains("no functions"), "{out}");
     }

--- a/fcc/src/diagnostics.rs
+++ b/fcc/src/diagnostics.rs
@@ -404,12 +404,16 @@ impl From<UnexpectedEof> for Diagnostic {
 
 /// `E0200`: a name is used without any declaration in scope.
 pub struct UndeclaredIdentifier {
+    pub span: Span,
     pub name: String,
 }
 
 impl UndeclaredIdentifier {
-    pub fn new(name: impl Into<String>) -> Self {
-        UndeclaredIdentifier { name: name.into() }
+    pub fn new(span: Span, name: impl Into<String>) -> Self {
+        UndeclaredIdentifier {
+            span,
+            name: name.into(),
+        }
     }
 }
 
@@ -419,18 +423,23 @@ impl From<UndeclaredIdentifier> for Diagnostic {
             Code::UndeclaredIdentifier,
             format!("use of undeclared identifier '{}'", d.name),
         )
+        .with_label(d.span, "not declared in this scope")
         .with_help(format!("declare '{}' with a type before using it", d.name))
     }
 }
 
 /// `E0900`: valid C that the code generator does not lower yet.
 pub struct UnsupportedConstruct {
+    pub span: Span,
     pub what: String,
 }
 
 impl UnsupportedConstruct {
-    pub fn new(what: impl Into<String>) -> Self {
-        UnsupportedConstruct { what: what.into() }
+    pub fn new(span: Span, what: impl Into<String>) -> Self {
+        UnsupportedConstruct {
+            span,
+            what: what.into(),
+        }
     }
 }
 
@@ -440,6 +449,7 @@ impl From<UnsupportedConstruct> for Diagnostic {
             Code::UnsupportedConstruct,
             format!("codegen not yet implemented for {}", d.what),
         )
+        .with_label(d.span, "not supported by codegen yet")
     }
 }
 
@@ -601,11 +611,21 @@ mod tests {
 
     #[test]
     fn spanless_diagnostic_renders_compact_header() {
-        let out = render(UndeclaredIdentifier::new("count").into());
-        assert!(out.starts_with("error[E0200]:"), "{out}");
-        assert!(out.contains("undeclared identifier 'count'"), "{out}");
-        assert!(out.contains("= help:"), "{out}");
-        assert!(out.contains("= note:"), "{out}");
+        let out = render(EmptyTranslationUnit.into());
+        assert!(out.starts_with("error[E0901]:"), "{out}");
+        assert!(out.contains("no functions"), "{out}");
+    }
+
+    #[test]
+    fn undeclared_identifier_points_at_its_span() {
+        let src = "int main(void) { return x; }";
+        let file = intern_file("<undeclared-test>", src);
+        let at = src.find('x').unwrap();
+        let out = render(UndeclaredIdentifier::new(Span::new(file, at), "x").into());
+        assert!(out.contains("[E0200]"), "{out}");
+        assert!(out.contains("undeclared identifier 'x'"), "{out}");
+        assert!(out.contains("not declared in this scope"), "{out}");
+        assert!(out.contains("Help"), "{out}");
     }
 
     #[test]

--- a/fcc/src/driver.rs
+++ b/fcc/src/driver.rs
@@ -12,8 +12,11 @@ use crate::preprocessor::preprocessed;
 #[derive(Debug, Parser)]
 #[command(name = "fcc")]
 pub struct Cli {
+    /// Print a detailed explanation of a diagnostic code, e.g. `--explain E0001`.
+    #[arg(long, value_name = "CODE")]
+    explain: Option<String>,
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -75,8 +78,24 @@ pub enum CompileStage {
 
 pub fn compiler_main() {
     let cli = Cli::parse();
+
+    if let Some(code) = cli.explain {
+        match crate::diagnostics::explain(&code) {
+            Some(text) => print!("{text}"),
+            None => {
+                eprintln!("fcc: unknown diagnostic code '{code}'");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
     match cli.command {
-        Commands::Compile(args) => run_compile(args),
+        Some(Commands::Compile(args)) => run_compile(args),
+        None => {
+            eprintln!("fcc: no subcommand given; try `fcc compile` or `fcc --explain <CODE>`");
+            std::process::exit(1);
+        }
     }
 }
 
@@ -95,33 +114,27 @@ fn run_compile(args: CompileArgs) {
     };
 
     for input in &args.inputs {
-        let reader: Box<dyn io::Read> = if input == "-" {
-            Box::new(io::stdin())
-        } else {
-            Box::new(File::open(input).unwrap_or_else(|e| {
-                eprintln!("fcc: cannot open input '{}': {e}", input.to_string_lossy());
-                std::process::exit(1);
-            }))
-        };
+        let (name, source) = read_input(input);
 
         match args.stage {
             CompileStage::Preprocess => {
-                emit_preprocess(
-                    &mut out,
-                    preprocessed(reader, build_defines(&args.defines), &[]),
-                );
+                for (tok, _) in preprocess(&name, &source, build_defines(&args.defines)) {
+                    write!(out, "{tok}").unwrap();
+                }
             }
             CompileStage::Tokens => {
-                let tokens: Vec<Token> =
-                    preprocessed(reader, build_defines(&args.defines), &[]).collect();
+                let tokens: Vec<Token> = preprocess(&name, &source, build_defines(&args.defines))
+                    .into_iter()
+                    .map(|(tok, _)| tok)
+                    .collect();
                 writeln!(out, "{tokens:#?}").unwrap();
             }
             CompileStage::Ast => {
-                let unit = parse_source(reader);
+                let unit = parse_source(&name, &source);
                 write!(out, "{}", crate::ast::render(&unit)).unwrap();
             }
             CompileStage::Ir => {
-                let unit = parse_source(reader);
+                let unit = parse_source(&name, &source);
                 let context = tir::Context::with_default_dialects();
                 let module = lower_to_ir(&context, &unit);
                 let mut ir = String::new();
@@ -134,23 +147,38 @@ fn run_compile(args: CompileArgs) {
                 write!(out, "{ir}").unwrap();
             }
             CompileStage::Asm | CompileStage::Obj => {
-                let bytes = emit_machine_code(&args, reader);
+                let bytes = emit_machine_code(&args, &name, &source);
                 out.write_all(&bytes).unwrap();
             }
         }
     }
 }
 
+/// Read an input into its `(display name, source text)` pair. `-` reads stdin.
+fn read_input(input: &OsString) -> (String, String) {
+    if input == "-" {
+        let mut source = String::new();
+        io::Read::read_to_string(&mut io::stdin(), &mut source).unwrap_or_default();
+        ("<stdin>".to_string(), source)
+    } else {
+        let source = std::fs::read_to_string(input).unwrap_or_else(|e| {
+            eprintln!("fcc: cannot open input '{}': {e}", input.to_string_lossy());
+            std::process::exit(1);
+        });
+        (input.to_string_lossy().into_owned(), source)
+    }
+}
+
 fn lower_to_ir(context: &tir::Context, unit: &crate::ast::Ast) -> tir::builtin::ModuleOp {
-    crate::codegen::codegen(context, unit).unwrap_or_else(|e| {
-        eprintln!("fcc: codegen error: {e}");
+    crate::codegen::codegen(context, unit).unwrap_or_else(|d| {
+        d.eprint();
         std::process::exit(1);
     })
 }
 
 /// Run the backend pipeline (mem2reg, instruction selection, register
 /// allocation, finalization) and render assembly or an ELF object.
-fn emit_machine_code(args: &CompileArgs, reader: Box<dyn io::Read>) -> Vec<u8> {
+fn emit_machine_code(args: &CompileArgs, name: &str, source: &str) -> Vec<u8> {
     use tir::Operation;
     use tir_be_common::pipeline::{StopAfter, build_pipeline};
 
@@ -163,7 +191,7 @@ fn emit_machine_code(args: &CompileArgs, reader: Box<dyn io::Read>) -> Vec<u8> {
         std::process::exit(1);
     });
 
-    let unit = parse_source(reader);
+    let unit = parse_source(name, source);
     let context = tir::Context::with_default_dialects();
     target.register_dialects(&context);
     let module = lower_to_ir(&context, &unit);
@@ -208,18 +236,32 @@ fn emit_machine_code(args: &CompileArgs, reader: Box<dyn io::Read>) -> Vec<u8> {
     tir_be_common::binary::write_elf(&object, &format)
 }
 
-fn parse_source(reader: Box<dyn io::Read>) -> crate::ast::Ast {
-    let tokens: Vec<Token> = preprocessed(reader, HashMap::new(), &[]).collect();
-    crate::parser::parse(&tokens).unwrap_or_else(|errors| {
-        for e in errors {
-            eprintln!("fcc: parse error: {e}");
+/// Preprocess `source`, reporting any `#error`/`#warning` diagnostics. Exits if
+/// any of them is an error.
+fn preprocess(
+    name: &str,
+    source: &str,
+    defines: HashMap<String, Token>,
+) -> Vec<(Token, crate::diagnostics::Span)> {
+    let mut stream = preprocessed(name, source, defines, &[]);
+    let tokens = stream.collect_tokens();
+    let mut had_error = false;
+    for diag in stream.diagnostics() {
+        diag.eprint();
+        had_error |= diag.is_error();
+    }
+    if had_error {
+        std::process::exit(1);
+    }
+    tokens
+}
+
+fn parse_source(name: &str, source: &str) -> crate::ast::Ast {
+    let tokens = preprocess(name, source, HashMap::new());
+    crate::parser::parse(&tokens).unwrap_or_else(|diags| {
+        for diag in &diags {
+            diag.eprint();
         }
         std::process::exit(1);
     })
-}
-
-fn emit_preprocess(out: &mut dyn Write, tokens: impl Iterator<Item = Token>) {
-    for tok in tokens {
-        write!(out, "{tok}").unwrap();
-    }
 }

--- a/fcc/src/lib.rs
+++ b/fcc/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod codegen;
+pub mod diagnostics;
 pub mod driver;
 pub mod lexer;
 pub mod parser;

--- a/fcc/src/parser.rs
+++ b/fcc/src/parser.rs
@@ -19,6 +19,7 @@ use chumsky::prelude::*;
 use tir::graph::{MutDag, NodeId};
 
 use crate::ast::*;
+use crate::diagnostics::{Diagnostic, UnexpectedEof, UnexpectedToken};
 use crate::lexer::Token;
 
 /// Index-based span over the token slice (we parse already-lexed tokens, so
@@ -26,14 +27,18 @@ use crate::lexer::Token;
 type Span = SimpleSpan<usize>;
 type Extra<'src> = extra::Full<Rich<'src, Token, Span>, SimpleState<Ast>, ()>;
 
-/// Parse a token stream into a translation unit. Whitespace tokens are dropped
-/// first; on failure the collected diagnostics are returned as strings.
-pub fn parse(tokens: &[Token]) -> Result<Ast, Vec<String>> {
-    let filtered: Vec<Token> = tokens
-        .iter()
-        .filter(|t| !matches!(t, Token::Whitespace(_)))
-        .cloned()
-        .collect();
+/// Parse a stream of tokens, each paired with its byte [`crate::diagnostics::Span`]
+/// in the source. Whitespace tokens are dropped first; on failure each parser
+/// error is turned into a [`Diagnostic`] whose label points back at the source.
+pub fn parse(tokens: &[(Token, crate::diagnostics::Span)]) -> Result<Ast, Vec<Diagnostic>> {
+    let mut filtered = Vec::with_capacity(tokens.len());
+    let mut byte_spans = Vec::with_capacity(tokens.len());
+    for (tok, span) in tokens {
+        if !matches!(tok, Token::Whitespace(_)) {
+            filtered.push(tok.clone());
+            byte_spans.push(*span);
+        }
+    }
 
     let mut state = SimpleState(Ast::new());
     let (out, errors) = translation_unit()
@@ -42,7 +47,35 @@ pub fn parse(tokens: &[Token]) -> Result<Ast, Vec<String>> {
 
     match out {
         Some(_) if errors.is_empty() => Ok(state.0),
-        _ => Err(errors.into_iter().map(|e| e.to_string()).collect()),
+        _ => Err(errors
+            .into_iter()
+            .map(|e| rich_to_diagnostic(&e, &byte_spans))
+            .collect()),
+    }
+}
+
+/// Convert a chumsky [`Rich`] error (spanned over token indices) into a
+/// [`Diagnostic`] spanned at the offending token's source position. An error
+/// past the final token (`found` is `None`) is reported at the last token.
+fn rich_to_diagnostic(
+    err: &Rich<'_, Token, Span>,
+    byte_spans: &[crate::diagnostics::Span],
+) -> Diagnostic {
+    let index = err.span().into_range().start;
+    let span = byte_spans
+        .get(index)
+        .or_else(|| byte_spans.last())
+        .copied()
+        .unwrap_or(crate::diagnostics::Span::new(
+            crate::diagnostics::FileId::default(),
+            0,
+        ));
+    let reason = err.reason().to_string();
+
+    if err.found().is_none() {
+        UnexpectedEof::new(span, reason).into()
+    } else {
+        UnexpectedToken::new(span, reason).into()
     }
 }
 
@@ -458,4 +491,46 @@ where
             }
             id
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use logos::Logos;
+
+    use super::parse;
+    use crate::diagnostics::{Code, Span as ByteSpan, intern_file};
+    use crate::lexer::Token;
+
+    fn lex(src: &str) -> Vec<(Token, ByteSpan)> {
+        let file = intern_file("<parser-test>", src);
+        Token::lexer(src)
+            .spanned()
+            .map(|(r, span)| (r.unwrap(), ByteSpan::new(file, span.start)))
+            .collect()
+    }
+
+    #[test]
+    fn accepts_a_well_formed_function() {
+        assert!(parse(&lex("int main(void) { return 0; }")).is_ok());
+    }
+
+    fn errors(src: &str) -> Vec<Code> {
+        match parse(&lex(src)) {
+            Ok(_) => panic!("expected parse to fail for {src:?}"),
+            Err(diags) => diags.iter().map(|d| d.code()).collect(),
+        }
+    }
+
+    #[test]
+    fn missing_semicolon_is_unexpected_token() {
+        assert_eq!(
+            errors("int main(void) { return 0 }"),
+            vec![Code::UnexpectedToken]
+        );
+    }
+
+    #[test]
+    fn missing_closing_brace_is_unexpected_eof() {
+        assert!(errors("int main(void) { return 0;").contains(&Code::UnexpectedEof));
+    }
 }

--- a/fcc/src/parser.rs
+++ b/fcc/src/parser.rs
@@ -19,13 +19,33 @@ use chumsky::prelude::*;
 use tir::graph::{MutDag, NodeId};
 
 use crate::ast::*;
-use crate::diagnostics::{Diagnostic, UnexpectedEof, UnexpectedToken};
+use crate::diagnostics::{Diagnostic, FileId, UnexpectedEof, UnexpectedToken};
 use crate::lexer::Token;
 
 /// Index-based span over the token slice (we parse already-lexed tokens, so
 /// byte offsets are not available — token indices are the natural span).
 type Span = SimpleSpan<usize>;
-type Extra<'src> = extra::Full<Rich<'src, Token, Span>, SimpleState<Ast>, ()>;
+type Extra<'src> = extra::Full<Rich<'src, Token, Span>, SimpleState<ParseState>, ()>;
+
+/// Parser state: the tree under construction plus the byte span of every input
+/// token, so each node can record where its construct starts in the source.
+struct ParseState {
+    ast: Ast,
+    spans: Vec<crate::diagnostics::Span>,
+}
+
+impl ParseState {
+    /// Append a node, spanning it at the byte position of token index `tok`
+    /// (the first token of the construct being reduced).
+    fn add(&mut self, kind: AstKind, tok: usize) -> NodeId {
+        let span = self
+            .spans
+            .get(tok)
+            .copied()
+            .unwrap_or(crate::diagnostics::Span::new(FileId::default(), 0));
+        self.ast.add_node(AstNode::new(kind, span))
+    }
+}
 
 /// Parse a stream of tokens, each paired with its byte [`crate::diagnostics::Span`]
 /// in the source. Whitespace tokens are dropped first; on failure each parser
@@ -40,13 +60,16 @@ pub fn parse(tokens: &[(Token, crate::diagnostics::Span)]) -> Result<Ast, Vec<Di
         }
     }
 
-    let mut state = SimpleState(Ast::new());
+    let mut state = SimpleState(ParseState {
+        ast: Ast::new(),
+        spans: byte_spans.clone(),
+    });
     let (out, errors) = translation_unit()
         .parse_with_state(filtered.as_slice(), &mut state)
         .into_output_errors();
 
     match out {
-        Some(_) if errors.is_empty() => Ok(state.0),
+        Some(_) if errors.is_empty() => Ok(state.0.ast),
         _ => Err(errors
             .into_iter()
             .map(|e| rich_to_diagnostic(&e, &byte_spans))
@@ -103,9 +126,10 @@ where
     recursive(|expr| {
         let literal = select! { Token::IntegerLiteral(n) => n.to_i64() }.map_with(
             |n, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::Int);
-                ast.set_leaf_data(id, AstLeaf::Int(n));
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Int, tok);
+                st.ast.set_leaf_data(id, AstLeaf::Int(n));
                 id
             },
         );
@@ -120,19 +144,21 @@ where
                     .delimited_by(just(Token::LParen), just(Token::RParen)),
             )
             .map_with(|(name, args), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::Call);
-                ast.set_leaf_data(id, AstLeaf::Call(name));
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Call, tok);
+                st.ast.set_leaf_data(id, AstLeaf::Call(name));
                 for arg in args {
-                    ast.add_edge(id, arg);
+                    st.ast.add_edge(id, arg);
                 }
                 id
             });
 
         let var = ident().map_with(|name, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::Var);
-            ast.set_leaf_data(id, AstLeaf::Var(name));
+            let tok = e.span().start;
+            let st = &mut e.state().0;
+            let id = st.add(AstKind::Var, tok);
+            st.ast.set_leaf_data(id, AstLeaf::Var(name));
             id
         });
 
@@ -154,10 +180,11 @@ where
         .then(primary)
         .map_with(
             |(ops, operand), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
+                let tok = e.span().start;
+                let st = &mut e.state().0;
                 ops.into_iter()
                     .rev()
-                    .fold(operand, |child, op| unary(ast, op, child))
+                    .fold(operand, |child, op| unary(st, op, child, tok))
             },
         );
 
@@ -217,23 +244,24 @@ where
         )
         .map_with(
             |(first, rest), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
+                let tok = e.span().start;
+                let st = &mut e.state().0;
                 rest.into_iter()
-                    .fold(first, |lhs, (op, rhs)| binary(ast, op, lhs, rhs))
+                    .fold(first, |lhs, (op, rhs)| binary(st, op, lhs, rhs, tok))
             },
         )
 }
 
-fn binary(ast: &mut Ast, op: AstKind, lhs: NodeId, rhs: NodeId) -> NodeId {
-    let id = ast.add_node(op);
-    ast.add_edge(id, lhs);
-    ast.add_edge(id, rhs);
+fn binary(st: &mut ParseState, op: AstKind, lhs: NodeId, rhs: NodeId, tok: usize) -> NodeId {
+    let id = st.add(op, tok);
+    st.ast.add_edge(id, lhs);
+    st.ast.add_edge(id, rhs);
     id
 }
 
-fn unary(ast: &mut Ast, op: AstKind, operand: NodeId) -> NodeId {
-    let id = ast.add_node(op);
-    ast.add_edge(id, operand);
+fn unary(st: &mut ParseState, op: AstKind, operand: NodeId, tok: usize) -> NodeId {
+    let id = st.add(op, tok);
+    st.ast.add_edge(id, operand);
     id
 }
 
@@ -246,15 +274,18 @@ where
     ctype()
         .then(ident())
         .then(just(Token::Assign).ignore_then(expr()).or_not())
-        .map_with(|((ty, name), init), e| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::Decl);
-            ast.set_leaf_data(id, AstLeaf::Decl { name, ty });
-            if let Some(init) = init {
-                ast.add_edge(id, init);
-            }
-            id
-        })
+        .map_with(
+            |((ty, name), init), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Decl, tok);
+                st.ast.set_leaf_data(id, AstLeaf::Decl { name, ty });
+                if let Some(init) = init {
+                    st.ast.add_edge(id, init);
+                }
+                id
+            },
+        )
 }
 
 /// Build an `x = value` assignment node (without the trailing `;`).
@@ -265,20 +296,24 @@ where
     ident()
         .then_ignore(just(Token::Assign))
         .then(expr())
-        .map_with(|(name, value), e| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::Assign);
-            ast.set_leaf_data(id, AstLeaf::Assign(name));
-            ast.add_edge(id, value);
-            id
-        })
+        .map_with(
+            |(name, value), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Assign, tok);
+                st.ast.set_leaf_data(id, AstLeaf::Assign(name));
+                st.ast.add_edge(id, value);
+                id
+            },
+        )
 }
 
 fn empty_node<'src, I>(e: &mut MapExtra<'src, '_, I, Extra<'src>>) -> NodeId
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
-    e.state().0.add_node(AstKind::Empty)
+    let tok = e.span().start;
+    e.state().0.add(AstKind::Empty, tok)
 }
 
 fn stmt<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
@@ -294,10 +329,11 @@ where
             .collect::<Vec<NodeId>>()
             .delimited_by(just(Token::LBrace), just(Token::RBrace))
             .map_with(|stmts, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::Block);
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Block, tok);
                 for s in stmts {
-                    ast.add_edge(id, s);
+                    st.ast.add_edge(id, s);
                 }
                 id
             });
@@ -306,10 +342,11 @@ where
             .ignore_then(expr().or_not())
             .then_ignore(semi.clone())
             .map_with(|value, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::Return);
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Return, tok);
                 if let Some(value) = value {
-                    ast.add_edge(id, value);
+                    st.ast.add_edge(id, value);
                 }
                 id
             });
@@ -325,12 +362,13 @@ where
             .then(just(Token::KwElse).ignore_then(stmt.clone()).or_not())
             .map_with(
                 |((c, then), els), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                    let ast: &mut Ast = &mut e.state().0;
-                    let id = ast.add_node(AstKind::If);
-                    ast.add_edge(id, c);
-                    ast.add_edge(id, then);
+                    let tok = e.span().start;
+                    let st = &mut e.state().0;
+                    let id = st.add(AstKind::If, tok);
+                    st.ast.add_edge(id, c);
+                    st.ast.add_edge(id, then);
                     if let Some(els) = els {
-                        ast.add_edge(id, els);
+                        st.ast.add_edge(id, els);
                     }
                     id
                 },
@@ -340,10 +378,11 @@ where
             .ignore_then(cond.clone())
             .then(stmt.clone())
             .map_with(|(c, body), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::While);
-                ast.add_edge(id, c);
-                ast.add_edge(id, body);
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::While, tok);
+                st.ast.add_edge(id, c);
+                st.ast.add_edge(id, body);
                 id
             });
 
@@ -353,10 +392,11 @@ where
             .then(cond.clone())
             .then_ignore(semi.clone())
             .map_with(|(body, c), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::DoWhile);
-                ast.add_edge(id, body);
-                ast.add_edge(id, c);
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::DoWhile, tok);
+                st.ast.add_edge(id, body);
+                st.ast.add_edge(id, c);
                 id
             });
 
@@ -384,34 +424,43 @@ where
             .then(stmt.clone())
             .map_with(
                 |(((init, c), step), body), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                    let ast: &mut Ast = &mut e.state().0;
-                    let id = ast.add_node(AstKind::For);
-                    ast.add_edge(id, init);
-                    ast.add_edge(id, c);
-                    ast.add_edge(id, step);
-                    ast.add_edge(id, body);
+                    let tok = e.span().start;
+                    let st = &mut e.state().0;
+                    let id = st.add(AstKind::For, tok);
+                    st.ast.add_edge(id, init);
+                    st.ast.add_edge(id, c);
+                    st.ast.add_edge(id, step);
+                    st.ast.add_edge(id, body);
                     id
                 },
             );
 
         let break_stmt = just(Token::KwBreak).then_ignore(semi.clone()).map_with(
-            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| e.state().0.add_node(AstKind::Break),
+            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let tok = e.span().start;
+                e.state().0.add(AstKind::Break, tok)
+            },
         );
         let continue_stmt = just(Token::KwContinue).then_ignore(semi.clone()).map_with(
-            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| e.state().0.add_node(AstKind::Continue),
+            |_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let tok = e.span().start;
+                e.state().0.add(AstKind::Continue, tok)
+            },
         );
 
         let null_stmt = semi
             .clone()
             .map_with(|_, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                e.state().0.add_node(AstKind::Empty)
+                let tok = e.span().start;
+                e.state().0.add(AstKind::Empty, tok)
             });
 
         let expr_stmt = expr().then_ignore(semi).map_with(
             |value, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
-                let ast: &mut Ast = &mut e.state().0;
-                let id = ast.add_node(AstKind::ExprStmt);
-                ast.add_edge(id, value);
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::ExprStmt, tok);
+                st.ast.add_edge(id, value);
                 id
             },
         );
@@ -441,12 +490,16 @@ fn function<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>> + Clone
 where
     I: ValueInput<'src, Token = Token, Span = Span>,
 {
-    let param = ctype().then(ident()).map_with(|(ty, name), e| {
-        let ast: &mut Ast = &mut e.state().0;
-        let id = ast.add_node(AstKind::Param);
-        ast.set_leaf_data(id, AstLeaf::Param { name, ty });
-        id
-    });
+    let param =
+        ctype()
+            .then(ident())
+            .map_with(|(ty, name), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+                let tok = e.span().start;
+                let st = &mut e.state().0;
+                let id = st.add(AstKind::Param, tok);
+                st.ast.set_leaf_data(id, AstLeaf::Param { name, ty });
+                id
+            });
 
     // `(void)` is an explicit empty parameter list; `()` is also accepted.
     let params = choice((
@@ -460,19 +513,18 @@ where
         .collect::<Vec<_>>()
         .delimited_by(just(Token::LBrace), just(Token::RBrace));
 
-    ctype()
-        .then(ident())
-        .then(params)
-        .then(body)
-        .map_with(|(((ret, name), params), body), e| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::Function);
-            ast.set_leaf_data(id, AstLeaf::Function { name, ret });
+    ctype().then(ident()).then(params).then(body).map_with(
+        |(((ret, name), params), body), e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+            let tok = e.span().start;
+            let st = &mut e.state().0;
+            let id = st.add(AstKind::Function, tok);
+            st.ast.set_leaf_data(id, AstLeaf::Function { name, ret });
             for child in params.into_iter().chain(body) {
-                ast.add_edge(id, child);
+                st.ast.add_edge(id, child);
             }
             id
-        })
+        },
+    )
 }
 
 fn translation_unit<'src, I>() -> impl Parser<'src, I, NodeId, Extra<'src>>
@@ -483,11 +535,12 @@ where
         .repeated()
         .collect::<Vec<_>>()
         .then_ignore(end())
-        .map_with(|functions, e| {
-            let ast: &mut Ast = &mut e.state().0;
-            let id = ast.add_node(AstKind::TranslationUnit);
+        .map_with(|functions, e: &mut MapExtra<'src, '_, I, Extra<'src>>| {
+            let tok = e.span().start;
+            let st = &mut e.state().0;
+            let id = st.add(AstKind::TranslationUnit, tok);
             for func in functions {
-                ast.add_edge(id, func);
+                st.ast.add_edge(id, func);
             }
             id
         })

--- a/fcc/src/preprocessor.rs
+++ b/fcc/src/preprocessor.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
-use std::io::Read;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use logos::{Lexer, Logos};
 
+use crate::diagnostics::{
+    Diagnostic, FileId, PreprocError, PreprocWarning, Span, file_source, intern_file,
+};
 use crate::lexer::Token;
 
 // ---------------------------------------------------------------------------
@@ -442,9 +444,18 @@ fn is_skipping(stack: &[CondState]) -> bool {
 /// only `Rc<str>` + `usize` offset and reconstructing a short-lived lexer on
 /// each call to `next()`.  Lexer initialisation is O(1) (pointer + state
 /// setup), so this is negligible.
+/// One source being lexed. Included files push new frames; the bottom frame is
+/// the primary translation unit. Each frame knows its interned [`FileId`], so a
+/// token's span points into the file it actually came from.
+struct Frame {
+    source: Arc<str>,
+    offset: usize,
+    file: FileId,
+}
+
 pub struct TokenStream {
-    /// Stack of (owned source, current byte offset).  Top = active frame.
-    source_stack: Vec<(Rc<str>, usize)>,
+    /// Stack of source frames.  Top = active frame.
+    frames: Vec<Frame>,
     /// Maps macro names to their single-token replacement value.
     ///
     /// `Token::Hash` is used as a sentinel meaning "defined but no replacement
@@ -453,6 +464,7 @@ pub struct TokenStream {
     defines: HashMap<String, Token>,
     include_paths: Vec<PathBuf>,
     cond_stack: Vec<CondState>,
+    diagnostics: Vec<Diagnostic>,
 }
 
 impl TokenStream {
@@ -466,12 +478,22 @@ impl TokenStream {
             Some(i) => source_len - remainder.len() + i + 1,
             None => source_len,
         };
-        if let Some(frame) = self.source_stack.last_mut() {
-            frame.1 = new_offset;
+        if let Some(frame) = self.frames.last_mut() {
+            frame.offset = new_offset;
         }
     }
 
-    fn process_directive(&mut self, source: &str, mut pp: Lexer<'_, PreprocToken>) {
+    /// The currently active file, for spanning directives.
+    fn current_file(&self) -> FileId {
+        self.frames.last().unwrap().file
+    }
+
+    fn process_directive(
+        &mut self,
+        source: &str,
+        directive_start: usize,
+        mut pp: Lexer<'_, PreprocToken>,
+    ) {
         let skipping = is_skipping(&self.cond_stack);
 
         match pp.next() {
@@ -523,7 +545,12 @@ impl TokenStream {
                     .iter()
                     .find_map(|dir| std::fs::read_to_string(dir.join(&path)).ok());
                 if let Some(content) = content {
-                    self.source_stack.push((Rc::from(content.as_str()), 0));
+                    let file = intern_file(&path, &content);
+                    self.frames.push(Frame {
+                        source: file_source(file),
+                        offset: 0,
+                        file,
+                    });
                 }
             }
 
@@ -652,68 +679,89 @@ impl TokenStream {
                 self.skip_line(source.len(), pp.remainder());
             }
 
+            Some(Ok(directive @ (PreprocToken::Error | PreprocToken::Warning))) if !skipping => {
+                let remainder = pp.remainder();
+                let line_end = remainder.find('\n').unwrap_or(remainder.len());
+                let text = remainder[..line_end].trim().to_string();
+                let span = Span::new(self.current_file(), directive_start);
+                let diag: Diagnostic = if directive == PreprocToken::Error {
+                    PreprocError::new(span, text).into()
+                } else {
+                    PreprocWarning::new(span, text).into()
+                };
+                self.diagnostics.push(diag);
+                self.skip_line(source.len(), remainder);
+            }
+
             _ => self.skip_line(source.len(), pp.remainder()),
         }
     }
 }
 
 impl Iterator for TokenStream {
-    type Item = Token;
+    type Item = (Token, Span);
 
-    fn next(&mut self) -> Option<Token> {
+    fn next(&mut self) -> Option<(Token, Span)> {
         loop {
             // Drop exhausted frames.
-            while self.source_stack.last().is_some_and(|(s, o)| *o >= s.len()) {
-                self.source_stack.pop();
+            while self
+                .frames
+                .last()
+                .is_some_and(|f| f.offset >= f.source.len())
+            {
+                self.frames.pop();
             }
 
-            // Clone Rc (cheap) + copy offset so we release the shared borrow
-            // on source_stack before taking &mut self below.
-            let (source_rc, offset) = {
-                let top = self.source_stack.last()?;
-                (Rc::clone(&top.0), top.1)
+            // Clone Arc (cheap) + copy offset/file so we release the shared
+            // borrow on frames before taking &mut self below.
+            let (source_rc, offset, file) = {
+                let top = self.frames.last()?;
+                (Arc::clone(&top.source), top.offset, top.file)
             };
+
+            // Every emitted token is spanned at its start position in its file.
+            let span = Span::new(file, offset);
 
             let mut lexer = Token::lexer(&source_rc[offset..]);
             let tok = lexer.next();
 
             match tok {
                 None => {
-                    self.source_stack.pop();
+                    self.frames.pop();
                 }
 
                 Some(Err(_)) => {
                     // Unrecognised character — skip it.
                     let new = source_rc.len() - lexer.remainder().len();
-                    self.source_stack.last_mut().unwrap().1 = new;
+                    self.frames.last_mut().unwrap().offset = new;
                 }
 
                 Some(Ok(Token::Hash)) => {
                     // morph hands the same source position to the directive lexer.
                     let pp = lexer.morph::<PreprocToken>();
-                    self.process_directive(&source_rc, pp);
+                    self.process_directive(&source_rc, offset, pp);
                     // process_directive always calls skip_line, which sets the offset.
                 }
 
                 Some(Ok(Token::Identifier(name))) => {
                     let new = source_rc.len() - lexer.remainder().len();
-                    self.source_stack.last_mut().unwrap().1 = new;
+                    self.frames.last_mut().unwrap().offset = new;
                     if !is_skipping(&self.cond_stack) {
                         match self.defines.get(&name).cloned() {
                             Some(Token::Hash) => {
                                 // Empty define — expands to nothing; continue.
                             }
-                            Some(tok) => return Some(tok),
-                            None => return Some(Token::Identifier(name)),
+                            Some(tok) => return Some((tok, span)),
+                            None => return Some((Token::Identifier(name), span)),
                         }
                     }
                 }
 
                 Some(Ok(c_tok)) => {
                     let new = source_rc.len() - lexer.remainder().len();
-                    self.source_stack.last_mut().unwrap().1 = new;
+                    self.frames.last_mut().unwrap().offset = new;
                     if !is_skipping(&self.cond_stack) {
-                        return Some(c_tok);
+                        return Some((c_tok, span));
                     }
                 }
             }
@@ -725,22 +773,72 @@ impl Iterator for TokenStream {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Preprocess C source code and return a lazy iterator over C tokens.
+impl TokenStream {
+    /// Drain the stream into the full token list. Diagnostics raised during
+    /// preprocessing (`#error`, `#warning`) are available via [`Self::diagnostics`]
+    /// afterwards.
+    pub fn collect_tokens(&mut self) -> Vec<(Token, Span)> {
+        self.by_ref().collect()
+    }
+
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+}
+
+/// Build a lazy preprocessed token stream over a source file.
 ///
-/// * `reader`        — source to preprocess
+/// * `name`          — file name shown in diagnostics (e.g. a path or `<stdin>`)
+/// * `source`        — primary translation unit text
 /// * `defines`       — predefined macros (name → single-token replacement)
 /// * `include_paths` — directories searched for `#include` files
 pub fn preprocessed(
-    mut reader: impl Read,
+    name: &str,
+    source: &str,
     defines: HashMap<String, Token>,
     include_paths: &[PathBuf],
-) -> impl Iterator<Item = Token> {
-    let mut source = String::new();
-    reader.read_to_string(&mut source).unwrap_or_default();
+) -> TokenStream {
+    let file = intern_file(name, source);
     TokenStream {
-        source_stack: vec![(Rc::from(source.as_str()), 0)],
+        frames: vec![Frame {
+            source: file_source(file),
+            offset: 0,
+            file,
+        }],
         defines,
         include_paths: include_paths.to_vec(),
         cond_stack: Vec::new(),
+        diagnostics: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preprocessed;
+    use crate::diagnostics::Code;
+    use std::collections::HashMap;
+
+    fn diagnostics(source: &str) -> Vec<Code> {
+        let mut stream = preprocessed("<pp-test>", source, HashMap::new(), &[]);
+        stream.collect_tokens();
+        stream.diagnostics().iter().map(|d| d.code()).collect()
+    }
+
+    #[test]
+    fn error_directive_raises_an_error() {
+        let codes = diagnostics("#error broken\nint main(void){return 0;}\n");
+        assert_eq!(codes, vec![Code::PreprocError]);
+    }
+
+    #[test]
+    fn warning_directive_raises_a_warning() {
+        let codes = diagnostics("#warning heads up\nint main(void){return 0;}\n");
+        assert_eq!(codes, vec![Code::PreprocWarning]);
+    }
+
+    #[test]
+    fn skipped_error_directive_is_silent() {
+        let codes = diagnostics("#if 0\n#error never\n#endif\n");
+        assert!(codes.is_empty());
     }
 }


### PR DESCRIPTION
Add a diagnostic system for fcc inspired by rustc and the Microsoft C
compiler. Errors and warnings now render via ariadne with a stable code,
a source caret, a fix hint and a citation of the C standard.

- diagnostics: a `Diagnostic` base type plus concrete per-problem types
  (UnexpectedToken, UndeclaredIdentifier, PreprocError, ...) that convert
  into it via `Into`. One `Code` catalog holds each code's title,
  long-form explanation and standard reference.
- spans: a packed `u64` (interned file id + byte offset) threaded from the
  preprocessor through the parser, so a diagnostic in an `#include`d file
  resolves to that file's own text.
- preprocessor: implement `#error`/`#warning`, the warning path.
- codegen/parser: report through the catalog instead of bare strings.
- cli: `fcc --explain <CODE>` prints the long-form description.

Tested via lib unit tests (catalog, span packing, rendering, parser and
preprocessor behaviour); existing lit checks unaffected.