### PR TITLE
fix(lit): build tir-tools so lit suites self-build the tir binary

### DIFF
--- a/backends/arm64/tests/lit.rs
+++ b/backends/arm64/tests/lit.rs
@@ -4,7 +4,7 @@
 //! selection and register allocation through the `tir-mc` driver.
 
 fn main() {
-    let tir = tir_lit::cargo_test_bin("tir", "tir");
+    let tir = tir_lit::cargo_test_bin("tir-tools", "tir");
     let tir = tir.to_str().expect("tir path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir", tir)]);

--- a/backends/riscv/tests/lit.rs
+++ b/backends/riscv/tests/lit.rs
@@ -4,7 +4,7 @@
 //! selection and register allocation through the `tir-mc` driver.
 
 fn main() {
-    let tir = tir_lit::cargo_test_bin("tir", "tir");
+    let tir = tir_lit::cargo_test_bin("tir-tools", "tir");
     let tir = tir.to_str().expect("tir-mc path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir", tir)]);

--- a/backends/targets/tests/lit.rs
+++ b/backends/targets/tests/lit.rs
@@ -1,7 +1,7 @@
 //! LIT-style FileCheck tests for target selection through `tir-mc`.
 
 fn main() {
-    let tir = tir_lit::cargo_test_bin("tir", "tir");
+    let tir = tir_lit::cargo_test_bin("tir-tools", "tir");
     let tir = tir.to_str().expect("tir path must be valid UTF-8");
 
     tir_lit::harness_main(env!("CARGO_MANIFEST_DIR"), "checks", &[("tir", tir)]);

--- a/core/tests/lit.rs
+++ b/core/tests/lit.rs
@@ -1,7 +1,7 @@
 //! LIT-style FileCheck tests for core IR passes.
 
 fn main() {
-    let tir = tir_lit::cargo_test_bin("tir", "tir");
+    let tir = tir_lit::cargo_test_bin("tir-tools", "tir");
     let tir = tir
         .to_str()
         .expect("tir-opt wrapper path must be valid UTF-8");

--- a/fcc/tests/lit.rs
+++ b/fcc/tests/lit.rs
@@ -8,7 +8,7 @@
 //! hand.
 
 fn main() {
-    let tir = tir_lit::cargo_test_bin("tir", "tir");
+    let tir = tir_lit::cargo_test_bin("tir-tools", "tir");
     let tir = tir.to_str().expect("tir path must be valid UTF-8");
 
     tir_lit::harness_main(


### PR DESCRIPTION
The lit harnesses called cargo_test_bin("tir", "tir"), which runs
`cargo build -p tir`. The `tir` package is the library and produces no
binary; the `tir` binary is owned by the `tir-tools` package. The copy
step then only found the binary when a prior full `cargo build` had
happened to build it, so `cargo nextest r` (or `cargo test`) failed
standalone and only CI passed because it runs `cargo build` first.

Build `tir-tools`, the package that actually owns the binary, so the lit
suites are self-sufficient.