### PR TITLE
Support named and non-contiguous SSA values in IR parsing

### DIFF
--- a/core/src/dialects/builtin/call.rs
+++ b/core/src/dialects/builtin/call.rs
@@ -94,11 +94,15 @@ impl IndirectCallOp {
         context: &Context,
     ) -> Result<Box<dyn Operation>, (tir::parse::Span, Error)> {
         use tir::parse::common::Cursor;
-        let callee = parser
+        let callee_ref = parser
             .parse_value_ref()
-            .and_then(|name| name.parse::<u32>().ok())
-            .map(ValueId::from_number)
             .ok_or_else(|| (parser.span(), Error::ExpectedValueRef))?;
+        let callee = parser.resolve_value(callee_ref).ok_or_else(|| {
+            (
+                parser.span(),
+                Error::UnknownValueRef(callee_ref.to_string()),
+            )
+        })?;
         let args = parse_arg_list(parser, context)?;
         let ret_type = parse_ret_type(parser, context)?;
 
@@ -168,11 +172,12 @@ fn parse_arg_list(
         return Ok(args);
     }
     loop {
-        let arg = parser
+        let arg_ref = parser
             .parse_value_ref()
-            .and_then(|name| name.parse::<u32>().ok())
-            .map(ValueId::from_number)
             .ok_or_else(|| (parser.span(), Error::ExpectedValueRef))?;
+        let arg = parser
+            .resolve_value(arg_ref)
+            .ok_or_else(|| (parser.span(), Error::UnknownValueRef(arg_ref.to_string())))?;
         args.push(arg);
         if !parser.parse_token(",") {
             break;

--- a/core/src/dialects/builtin/control.rs
+++ b/core/src/dialects/builtin/control.rs
@@ -252,10 +252,9 @@ fn parse_value_id(
     let value_ref = parser
         .parse_value_ref()
         .ok_or_else(|| (parser.span(), Error::ExpectedValueRef))?;
-    let id = value_ref
-        .parse::<u32>()
-        .map_err(|_| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))?;
-    Ok(ValueId::from_number(id))
+    parser
+        .resolve_value(value_ref)
+        .ok_or_else(|| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))
 }
 
 fn parse_arg_type(

--- a/core/src/dialects/builtin/func.rs
+++ b/core/src/dialects/builtin/func.rs
@@ -112,7 +112,7 @@ impl FuncOp {
 
         if !parser.parse_token(")") {
             loop {
-                let _val_name = parser
+                let val_name = parser
                     .parse_value_ref()
                     .ok_or_else(|| (parser.span(), tir::Error::ExpectedValueRef))?
                     .to_string();
@@ -127,6 +127,7 @@ impl FuncOp {
 
                 // Create a value in context with the parsed type
                 let value = context.create_value(ty, None);
+                parser.define_value(&val_name, value.id());
                 block_args.push(value);
 
                 if parser.parse_token(")") {
@@ -214,6 +215,25 @@ mod tests {
 
     // Func roundtrip coverage (single-block, multi-block, block args, void)
     // lives in the FileCheck suite under core/checks/IRRoundtrip.
+
+    #[test]
+    fn parse_non_contiguous_and_named_values() {
+        let context = Context::with_default_dialects();
+        // Names are neither contiguous nor numeric; they must still resolve to the
+        // actual allocated value ids rather than being read as literal ids.
+        let src = r#"func @nc(%100: !i32) -> !i32 {
+    %sum = addi %100, %100 : !i32
+    return %sum
+  }"#;
+        let func = parse_ir::<FuncOp>(&context, src).expect("parse");
+        assert!(func.verify(&context).is_ok());
+
+        let arg_id = func.body().arguments()[0].id();
+        let ops: Vec<_> = func.body().iter(context.clone()).collect();
+        assert_eq!(ops[0].operands, vec![arg_id, arg_id]);
+        let sum_id = ops[0].results[0];
+        assert_eq!(ops[1].operands, vec![sum_id]);
+    }
 
     #[test]
     fn parse_text_labeled_blocks() {

--- a/core/src/dialects/scf/mod.rs
+++ b/core/src/dialects/scf/mod.rs
@@ -220,10 +220,9 @@ fn parse_value_id(
     let value_ref = parser
         .parse_value_ref()
         .ok_or_else(|| (parser.span(), Error::ExpectedValueRef))?;
-    let id = value_ref
-        .parse::<u32>()
-        .map_err(|_| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))?;
-    Ok(ValueId::from_number(id))
+    parser
+        .resolve_value(value_ref)
+        .ok_or_else(|| (parser.span(), Error::UnknownValueRef(value_ref.to_string())))
 }
 
 fn expect_token(

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -10,7 +10,7 @@ use super::common::{Cursor, Span};
 use super::text::Parser as TextParser;
 
 type ParseResult<T> = Result<T, (Span, Error)>;
-type BlockLabel = (u32, Vec<Value>);
+type BlockLabel = (u32, Vec<(String, crate::TypeId)>);
 
 pub fn parse_ir<T: Operation>(context: &Context, src: &str) -> Result<T, (Span, Error)> {
     let mut parser = TextParser::new(src);
@@ -37,12 +37,17 @@ pub(crate) fn parse_single_op<'src>(
 ) -> Result<Box<dyn Operation>, (Span, Error)> {
     parser.skip_trivia();
 
-    // Optional SSA result assignment prefix (e.g. "%2 =").
-    // The concrete ValueId is currently allocated by builders from context state.
+    // Optional SSA result assignment prefix (e.g. "%2 ="). The builder allocates the
+    // concrete ValueId; we bind the textual name to it once the op exists so later
+    // operands resolve by name rather than by a literal id.
     let mark = parser.pos();
-    if parser.parse_value_ref().is_some() && !parser.parse_token("=") {
-        parser.set_pos(mark);
-    }
+    let result_name = match parser.parse_value_ref() {
+        Some(name) if parser.parse_token("=") => Some(name.to_string()),
+        _ => {
+            parser.set_pos(mark);
+            None
+        }
+    };
 
     if let Some(name) = parser.parse_ident() {
         let (dialect, name) = if parser.parse_token(".") {
@@ -60,7 +65,13 @@ pub(crate) fn parse_single_op<'src>(
             .get_parser(dialect, name)
             .map_err(|e| (parser.span(), e))?;
 
-        op_parser(parser, context)
+        let op = op_parser(parser, context)?;
+        if let Some(name) = result_name
+            && let Some(result) = context.get_op(op.id()).results.first()
+        {
+            parser.define_value(&name, *result);
+        }
+        Ok(op)
     } else {
         Err((parser.span(), Error::ExpectedOpName))
     }
@@ -202,7 +213,7 @@ impl<'src> TextParser<'src> {
     fn parse_block_argument_list(
         &mut self,
         context: &Context,
-    ) -> Result<Vec<Value>, (Span, Error)> {
+    ) -> Result<Vec<(String, crate::TypeId)>, (Span, Error)> {
         let mut args = vec![];
 
         loop {
@@ -210,9 +221,10 @@ impl<'src> TextParser<'src> {
                 return Ok(args);
             }
 
-            let _val_name = self
+            let name = self
                 .parse_value_ref()
-                .ok_or_else(|| (self.span(), Error::ExpectedValueRef))?;
+                .ok_or_else(|| (self.span(), Error::ExpectedValueRef))?
+                .to_string();
 
             if !self.parse_token(":") {
                 return Err((self.span(), Error::ExpectedToken(":")));
@@ -221,7 +233,7 @@ impl<'src> TextParser<'src> {
             let ty = self
                 .parse_type(context)?
                 .ok_or_else(|| (self.span(), Error::ExpectedType))?;
-            args.push(context.create_value(ty, None));
+            args.push((name, ty));
 
             if self.parse_token(")") {
                 return Ok(args);
@@ -237,22 +249,27 @@ impl<'src> TextParser<'src> {
         context: &Context,
         region: &Arc<Region>,
         index: u32,
-        block_args: Vec<Value>,
+        named_args: Vec<(String, crate::TypeId)>,
     ) -> Result<Arc<Block>, (Span, Error)> {
-        let state = self
+        let existing = self
             .region_parse
-            .as_mut()
-            .expect("block labels require an active region parse scope");
+            .as_ref()
+            .and_then(|s| s.indices.get(&index).copied());
 
-        if let Some(id) = state.indices.get(&index) {
-            let block = context.get_block(*id);
-            if !block_args.is_empty() && block.arguments().is_empty() {
+        // A forward branch may have already created the block from the successor's
+        // type list; bind the label's names to those existing arguments.
+        if let Some(id) = existing {
+            let block = context.get_block(id);
+            if !named_args.is_empty() && block.arguments().is_empty() {
                 return Err((
                     self.span(),
                     Error::VerificationError(format!(
                         "block ^bb{index} was already referenced without arguments"
                     )),
                 ));
+            }
+            for ((name, _), arg) in named_args.iter().zip(block.arguments()) {
+                self.define_value(name, arg.id());
             }
             return Ok(block);
         }
@@ -265,9 +282,20 @@ impl<'src> TextParser<'src> {
             ));
         }
 
+        let block_args: Vec<Value> = named_args
+            .iter()
+            .map(|(_, ty)| context.create_value(*ty, None))
+            .collect();
+        for ((name, _), arg) in named_args.iter().zip(&block_args) {
+            self.define_value(name, arg.id());
+        }
         let block = context.create_block(block_args);
         region.add_block(block.id());
-        state.indices.insert(index, block.id());
+        self.region_parse
+            .as_mut()
+            .expect("block labels require an active region parse scope")
+            .indices
+            .insert(index, block.id());
         Ok(block)
     }
 }

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::block::BlockId;
-use crate::value::{Value, ValueId};
+use crate::value::Value;
 use crate::{Block, Context, Error, Operation, Region};
 
 use super::common::{Cursor, Span};
@@ -74,26 +74,6 @@ pub(crate) fn parse_single_op<'src>(
         Ok(op)
     } else {
         Err((parser.span(), Error::ExpectedOpName))
-    }
-}
-
-/// Maps value names (e.g. "0", "1", "arg") to ValueIds during parsing.
-#[derive(Default, Clone)]
-pub struct ValueScope {
-    values: HashMap<String, ValueId>,
-}
-
-impl ValueScope {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn insert(&mut self, name: String, id: ValueId) {
-        self.values.insert(name, id);
-    }
-
-    pub fn get(&self, name: &str) -> Option<ValueId> {
-        self.values.get(name).copied()
     }
 }
 

--- a/core/src/parse/text.rs
+++ b/core/src/parse/text.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::Region;
 use crate::block::BlockId;
 use crate::parse::common::{Cursor, Span};
+use crate::value::ValueId;
 
 pub(crate) struct RegionParseState {
     pub region: Arc<Region>,
@@ -14,6 +15,11 @@ pub struct Parser<'src> {
     src: &'src str,
     position: u32,
     pub(crate) region_parse: Option<RegionParseState>,
+    /// Maps textual SSA names (the text after `%`) to the value ids actually
+    /// allocated for them, so names need not match internal ids and need not be
+    /// contiguous. Stays flat across nested regions: the printer emits globally
+    /// unique value numbers, so a single namespace is enough.
+    value_names: HashMap<String, ValueId>,
 }
 
 impl<'src> Parser<'src> {
@@ -22,7 +28,23 @@ impl<'src> Parser<'src> {
             src,
             position: 0,
             region_parse: None,
+            value_names: HashMap::new(),
         }
+    }
+
+    /// Bind a textual SSA name to the value id allocated for it.
+    pub fn define_value(&mut self, name: &str, id: ValueId) {
+        self.value_names.insert(name.to_string(), id);
+    }
+
+    /// Resolve a textual SSA name to its value id. Names bound during this parse
+    /// win; a purely numeric name otherwise falls back to its literal id, so
+    /// single-op parses can still wire operands to pre-existing values.
+    pub fn resolve_value(&self, name: &str) -> Option<ValueId> {
+        self.value_names
+            .get(name)
+            .copied()
+            .or_else(|| name.parse::<u32>().ok().map(ValueId::from_number))
     }
 
     pub fn peek_char(&self) -> Option<char> {

--- a/utils/macros/src/operation.rs
+++ b/utils/macros/src/operation.rs
@@ -1857,8 +1857,8 @@ fn make_parser(
             quote! {
                 #comma
                 if let Some(ref_name) = parser.parse_value_ref() {
-                    if let Ok(num) = ref_name.parse::<u32>() {
-                        builder = builder.#field(tir::ValueId::from_number(num));
+                    if let Some(id) = parser.resolve_value(ref_name) {
+                        builder = builder.#field(id);
                     }
                 }
             }


### PR DESCRIPTION
Enable parsing of SSA values with arbitrary names (not just numeric ids) and non-contiguous numbering. Previously, the parser required value references to be numeric and treated them as literal ValueIds. Now textual names are bound to allocated ValueIds during parsing, allowing operands to resolve by name rather than by literal id.

Key changes:
- Add `value_names` HashMap to Parser to track textual SSA name → ValueId mappings
- Implement `define_value()` to bind names during parsing and `resolve_value()` to look them up with fallback to numeric parsing for single-op parses
- Remove `ValueScope` struct (no longer needed with flat namespace in Parser)
- Update `BlockLabel` type from `Vec<Value>` to `Vec<(String, TypeId)>` to defer value creation
- Capture result names from SSA assignments and bind them after operation creation
- Update block argument parsing to collect names and types, then create values and bind names
- Update all dialect parsers (builtin/func, builtin/call, builtin/control, scf) to use `resolve_value()` instead of manual numeric parsing
- Add test verifying non-contiguous and named value resolution works correctly

https://claude.ai/code/session_01LwNZXJeKKChiTFuAbPc96A